### PR TITLE
Fixes use of deprecated functions, improves memory safety and (slightly) improves performance.

### DIFF
--- a/app/arduino/codegenerator.cpp
+++ b/app/arduino/codegenerator.cpp
@@ -19,13 +19,9 @@ CodeGenerator::CodeGenerator( QString fileName, const QVector< GraphicElement* >
 
 }
 
-QString highLow( int val ) {
-  if( val == 1 ) {
-    return( "HIGH" );
-  }
-  else {
-    return( "LOW" );
-  }
+static inline QString highLow( int val )
+{
+    return val == 1 ? "HIGH" : "LOW";
 }
 
 QString clearString( QString input ) {

--- a/app/arduino/codegenerator.cpp
+++ b/app/arduino/codegenerator.cpp
@@ -202,10 +202,10 @@ void CodeGenerator::declareAuxVariables( ) {
 
 void CodeGenerator::setup( ) {
   out << "void setup( ) {" << endl;
-  for( MappedPin pin : inputMap ) {
+  for( MappedPin pin : qAsConst(inputMap) ) {
     out << "    pinMode( " << pin.varName << ", INPUT );" << endl;
   }
-  for( MappedPin pin : outputMap ) {
+  for( MappedPin pin : qAsConst(outputMap) ) {
     out << "    pinMode( " << pin.varName << ", OUTPUT );" << endl;
   }
   out << "}" << endl << endl;
@@ -289,7 +289,7 @@ void CodeGenerator::assignVariablesRec( const QVector< GraphicElement* > &elms )
           out << QString( "    if( %1 && !%2 ) { " ).arg( clk ).arg( inclk ) << endl;
           out << QString( "        if( %1 && %2) { " ).arg( j ).arg( k ) << endl;
           out << QString( "            boolean aux = %1;" ).arg( firstOut ) << endl;
-          out << QString( "            %1 = %2;" ).arg( firstOut ).arg( secondOut ) << endl;
+          out << QString( "            %1 = %2;" ).arg( firstOut, secondOut ) << endl;
           out << QString( "            %1 = aux;" ).arg( secondOut ) << endl;
           out << QString( "        } else if ( %1 ) {" ).arg( j ) << endl;
           out << QString( "            %1 = 1;" ).arg( firstOut ) << endl;
@@ -318,13 +318,13 @@ void CodeGenerator::assignVariablesRec( const QVector< GraphicElement* > &elms )
           QString r = otherPortName( elm->input( 2 ) );
           QString inclk = firstOut + "_inclk";
           out << QString( "    //SR FlipFlop" ) << endl;
-          out << QString( "    if( %1 && !%2 ) { " ).arg( clk ).arg( inclk ) << endl;
-          out << QString( "        if( %1 && %2) { " ).arg( s ).arg( r ) << endl;
+          out << QString( "    if( %1 && !%2 ) { " ).arg( clk, inclk ) << endl;
+          out << QString( "        if( %1 && %2) { " ).arg( s, r ) << endl;
           out << QString( "            %1 = 1;" ).arg( firstOut ) << endl;
           out << QString( "            %1 = 1;" ).arg( secondOut ) << endl;
-          out << QString( "        } else if ( %1 != %2) {" ).arg( s ).arg( r ) << endl;
-          out << QString( "            %1 = %2;" ).arg( firstOut ).arg( s ) << endl;
-          out << QString( "            %1 = %2;" ).arg( secondOut ).arg( r ) << endl;
+          out << QString( "        } else if ( %1 != %2) {" ).arg( s, r ) << endl;
+          out << QString( "            %1 = %2;" ).arg( firstOut, s ) << endl;
+          out << QString( "            %1 = %2;" ).arg( secondOut, r ) << endl;
           out << QString( "        }" ) << endl;
           out << QString( "    }" ) << endl;
           QString prst = otherPortName( elm->input( 3 ) );
@@ -463,7 +463,8 @@ void CodeGenerator::loop( ) {
   out << "    // Updating clocks. //" << endl;
   for( GraphicElement *elm : elements ) {
     if( elm->elementType( ) == ElementType::CLOCK ) {
-      QString varName = varMap[ elm->outputs( ).first( ) ];
+      const auto elm_outputs = elm->outputs();
+      QString varName = varMap[ elm_outputs.first( ) ];
       out << QString( "    if( %1_elapsed > %1_interval ){" ).arg( varName ) << endl;
       out << QString( "        %1_elapsed = 0;" ).arg( varName ) << endl;
       out << QString( "        %1 = ! %1;" ).arg( varName ) << endl;
@@ -481,7 +482,7 @@ void CodeGenerator::loop( ) {
     if( varName.isEmpty( ) ) {
       varName = highLow( pin.port->defaultValue( ) );
     }
-    out << QString( "    digitalWrite( %1, %2 );" ).arg( pin.varName ).arg( varName ) << endl;
+    out << QString( "    digitalWrite( %1, %2 );" ).arg( pin.varName, varName ) << endl;
   }
   out << "}" << endl;
 }

--- a/app/arduino/codegenerator.h
+++ b/app/arduino/codegenerator.h
@@ -37,7 +37,8 @@ private:
   const QVector< GraphicElement* > elements;
   QVector< MappedPin > inputMap, outputMap;
   QHash< QNEPort*, QString > varMap;
-  QVector< QString > availblePins;
+  //! carmesim: fix typo in availablePins
+  QVector< QString > availablePins;
   void setup( );
   void loop( );
   unsigned int globalCounter;

--- a/app/boxmanager.cpp
+++ b/app/boxmanager.cpp
@@ -79,7 +79,7 @@ void BoxManager::clear( ) {
   }
 }
 
-void BoxManager::updateRecentBoxes( QString fname ) {
+void BoxManager::updateRecentBoxes(const QString& fname ) {
   QSettings settings( QSettings::IniFormat, QSettings::UserScope,
                       QApplication::organizationName( ), QApplication::applicationName( ) );
   QStringList files;

--- a/app/boxmanager.h
+++ b/app/boxmanager.h
@@ -36,7 +36,7 @@ private:
   bool warnAboutFileChange( const QString &fileName );
 
   static BoxManager *globalBoxManager;
-  void updateRecentBoxes( QString fname );
+  void updateRecentBoxes(const QString &fname);
 };
 
 #endif // BOXMANAGER_H

--- a/app/boxmapping.cpp
+++ b/app/boxmapping.cpp
@@ -16,19 +16,21 @@ BoxMapping::~BoxMapping( ) {
 
 void BoxMapping::initialize( ) {
   ElementMapping::initialize( );
-  for( QNEPort *port : boxInputs ) {
+  //! carmesim: use qAsConst here in order to avoid Qt container detachment
+  for( QNEPort *port : qAsConst(boxInputs) ) {
     inputs.append( map[ port->graphicElement( ) ] );
   }
-  for( QNEPort *port : boxOutputs ) {
+  for( QNEPort *port : qAsConst(boxOutputs) ) {
     outputs.append( map[ port->graphicElement( ) ] );
   }
 }
 
 void BoxMapping::clearConnections( ) {
-  for( LogicElement *in : inputs ) {
+    //! carmesim: use qAsConst here in order to avoid Qt container detachment
+  for( LogicElement *in : qAsConst(inputs)) {
     in->clearPredecessors( );
   }
-  for( LogicElement *out : outputs ) {
+  for( LogicElement *out : qAsConst(outputs)) {
     out->clearSucessors( );
   }
 }

--- a/app/boxprototype.cpp
+++ b/app/boxprototype.cpp
@@ -68,7 +68,7 @@ void BoxPrototype::reload( ) {
   clear( );
 
   boxImpl.loadFile( m_fileName );
-  for( Box *box : boxObservers ) {
+  for( Box *box : qAsConst(boxObservers)) {
     box->loadFile( m_fileName );
   }
 }

--- a/app/boxprototypeimpl.cpp
+++ b/app/boxprototypeimpl.cpp
@@ -7,7 +7,7 @@
 #include <QFile>
 
 BoxPrototypeImpl::~BoxPrototypeImpl( ) {
-  for( GraphicElement *elm: elements ) {
+  for( GraphicElement *elm: qAsConst(elements) ) {
     delete elm;
   }
 }
@@ -116,7 +116,8 @@ void BoxPrototypeImpl::loadOutputs( ) {
 }
 
 void BoxPrototypeImpl::loadInputElement( GraphicElement *elm ) {
-  for( QNEOutputPort *port : elm->outputs( ) ) {
+  auto const outputs = elm->outputs();
+  for( QNEOutputPort *port : outputs ) {
     GraphicElement *nodeElm = ElementFactory::buildElement( ElementType::NODE );
     nodeElm->setPos( elm->pos( ) );
     nodeElm->setLabel( elm->getLabel( ) );
@@ -142,7 +143,8 @@ void BoxPrototypeImpl::loadInputElement( GraphicElement *elm ) {
 }
 
 void BoxPrototypeImpl::loadOutputElement( GraphicElement *elm ) {
-  for( QNEInputPort *port : elm->inputs( ) ) {
+  auto const inputs = elm->inputs( );
+  for( QNEInputPort *port :  inputs) {
     GraphicElement *nodeElm = ElementFactory::buildElement( ElementType::NODE );
     nodeElm->setPos( elm->pos( ) );
     nodeElm->setLabel( elm->getLabel( ) );

--- a/app/commands.cpp
+++ b/app/commands.cpp
@@ -299,14 +299,14 @@ void RotateCommand::redo( ) {
     scn->clearSelection( );
     double cx = 0, cy = 0;
     int sz = 0;
-    for( GraphicElement *item : list ) {
+    for( GraphicElement *item : qAsConst(list) ) {
         cx += item->pos( ).x( );
         cy += item->pos( ).y( );
         sz++;
     }
     cx /= sz;
     cy /= sz;
-    for( GraphicElement *elm : list ) {
+    for( GraphicElement *elm : qAsConst(list) ) {
         QTransform transform;
         transform.translate( cx, cy );
         transform.rotate( angle );
@@ -732,7 +732,7 @@ void FlipCommand::redo( ) {
     QList< GraphicElement* > list = findElements( ids );
     QGraphicsScene *scn = list[ 0 ]->scene( );
     scn->clearSelection( );
-    for( GraphicElement *elm : list ) {
+    for( GraphicElement *elm : qAsConst(list) ) {
         QPointF pos = elm->pos( );
         if( axis == 0 ) {
             pos.setX( minPos.rx() + ( maxPos.rx() - pos.rx()));

--- a/app/commands.cpp
+++ b/app/commands.cpp
@@ -735,7 +735,7 @@ void FlipCommand::redo( ) {
     for( GraphicElement *elm : list ) {
         QPointF pos = elm->pos( );
         if( axis == 0 ) {
-            pos.setX( minPos.rx( ) + ( maxPos.rx( ) - pos.rx( ) ) );
+            pos.setX( minPos.rx() + ( maxPos.rx() - pos.rx()));
         }
         else {
             pos.setY( minPos.ry( ) + ( maxPos.ry( ) - pos.ry( ) ) );

--- a/app/commands.cpp
+++ b/app/commands.cpp
@@ -13,360 +13,366 @@
 
 
 void storeIds( const QList< QGraphicsItem* > &items, QVector< int > &ids ) {
-  ids.reserve( items.size( ) );
-  for( QGraphicsItem *item : items ) {
-    ItemWithId *iwid = dynamic_cast< ItemWithId* >( item );
-    if( iwid ) {
-      ids.append( iwid->id( ) );
+    ids.reserve( items.size( ) );
+    for( QGraphicsItem *item : items ) {
+        ItemWithId *iwid = dynamic_cast< ItemWithId* >( item );
+        if( iwid ) {
+            ids.append( iwid->id( ) );
+        }
     }
-  }
 }
 
 void storeOtherIds( const QList< QGraphicsItem* > &connections, const QVector< int > &ids, QVector< int > &otherIds ) {
-  for( QGraphicsItem *item : connections ) {
-    QNEConnection *conn = qgraphicsitem_cast< QNEConnection* >( item );
-    if( ( item->type( ) == QNEConnection::Type ) && conn ) {
-      QNEOutputPort *p1 = conn->start( );
-      if( p1 && p1->graphicElement( ) && !ids.contains( p1->graphicElement( )->id( ) ) ) {
-        otherIds.append( p1->graphicElement( )->id( ) );
-      }
-      QNEInputPort *p2 = conn->end( );
-      if( p2 && p2->graphicElement( ) && !ids.contains( p2->graphicElement( )->id( ) ) ) {
-        otherIds.append( p2->graphicElement( )->id( ) );
-      }
+    for( QGraphicsItem *item : connections ) {
+        QNEConnection *conn = qgraphicsitem_cast< QNEConnection* >( item );
+        if( ( item->type( ) == QNEConnection::Type ) && conn ) {
+            QNEOutputPort *p1 = conn->start( );
+            if( p1 && p1->graphicElement( ) && !ids.contains( p1->graphicElement( )->id( ) ) ) {
+                otherIds.append( p1->graphicElement( )->id( ) );
+            }
+            QNEInputPort *p2 = conn->end( );
+            if( p2 && p2->graphicElement( ) && !ids.contains( p2->graphicElement( )->id( ) ) ) {
+                otherIds.append( p2->graphicElement( )->id( ) );
+            }
+        }
     }
-  }
 }
 
 QList< QGraphicsItem* > loadList( const QList< QGraphicsItem* > &aItems, QVector< int > &ids,
                                   QVector< int > &otherIds ) {
 
-  QList< QGraphicsItem* > elements;
-  /* Stores selected graphicElements */
-  for( QGraphicsItem *item : aItems ) {
-    if( item->type( ) == GraphicElement::Type ) {
-      if( !elements.contains( item ) ) {
-        elements.append( item );
-      }
-    }
-  }
-  QList< QGraphicsItem* > connections;
-  /* Stores all the wires linked to these elements */
-  for( QGraphicsItem *item : elements ) {
-    GraphicElement *elm = qgraphicsitem_cast< GraphicElement* >( item );
-    if( elm ) {
-      for( QNEInputPort *port : elm->inputs( ) ) {
-        for( QNEConnection *conn : port->connections( ) ) {
-          if( !connections.contains( conn ) ) {
-            connections.append( conn );
-          }
+    QList< QGraphicsItem* > elements;
+    /* Stores selected graphicElements */
+    for( QGraphicsItem *item : aItems ) {
+        if( item->type( ) == GraphicElement::Type ) {
+            if( !elements.contains( item ) ) {
+                elements.append( item );
+            }
         }
-      }
-      for( QNEOutputPort *port : elm->outputs( ) ) {
-        for( QNEConnection *conn : port->connections( ) ) {
-          if( !connections.contains( conn ) ) {
-            connections.append( conn );
-          }
+    }
+    QList< QGraphicsItem* > connections;
+    /* Stores all the wires linked to these elements */
+    for( QGraphicsItem *item : elements )
+    {
+        GraphicElement *elm = qgraphicsitem_cast< GraphicElement* >( item );
+        if( elm ) {
+            auto const inputs = elm->inputs();  /*! carmesim: Using this instead of qAsConst to avoid possible ownership issues with the rvalue !*/
+            for( QNEInputPort *port : inputs)   //! carmesim: Using `inputs` here instead to avoid Qt container detachment
+            {
+                for( QNEConnection *conn : port->connections( ) ) {
+                    if( !connections.contains( conn ) ) {
+                        connections.append( conn );
+                    }
+                }
+            }
+            auto const outputs = elm->outputs();
+            for( QNEOutputPort *port : outputs) //! carmesim: Using `outputs` here instead to avoid Qt container detachment
+            {
+                for( QNEConnection *conn : port->connections( ) ) {
+                    if( !connections.contains( conn ) ) {
+                        connections.append( conn );
+                    }
+                }
+            }
         }
-      }
     }
-  }
-  /* Stores the other wires selected */
-  for( QGraphicsItem *item : aItems ) {
-    if( item->type( ) == QNEConnection::Type ) {
-      if( !connections.contains( item ) ) {
-        connections.append( item );
-      }
+    /* Stores the other wires selected */
+    for( QGraphicsItem *item : aItems ) {
+        if( item->type( ) == QNEConnection::Type ) {
+            if( !connections.contains( item ) ) {
+                connections.append( item );
+            }
+        }
     }
-  }
-  /* Stores the ids of all elements listed in items; */
-  storeIds( elements + connections, ids );
-  /* Stores all the elements linked to each connection that will not be deleted. */
-  storeOtherIds( connections, ids, otherIds );
-  return( elements + connections );
+    /* Stores the ids of all elements listed in items; */
+    storeIds( elements + connections, ids );
+    /* Stores all the elements linked to each connection that will not be deleted. */
+    storeOtherIds( connections, ids, otherIds );
+    return( elements + connections );
 }
 
 QList< QGraphicsItem* > findItems( const QVector< int > &ids ) {
-  QList< QGraphicsItem* > items;
-  for( int id : ids ) {
-    QGraphicsItem *item = dynamic_cast< QGraphicsItem* >( ElementFactory::getItemById( id ) );
-    if( item ) {
-      items.append( item );
+    QList< QGraphicsItem* > items;
+    for( int id : ids ) {
+        QGraphicsItem *item = dynamic_cast< QGraphicsItem* >( ElementFactory::getItemById( id ) );
+        if( item ) {
+            items.append( item );
+        }
     }
-  }
-  if( items.size( ) != ids.size( ) ) {
-    throw std::runtime_error( ERRORMSG( "One or more items was not found on the scene." ) );
-  }
-  return( items );
+    if( items.size( ) != ids.size( ) ) {
+        throw std::runtime_error( ERRORMSG( "One or more items was not found on the scene." ) );
+    }
+    return( items );
 }
 
 QList< GraphicElement* > findElements( const QVector< int > &ids ) {
-  QList< GraphicElement* > items;
-  for( int id : ids ) {
-    GraphicElement *item = dynamic_cast< GraphicElement* >( ElementFactory::getItemById( id ) );
-    if( item ) {
-      items.append( item );
+    QList< GraphicElement* > items;
+    for( int id : ids ) {
+        GraphicElement *item = dynamic_cast< GraphicElement* >( ElementFactory::getItemById( id ) );
+        if( item ) {
+            items.append( item );
+        }
     }
-  }
-  if( items.size( ) != ids.size( ) ) {
-    throw std::runtime_error( ERRORMSG( "One or more elements was not found on the scene." ) );
-  }
-  return( items );
+    if( items.size( ) != ids.size( ) ) {
+        throw std::runtime_error( ERRORMSG( "One or more elements was not found on the scene." ) );
+    }
+    return( items );
 }
 
 void saveitems( QByteArray &itemData, const QList< QGraphicsItem* > &items, const QVector< int > &otherIds ) {
-  itemData.clear( );
-  QDataStream dataStream( &itemData, QIODevice::WriteOnly );
-  QList< GraphicElement* > others = findElements( otherIds );
-  for( GraphicElement *elm : others ) {
-    elm->save( dataStream );
-  }
-  SerializationFunctions::serialize( items, dataStream );
+    itemData.clear( );
+    QDataStream dataStream( &itemData, QIODevice::WriteOnly );
+    QList< GraphicElement* > others = findElements( otherIds );
+    for( GraphicElement *elm : others ) {
+        elm->save( dataStream );
+    }
+    SerializationFunctions::serialize( items, dataStream );
 }
 
 void addItems( Editor *editor, QList< QGraphicsItem* > items ) {
-  editor->getScene( )->clearSelection( );
-  for( QGraphicsItem *item : items ) {
-    if( item->scene( ) != editor->getScene( ) ) {
-      editor->getScene( )->addItem( item );
+    editor->getScene( )->clearSelection( );
+    for( QGraphicsItem *item : items ) {
+        if( item->scene( ) != editor->getScene( ) ) {
+            editor->getScene( )->addItem( item );
+        }
+        if( item->type( ) == GraphicElement::Type ) {
+            item->setSelected( true );
+        }
     }
-    if( item->type( ) == GraphicElement::Type ) {
-      item->setSelected( true );
-    }
-  }
 }
 
 QList< QGraphicsItem* > loadItems( QByteArray &itemData,
                                    const QVector< int > &ids,
                                    Editor *editor,
                                    QVector< int > &otherIds ) {
-  if( itemData.isEmpty( ) ) {
-    return( QList< QGraphicsItem* >( ) );
-  }
-  QVector< GraphicElement* > otherElms = findElements( otherIds ).toVector( );
-  QDataStream dataStream( &itemData, QIODevice::ReadOnly );
-  double version = GlobalProperties::version;
-  QMap< quint64, QNEPort* > portMap;
-  for( GraphicElement *elm : otherElms ) {
-    elm->load( dataStream, portMap, version );
-  }
-  /*
+    if( itemData.isEmpty( ) ) {
+        return( QList< QGraphicsItem* >( ) );
+    }
+    QVector< GraphicElement* > otherElms = findElements( otherIds ).toVector( );
+    QDataStream dataStream( &itemData, QIODevice::ReadOnly );
+    double version = GlobalProperties::version;
+    QMap< quint64, QNEPort* > portMap;
+    for( GraphicElement *elm : otherElms ) {
+        elm->load( dataStream, portMap, version );
+    }
+    /*
    * Assuming that all connections are stored after the elements, we will deserialize the elements first.
    * We will store one additional information: The element IDs!
    */
-  QList< QGraphicsItem* > items =
-    SerializationFunctions::deserialize( dataStream,
-                                         version,
-                                         GlobalProperties::currentFile,
-                                         portMap );
-  if( items.size( ) != ids.size( ) ) {
-    QString msg( "One or more elements were not found on scene. Expected %1, found %2." );
-    msg = msg.arg( ids.size( ) ).arg( items.size( ) );
-    throw std::runtime_error( ERRORMSG( msg.toStdString( ) ) );
-  }
-  for( int i = 0; i < items.size( ); ++i ) {
-    ItemWithId *iwid = dynamic_cast< ItemWithId* >( items[ i ] );
-    if( iwid ) {
-      ElementFactory::updateItemId( iwid, ids[ i ] );
+    QList< QGraphicsItem* > items =
+            SerializationFunctions::deserialize( dataStream,
+                                                 version,
+                                                 GlobalProperties::currentFile,
+                                                 portMap );
+    if( items.size( ) != ids.size( ) ) {
+        QString msg( "One or more elements were not found on scene. Expected %1, found %2." );
+        msg = msg.arg( ids.size( ) ).arg( items.size( ) );
+        throw std::runtime_error( ERRORMSG( msg.toStdString( ) ) );
     }
-  }
-  addItems( editor, items );
-  return( items );
+    for( int i = 0; i < items.size( ); ++i ) {
+        ItemWithId *iwid = dynamic_cast< ItemWithId* >( items[ i ] );
+        if( iwid ) {
+            ElementFactory::updateItemId( iwid, ids[ i ] );
+        }
+    }
+    addItems( editor, items );
+    return( items );
 }
 
 void deleteItems( const QList< QGraphicsItem* > &items, Editor *editor ) {
-  QVector< QGraphicsItem* > itemsVec = items.toVector( );
-  /* Delete items on reverse order */
-  for( int i = itemsVec.size( ) - 1; i >= 0; --i ) {
-    editor->getScene( )->removeItem( itemsVec[ i ] );
-    delete itemsVec[ i ];
-  }
+    QVector< QGraphicsItem* > itemsVec = items.toVector( );
+    /* Delete items on reverse order */
+    for( int i = itemsVec.size( ) - 1; i >= 0; --i ) {
+        editor->getScene( )->removeItem( itemsVec[ i ] );
+        delete itemsVec[ i ];
+    }
 }
 
 
 AddItemsCommand::AddItemsCommand( GraphicElement *aItem, Editor *aEditor, QUndoCommand *parent ) : QUndoCommand(
-    parent ) {
-  QList< QGraphicsItem* > items( { aItem } );
-  items = loadList( items, ids, otherIds );
-  editor = aEditor;
-  addItems( editor, items );
-  setText( tr( "Add %1 element" ).arg( aItem->objectName( ) ) );
+                                                                                                       parent ) {
+    QList< QGraphicsItem* > items( { aItem } );
+    items = loadList( items, ids, otherIds );
+    editor = aEditor;
+    addItems( editor, items );
+    setText( tr( "Add %1 element" ).arg( aItem->objectName( ) ) );
 }
 
 AddItemsCommand::AddItemsCommand( QNEConnection *aItem, Editor *aEditor, QUndoCommand *parent ) : QUndoCommand(
-    parent ) {
-  QList< QGraphicsItem* > items( { aItem } );
-  items = loadList( items, ids, otherIds );
-  editor = aEditor;
-  addItems( editor, items );
-  setText( tr( "Add connection" ) );
+                                                                                                      parent ) {
+    QList< QGraphicsItem* > items( { aItem } );
+    items = loadList( items, ids, otherIds );
+    editor = aEditor;
+    addItems( editor, items );
+    setText( tr( "Add connection" ) );
 }
 
 AddItemsCommand::AddItemsCommand( const QList< QGraphicsItem* > &aItems, Editor *aEditor,
                                   QUndoCommand *parent ) : QUndoCommand( parent ) {
-  QList< QGraphicsItem* > items = loadList( aItems, ids, otherIds );
-  editor = aEditor;
-  addItems( editor, items );
-  setText( tr( "Add %1 elements" ).arg( items.size( ) ) );
+    QList< QGraphicsItem* > items = loadList( aItems, ids, otherIds );
+    editor = aEditor;
+    addItems( editor, items );
+    setText( tr( "Add %1 elements" ).arg( items.size( ) ) );
 }
 
 DeleteItemsCommand::DeleteItemsCommand( const QList< QGraphicsItem* > &aItems, Editor *aEditor,
                                         QUndoCommand *parent ) : QUndoCommand( parent ) {
-  QList< QGraphicsItem* > items = loadList( aItems, ids, otherIds );
-  editor = aEditor;
-  setText( tr( "Delete %1 elements" ).arg( items.size( ) ) );
+    QList< QGraphicsItem* > items = loadList( aItems, ids, otherIds );
+    editor = aEditor;
+    setText( tr( "Delete %1 elements" ).arg( items.size( ) ) );
 }
 
 DeleteItemsCommand::DeleteItemsCommand( QGraphicsItem *item, Editor *aEditor, QUndoCommand *parent ) :
-  DeleteItemsCommand( QList< QGraphicsItem* >( {
-  item
-} ), aEditor, parent ) {
+    DeleteItemsCommand( QList< QGraphicsItem* >( {
+                                                     item
+                                                 } ), aEditor, parent ) {
 
 }
 
 void AddItemsCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  QList< QGraphicsItem* > items = findItems( ids );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    QList< QGraphicsItem* > items = findItems( ids );
 
-  saveitems( itemData, items, otherIds );
-  deleteItems( items, editor );
-  emit editor->circuitHasChanged( );
+    saveitems( itemData, items, otherIds );
+    deleteItems( items, editor );
+    emit editor->circuitHasChanged( );
 }
 
 
 void AddItemsCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QList< QGraphicsItem* > items = loadItems( itemData, ids, editor, otherIds );
-  emit editor->circuitHasChanged( );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    //! carmesim: items seems unused
+    QList< QGraphicsItem* > items = loadItems( itemData, ids, editor, otherIds );
+    emit editor->circuitHasChanged( );
 }
 
 void DeleteItemsCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  loadItems( itemData, ids, editor, otherIds );
-  emit editor->circuitHasChanged( );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    loadItems( itemData, ids, editor, otherIds );
+    emit editor->circuitHasChanged( );
 }
 
 void DeleteItemsCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QList< QGraphicsItem* > items = findItems( ids );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    QList< QGraphicsItem* > items = findItems( ids );
 
-  saveitems( itemData, items, otherIds );
+    saveitems( itemData, items, otherIds );
 
-  deleteItems( items, editor );
-  emit editor->circuitHasChanged( );
+    deleteItems( items, editor );
+    emit editor->circuitHasChanged( );
 }
 
 
 RotateCommand::RotateCommand( const QList< GraphicElement* > &aItems, int aAngle, QUndoCommand *parent ) : QUndoCommand(
-    parent ) {
-  angle = aAngle;
-  setText( tr( "Rotate %1 degrees" ).arg( angle ) );
-  ids.reserve( aItems.size( ) );
-  positions.reserve( aItems.size( ) );
-  for( GraphicElement *item : aItems ) {
-    positions.append( item->pos( ) );
-    item->setPos( item->pos( ) );
-    ids.append( item->id( ) );
-  }
+                                                                                                               parent ) {
+    angle = aAngle;
+    setText( tr( "Rotate %1 degrees" ).arg( angle ) );
+    ids.reserve( aItems.size( ) );
+    positions.reserve( aItems.size( ) );
+    for( GraphicElement *item : aItems ) {
+        positions.append( item->pos( ) );
+        item->setPos( item->pos( ) );
+        ids.append( item->id( ) );
+    }
 }
 
 void RotateCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  QList< GraphicElement* > list = findElements( ids );
-  QGraphicsScene *scn = list[ 0 ]->scene( );
-  scn->clearSelection( );
-  for( int i = 0; i < list.size( ); ++i ) {
-    GraphicElement *elm = list[ i ];
-    if( elm->rotatable( ) ) {
-      elm->setRotation( elm->rotation( ) - angle );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    QList< GraphicElement* > list = findElements( ids );
+    QGraphicsScene *scn = list[ 0 ]->scene( );
+    scn->clearSelection( );
+    for( int i = 0; i < list.size( ); ++i ) {
+        GraphicElement *elm = list[ i ];
+        if( elm->rotatable( ) ) {
+            elm->setRotation( elm->rotation( ) - angle );
+        }
+        elm->setPos( positions[ i ] );
+        elm->update( );
+        elm->setSelected( true );
     }
-    elm->setPos( positions[ i ] );
-    elm->update( );
-    elm->setSelected( true );
-  }
 }
 
 void RotateCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QList< GraphicElement* > list = findElements( ids );
-  QGraphicsScene *scn = list[ 0 ]->scene( );
-  scn->clearSelection( );
-  double cx = 0, cy = 0;
-  int sz = 0;
-  for( GraphicElement *item : list ) {
-    cx += item->pos( ).x( );
-    cy += item->pos( ).y( );
-    sz++;
-  }
-  cx /= sz;
-  cy /= sz;
-  for( GraphicElement *elm : list ) {
-    QTransform transform;
-    transform.translate( cx, cy );
-    transform.rotate( angle );
-    transform.translate( -cx, -cy );
-    if( elm->rotatable( ) ) {
-      elm->setRotation( elm->rotation( ) + angle );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    QList< GraphicElement* > list = findElements(ids);
+    QGraphicsScene *scn = list[ 0 ]->scene( );
+    scn->clearSelection( );
+    double cx = 0, cy = 0;
+    int sz = 0;
+    for( GraphicElement *item : list ) {
+        cx += item->pos( ).x( );
+        cy += item->pos( ).y( );
+        sz++;
     }
-    elm->setPos( transform.map( elm->pos( ) ) );
-    elm->update( );
-    elm->setSelected( true );
-  }
+    cx /= sz;
+    cy /= sz;
+    for( GraphicElement *elm : list ) {
+        QTransform transform;
+        transform.translate( cx, cy );
+        transform.rotate( angle );
+        transform.translate( -cx, -cy );
+        if( elm->rotatable( ) ) {
+            elm->setRotation( elm->rotation( ) + angle );
+        }
+        elm->setPos( transform.map( elm->pos( ) ) );
+        elm->update( );
+        elm->setSelected( true );
+    }
 }
 
 bool RotateCommand::mergeWith( const QUndoCommand *command ) {
-  const RotateCommand *rotateCommand = static_cast< const RotateCommand* >( command );
-  if( ids.size( ) != rotateCommand->ids.size( ) ) {
-    return( false );
-  }
-  QVector< GraphicElement* > list = findElements( ids ).toVector( );
-  QVector< GraphicElement* > list2 = findElements( rotateCommand->ids ).toVector( );
-  for( int i = 0; i < list.size( ); ++i ) {
-    if( list[ i ] != list2[ i ] ) {
-      return( false );
+    const RotateCommand *rotateCommand = static_cast< const RotateCommand* >( command );
+    if( ids.size( ) != rotateCommand->ids.size( ) ) {
+        return( false );
     }
-  }
-  angle = ( angle + rotateCommand->angle ) % 360;
-  setText( tr( "Rotate %1 degrees" ).arg( angle ) );
-  undo( );
-  redo( );
-  return( true );
+    QVector< GraphicElement* > list = findElements( ids ).toVector( );
+    QVector< GraphicElement* > list2 = findElements( rotateCommand->ids ).toVector( );
+    for( int i = 0; i < list.size( ); ++i ) {
+        if( list[ i ] != list2[ i ] ) {
+            return( false );
+        }
+    }
+    angle = ( angle + rotateCommand->angle ) % 360;
+    setText( tr( "Rotate %1 degrees" ).arg( angle ) );
+    undo( );
+    redo( );
+    return( true );
 }
 
 
 int RotateCommand::id( ) const {
-  return( Id );
+    return( Id );
 }
 
 
 MoveCommand::MoveCommand( const QList< GraphicElement* > &list,
                           const QList< QPointF > &aOldPositions,
                           QUndoCommand *parent ) : QUndoCommand(
-    parent ) {
-  oldPositions = aOldPositions;
-  newPositions.reserve( list.size( ) );
-  ids.reserve( list.size( ) );
-  for( GraphicElement *elm : list ) {
-    ids.append( elm->id( ) );
-    newPositions.append( elm->pos( ) );
-  }
-  setText( tr( "Move elements" ) );
+                                                       parent ) {
+    oldPositions = aOldPositions;
+    newPositions.reserve( list.size( ) );
+    ids.reserve( list.size( ) );
+    for( GraphicElement *elm : list ) {
+        ids.append( elm->id( ) );
+        newPositions.append( elm->pos( ) );
+    }
+    setText( tr( "Move elements" ) );
 }
 
 void MoveCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  QVector< GraphicElement* > elms = findElements( ids ).toVector( );
-  for( int i = 0; i < elms.size( ); ++i ) {
-    elms[ i ]->setPos( oldPositions[ i ] );
-  }
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    QVector< GraphicElement* > elms = findElements( ids ).toVector( );
+    for( int i = 0; i < elms.size( ); ++i ) {
+        elms[ i ]->setPos( oldPositions[ i ] );
+    }
 }
 
 void MoveCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QVector< GraphicElement* > elms = findElements( ids ).toVector( );
-  for( int i = 0; i < elms.size( ); ++i ) {
-    elms[ i ]->setPos( newPositions[ i ] );
-  }
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    QVector< GraphicElement* > elms = findElements( ids ).toVector( );
+    for( int i = 0; i < elms.size( ); ++i ) {
+        elms[ i ]->setPos( newPositions[ i ] );
+    }
 }
 
 
@@ -374,237 +380,237 @@ UpdateCommand::UpdateCommand( const QVector< GraphicElement* > &elements,
                               QByteArray oldData,
                               Editor *editor,
                               QUndoCommand *parent ) : QUndoCommand( parent ), editor( editor ) {
-  m_oldData = oldData;
-  ids.reserve( elements.size( ) );
-  QDataStream dataStream( &m_newData, QIODevice::WriteOnly );
-  for( GraphicElement *elm : elements ) {
-    elm->save( dataStream );
-    ids.append( elm->id( ) );
-  }
-  setText( tr( "Update %1 elements" ).arg( elements.size( ) ) );
+    m_oldData = oldData;
+    ids.reserve( elements.size( ) );
+    QDataStream dataStream( &m_newData, QIODevice::WriteOnly );
+    for( GraphicElement *elm : elements ) {
+        elm->save( dataStream );
+        ids.append( elm->id( ) );
+    }
+    setText( tr( "Update %1 elements" ).arg( elements.size( ) ) );
 }
 
 void UpdateCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  loadData( m_oldData );
-  emit editor->circuitHasChanged( );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    loadData( m_oldData );
+    emit editor->circuitHasChanged( );
 }
 
 void UpdateCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  loadData( m_newData );
-  emit editor->circuitHasChanged( );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    loadData( m_newData );
+    emit editor->circuitHasChanged( );
 }
 
 void UpdateCommand::loadData( QByteArray itemData ) {
-  QVector< GraphicElement* > elements = findElements( ids ).toVector( );
-  QDataStream dataStream( &itemData, QIODevice::ReadOnly );
-  QMap< quint64, QNEPort* > portMap;
-  if( !elements.isEmpty( ) && elements.front( )->scene( ) ) {
-    elements.front( )->scene( )->clearSelection( );
-  }
-  double version = GlobalProperties::version;
-  if( !elements.isEmpty( ) ) {
-    for( GraphicElement *elm : elements ) {
-      elm->load( dataStream, portMap, version );
-      elm->setSelected( true );
+    QVector< GraphicElement* > elements = findElements( ids ).toVector( );
+    QDataStream dataStream( &itemData, QIODevice::ReadOnly );
+    QMap< quint64, QNEPort* > portMap;
+    if( !elements.isEmpty( ) && elements.front( )->scene( ) ) {
+        elements.front( )->scene( )->clearSelection( );
     }
-  }
+    double version = GlobalProperties::version;
+    if( !elements.isEmpty( ) ) {
+        for( GraphicElement *elm : elements ) {
+            elm->load( dataStream, portMap, version );
+            elm->setSelected( true );
+        }
+    }
 }
 
 
 SplitCommand::SplitCommand( QNEConnection *conn, QPointF point, Editor *editor, QUndoCommand *parent ) :
-  QUndoCommand( parent ),
-  editor( editor ),
-  scene( editor->getScene( ) ) {
-  GraphicElement *node = ElementFactory::buildElement( ElementType::NODE );
-  QNEConnection *conn2 = ElementFactory::instance->buildConnection( );
+    QUndoCommand( parent ),
+    editor( editor ),
+    scene( editor->getScene( ) ) {
+    GraphicElement *node = ElementFactory::buildElement( ElementType::NODE );
+    QNEConnection *conn2 = ElementFactory::instance->buildConnection( );
 
-  /* Align node to Grid */
-  nodePos = point - QPointF( node->boundingRect( ).center( ) );
-  if( scene ) {
-    int gridSize = scene->gridSize( );
-    qreal xV = qRound( nodePos.x( ) / gridSize ) * gridSize;
-    qreal yV = qRound( nodePos.y( ) / gridSize ) * gridSize;
-    nodePos = QPointF( xV, yV );
-  }
-  /* Rotate line according to angle between p1 and p2 */
-  nodeAngle = conn->angle( );
-  nodeAngle = 360 - 90 * ( std::round( nodeAngle / 90.0 ) );
+    /* Align node to Grid */
+    nodePos = point - QPointF( node->boundingRect( ).center( ) );
+    if( scene ) {
+        int gridSize = scene->gridSize( );
+        qreal xV = qRound( nodePos.x( ) / gridSize ) * gridSize;
+        qreal yV = qRound( nodePos.y( ) / gridSize ) * gridSize;
+        nodePos = QPointF( xV, yV );
+    }
+    /* Rotate line according to angle between p1 and p2 */
+    nodeAngle = conn->angle( );
+    nodeAngle = 360 - 90 * ( std::round( nodeAngle / 90.0 ) );
 
-  /* Assingning class attributes */
-  elm1_id = conn->start( )->graphicElement( )->id( );
-  elm2_id = conn->end( )->graphicElement( )->id( );
+    /* Assingning class attributes */
+    elm1_id = conn->start( )->graphicElement( )->id( );
+    elm2_id = conn->end( )->graphicElement( )->id( );
 
-  c1_id = conn->id( );
-  c2_id = conn2->id( );
+    c1_id = conn->id( );
+    c2_id = conn2->id( );
 
-  node_id = node->id( );
+    node_id = node->id( );
 
-  setText( tr( "Wire split" ) );
+    setText( tr( "Wire split" ) );
 }
 
 QNEConnection* findConn( int id ) {
-  return( dynamic_cast< QNEConnection* >( ElementFactory::getItemById( id ) ) );
+    return( dynamic_cast< QNEConnection* >( ElementFactory::getItemById( id ) ) );
 }
 
 GraphicElement* findElm( int id ) {
-  return( dynamic_cast< GraphicElement* >( ElementFactory::getItemById( id ) ) );
+    return( dynamic_cast< GraphicElement* >( ElementFactory::getItemById( id ) ) );
 }
 
 void SplitCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QNEConnection *c1 = findConn( c1_id );
-  QNEConnection *c2 = findConn( c2_id );
-  GraphicElement *node = findElm( node_id );
-  GraphicElement *elm1 = findElm( elm1_id );
-  GraphicElement *elm2 = findElm( elm2_id );
-  if( !c2 ) {
-    c2 = ElementFactory::buildConnection( );
-    ElementFactory::updateItemId( c2, c2_id );
-  }
-  if( !node ) {
-    node = ElementFactory::buildElement( ElementType::NODE );
-    ElementFactory::updateItemId( node, node_id );
-  }
-  if( c1 && c2 && elm1 && elm2 && node ) {
-    node->setPos( nodePos );
-    node->setRotation( nodeAngle );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    QNEConnection *c1 = findConn( c1_id );
+    QNEConnection *c2 = findConn( c2_id );
+    GraphicElement *node = findElm( node_id );
+    GraphicElement *elm1 = findElm( elm1_id );
+    GraphicElement *elm2 = findElm( elm2_id );
+    if( !c2 ) {
+        c2 = ElementFactory::buildConnection( );
+        ElementFactory::updateItemId( c2, c2_id );
+    }
+    if( !node ) {
+        node = ElementFactory::buildElement( ElementType::NODE );
+        ElementFactory::updateItemId( node, node_id );
+    }
+    if( c1 && c2 && elm1 && elm2 && node ) {
+        node->setPos( nodePos );
+        node->setRotation( nodeAngle );
 
-/*    QNEOutputPort *startPort = c1->start( ); */
-    QNEInputPort *endPort = c1->end( );
-    c2->setStart( node->output( ) );
-    c2->setEnd( endPort );
-    c1->setEnd( node->input( ) );
+        /*    QNEOutputPort *startPort = c1->start( ); */
+        QNEInputPort *endPort = c1->end( );
+        c2->setStart( node->output( ) );
+        c2->setEnd( endPort );
+        c1->setEnd( node->input( ) );
 
-    scene->addItem( node );
-    scene->addItem( c2 );
+        scene->addItem( node );
+        scene->addItem( c2 );
 
-    c1->updatePosFromPorts( );
-    c1->updatePath( );
-    c2->updatePosFromPorts( );
-    c2->updatePath( );
-  }
-  else {
-    throw std::runtime_error( ERRORMSG( QString( "Error tryng to redo %1" ).arg( text( ) ).toStdString( ) ) );
-  }
-  emit editor->circuitHasChanged( );
+        c1->updatePosFromPorts( );
+        c1->updatePath( );
+        c2->updatePosFromPorts( );
+        c2->updatePath( );
+    }
+    else {
+        throw std::runtime_error( ERRORMSG( QString( "Error tryng to redo %1" ).arg( text( ) ).toStdString( ) ) );
+    }
+    emit editor->circuitHasChanged( );
 }
 
 void SplitCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  QNEConnection *c1 = findConn( c1_id );
-  QNEConnection *c2 = findConn( c2_id );
-  GraphicElement *node = findElm( node_id );
-  GraphicElement *elm1 = findElm( elm1_id );
-  GraphicElement *elm2 = findElm( elm2_id );
-  if( c1 && c2 && elm1 && elm2 && node ) {
-    c1->setEnd( c2->end( ) );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    QNEConnection *c1 = findConn( c1_id );
+    QNEConnection *c2 = findConn( c2_id );
+    GraphicElement *node = findElm( node_id );
+    GraphicElement *elm1 = findElm( elm1_id );
+    GraphicElement *elm2 = findElm( elm2_id );
+    if( c1 && c2 && elm1 && elm2 && node ) {
+        c1->setEnd( c2->end( ) );
 
-    c1->updatePosFromPorts( );
-    c1->updatePath( );
+        c1->updatePosFromPorts( );
+        c1->updatePath( );
 
-    editor->getScene( )->removeItem( c2 );
-    editor->getScene( )->removeItem( node );
+        editor->getScene( )->removeItem( c2 );
+        editor->getScene( )->removeItem( node );
 
-    delete c2;
-    delete node;
-  }
-  else {
-    throw std::runtime_error( ERRORMSG( QString( "Error tryng to undo %1" ).arg( text( ) ).toStdString( ) ) );
-  }
-  emit editor->circuitHasChanged( );
+        delete c2;
+        delete node;
+    }
+    else {
+        throw std::runtime_error( ERRORMSG( QString( "Error tryng to undo %1" ).arg( text( ) ).toStdString( ) ) );
+    }
+    emit editor->circuitHasChanged( );
 }
 
 MorphCommand::MorphCommand( const QVector< GraphicElement* > &elements,
                             ElementType aType,
                             Editor *aEditor,
                             QUndoCommand *parent ) : QUndoCommand( parent ) {
-  newtype = aType;
-  editor = aEditor;
-  ids.reserve( elements.size( ) );
-  types.reserve( elements.size( ) );
-  for( GraphicElement *oldElm : elements ) {
-    ids.append( oldElm->id( ) );
-    types.append( oldElm->elementType( ) );
-  }
-  setText( tr( "Morph %1 elements to %2" ).arg( elements.size( ) ).arg( elements.front( )->objectName( ) ) );
+    newtype = aType;
+    editor = aEditor;
+    ids.reserve( elements.size( ) );
+    types.reserve( elements.size( ) );
+    for( GraphicElement *oldElm : elements ) {
+        ids.append( oldElm->id( ) );
+        types.append( oldElm->elementType( ) );
+    }
+    setText( tr( "Morph %1 elements to %2" ).arg( elements.size( ) ).arg( elements.front( )->objectName( ) ) );
 }
 
 void MorphCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  QVector< GraphicElement* > newElms = findElements( ids ).toVector( );
-  QVector< GraphicElement* > oldElms( newElms.size( ) );
-  for( int i = 0; i < ids.size( ); ++i ) {
-    oldElms[ i ] = ElementFactory::buildElement( types[ i ] );
-  }
-  transferConnections( newElms, oldElms );
-  emit editor->circuitHasChanged( );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    QVector< GraphicElement* > newElms = findElements( ids ).toVector( );
+    QVector< GraphicElement* > oldElms( newElms.size( ) );
+    for( int i = 0; i < ids.size( ); ++i ) {
+        oldElms[ i ] = ElementFactory::buildElement( types[ i ] );
+    }
+    transferConnections( newElms, oldElms );
+    emit editor->circuitHasChanged( );
 }
 
 void MorphCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QVector< GraphicElement* > oldElms = findElements( ids ).toVector( );
-  QVector< GraphicElement* > newElms( oldElms.size( ) );
-  for( int i = 0; i < ids.size( ); ++i ) {
-    newElms[ i ] = ElementFactory::buildElement( newtype );
-  }
-  transferConnections( oldElms, newElms );
-  emit editor->circuitHasChanged( );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    QVector< GraphicElement* > oldElms = findElements( ids ).toVector( );
+    QVector< GraphicElement* > newElms( oldElms.size( ) );
+    for( int i = 0; i < ids.size( ); ++i ) {
+        newElms[ i ] = ElementFactory::buildElement( newtype );
+    }
+    transferConnections( oldElms, newElms );
+    emit editor->circuitHasChanged( );
 }
 
 void MorphCommand::transferConnections( QVector< GraphicElement* > from, QVector< GraphicElement* > to ) {
-  for( int elm = 0; elm < from.size( ); ++elm ) {
-    GraphicElement *oldElm = from[ elm ];
-    GraphicElement *newElm = to[ elm ];
-    newElm->setInputSize( oldElm->inputSize( ) );
+    for( int elm = 0; elm < from.size( ); ++elm ) {
+        GraphicElement *oldElm = from[ elm ];
+        GraphicElement *newElm = to[ elm ];
+        newElm->setInputSize( oldElm->inputSize( ) );
 
-    newElm->setPos( oldElm->pos( ) );
-    if( newElm->rotatable( ) && oldElm->rotatable( ) ) {
-      newElm->setRotation( oldElm->rotation( ) );
-    }
-    if( ( newElm->elementType( ) == ElementType::NOT ) && ( oldElm->elementType( ) == ElementType::NODE ) ) {
-      newElm->setRotation( oldElm->rotation( ) + 90.0 );
-    }
-    else if( ( newElm->elementType( ) == ElementType::NODE ) && ( oldElm->elementType( ) == ElementType::NOT ) ) {
-      newElm->setRotation( oldElm->rotation( ) - 90.0 );
-    }
-    if( newElm->hasLabel( ) && oldElm->hasLabel( ) ) {
-      newElm->setLabel( oldElm->getLabel( ) );
-    }
-    if( newElm->hasColors( ) && oldElm->hasColors( ) ) {
-      newElm->setColor( oldElm->getColor( ) );
-    }
-    if( newElm->hasFrequency( ) && oldElm->hasFrequency( ) ) {
-      newElm->setFrequency( oldElm->getFrequency( ) );
-    }
-    if( newElm->hasTrigger( ) && oldElm->hasTrigger( ) ) {
-      newElm->setTrigger( oldElm->getTrigger( ) );
-    }
-    for( int in = 0; in < oldElm->inputSize( ); ++in ) {
-      while( !oldElm->input( in )->connections( ).isEmpty( ) ) {
-        QNEConnection *conn = oldElm->input( in )->connections( ).first( );
-        if( conn->end( ) == oldElm->input( in ) ) {
-          conn->setEnd( newElm->input( in ) );
+        newElm->setPos( oldElm->pos( ) );
+        if( newElm->rotatable( ) && oldElm->rotatable( ) ) {
+            newElm->setRotation( oldElm->rotation( ) );
         }
-      }
-    }
-    for( int out = 0; out < oldElm->outputSize( ); ++out ) {
-      while( !oldElm->output( out )->connections( ).isEmpty( ) ) {
-        QNEConnection *conn = oldElm->output( out )->connections( ).first( );
-        if( conn->start( ) == oldElm->output( out ) ) {
-          conn->setStart( newElm->output( out ) );
+        if( ( newElm->elementType( ) == ElementType::NOT ) && ( oldElm->elementType( ) == ElementType::NODE ) ) {
+            newElm->setRotation( oldElm->rotation( ) + 90.0 );
         }
-      }
-    }
-    int oldId = oldElm->id( );
-    editor->getScene( )->removeItem( oldElm );
-    delete oldElm;
+        else if( ( newElm->elementType( ) == ElementType::NODE ) && ( oldElm->elementType( ) == ElementType::NOT ) ) {
+            newElm->setRotation( oldElm->rotation( ) - 90.0 );
+        }
+        if( newElm->hasLabel( ) && oldElm->hasLabel( ) ) {
+            newElm->setLabel( oldElm->getLabel( ) );
+        }
+        if( newElm->hasColors( ) && oldElm->hasColors( ) ) {
+            newElm->setColor( oldElm->getColor( ) );
+        }
+        if( newElm->hasFrequency( ) && oldElm->hasFrequency( ) ) {
+            newElm->setFrequency( oldElm->getFrequency( ) );
+        }
+        if( newElm->hasTrigger( ) && oldElm->hasTrigger( ) ) {
+            newElm->setTrigger( oldElm->getTrigger( ) );
+        }
+        for( int in = 0; in < oldElm->inputSize( ); ++in ) {
+            while( !oldElm->input( in )->connections( ).isEmpty( ) ) {
+                QNEConnection *conn = oldElm->input( in )->connections( ).first( );
+                if( conn->end( ) == oldElm->input( in ) ) {
+                    conn->setEnd( newElm->input( in ) );
+                }
+            }
+        }
+        for( int out = 0; out < oldElm->outputSize( ); ++out ) {
+            while( !oldElm->output( out )->connections( ).isEmpty( ) ) {
+                QNEConnection *conn = oldElm->output( out )->connections( ).first( );
+                if( conn->start( ) == oldElm->output( out ) ) {
+                    conn->setStart( newElm->output( out ) );
+                }
+            }
+        }
+        int oldId = oldElm->id( );
+        editor->getScene( )->removeItem( oldElm );
+        delete oldElm;
 
-    ElementFactory::updateItemId( newElm, oldId );
-    editor->getScene( )->addItem( newElm );
-    newElm->updatePorts( );
-  }
+        ElementFactory::updateItemId( newElm, oldId );
+        editor->getScene( )->addItem( newElm );
+        newElm->updatePorts( );
+    }
 }
 
 
@@ -612,132 +618,133 @@ ChangeInputSZCommand::ChangeInputSZCommand( const QVector< GraphicElement* > &el
                                             int newInputSize,
                                             Editor *editor,
                                             QUndoCommand *parent ) : QUndoCommand( parent ), editor( editor ) {
-  for( GraphicElement *elm : elements ) {
-    elms.append( elm->id( ) );
-  }
-  m_newInputSize = newInputSize;
-  if( !elements.isEmpty( ) ) {
-    scene = elements.front( )->scene( );
-  }
-  setText( tr( "Change input size to %1" ).arg( newInputSize ) );
+    for( GraphicElement *elm : elements ) {
+        elms.append( elm->id( ) );
+    }
+    m_newInputSize = newInputSize;
+    if( !elements.isEmpty( ) ) {
+        scene = elements.front( )->scene( );
+    }
+    setText( tr( "Change input size to %1" ).arg( newInputSize ) );
 }
 
 void ChangeInputSZCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  const QVector< GraphicElement* > m_elements = findElements( elms ).toVector( );
-  if( !m_elements.isEmpty( ) && m_elements.front( )->scene( ) ) {
-    scene->clearSelection( );
-  }
-  QVector< GraphicElement* > serializationOrder;
-  m_oldData.clear( );
-  QDataStream dataStream( &m_oldData, QIODevice::WriteOnly );
-  for( int i = 0; i < m_elements.size( ); ++i ) {
-    GraphicElement *elm = m_elements[ i ];
-    elm->save( dataStream );
-    serializationOrder.append( elm );
-    for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
-      for( QNEConnection *conn : elm->input( in )->connections( ) ) {
-        QNEPort *otherPort = conn->otherPort( elm->input( in ) );
-        otherPort->graphicElement( )->save( dataStream );
-        serializationOrder.append( otherPort->graphicElement( ) );
-      }
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    const QVector< GraphicElement* > m_elements = findElements( elms ).toVector( );
+    if( !m_elements.isEmpty( ) && m_elements.front( )->scene( ) ) {
+        scene->clearSelection( );
     }
-  }
-  for( int i = 0; i < m_elements.size( ); ++i ) {
-    GraphicElement *elm = m_elements[ i ];
-    for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
-      while( !elm->input( in )->connections( ).isEmpty( ) ) {
-        QNEConnection *conn = elm->input( in )->connections( ).front( );
-        conn->save( dataStream );
-        scene->removeItem( conn );
-        QNEPort *otherPort = conn->otherPort( elm->input( in ) );
-        elm->input( in )->disconnect( conn );
-        otherPort->disconnect( conn );
-      }
+    QVector< GraphicElement* > serializationOrder;
+    m_oldData.clear( );
+    QDataStream dataStream( &m_oldData, QIODevice::WriteOnly );
+    for( int i = 0; i < m_elements.size( ); ++i ) {
+        GraphicElement *elm = m_elements[ i ];
+        elm->save( dataStream );
+        serializationOrder.append( elm );
+        for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
+            for( QNEConnection *conn : elm->input( in )->connections( ) ) {
+                QNEPort *otherPort = conn->otherPort( elm->input( in ) );
+                otherPort->graphicElement( )->save( dataStream );
+                serializationOrder.append( otherPort->graphicElement( ) );
+            }
+        }
     }
-    elm->setInputSize( m_newInputSize );
-    elm->setSelected( true );
-  }
-  order.clear( );
-  for( GraphicElement *elm : serializationOrder ) {
-    order.append( elm->id( ) );
-  }
-  emit editor->circuitHasChanged( );
+    for( int i = 0; i < m_elements.size( ); ++i ) {
+        GraphicElement *elm = m_elements[ i ];
+        for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
+            while( !elm->input( in )->connections( ).isEmpty( ) ) {
+                QNEConnection *conn = elm->input( in )->connections( ).front( );
+                conn->save( dataStream );
+                scene->removeItem( conn );
+                QNEPort *otherPort = conn->otherPort( elm->input( in ) );
+                elm->input( in )->disconnect( conn );
+                otherPort->disconnect( conn );
+            }
+        }
+        elm->setInputSize( m_newInputSize );
+        elm->setSelected( true );
+    }
+    order.clear( );
+    for( GraphicElement *elm : serializationOrder ) {
+        order.append( elm->id( ) );
+    }
+    emit editor->circuitHasChanged( );
 }
 
 void ChangeInputSZCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  const QVector< GraphicElement* > m_elements = findElements( elms ).toVector( );
-  const QVector< GraphicElement* > serializationOrder = findElements( order ).toVector( );
-  if( !m_elements.isEmpty( ) && m_elements.front( )->scene( ) ) {
-    scene->clearSelection( );
-  }
-  QDataStream dataStream( &m_oldData, QIODevice::ReadOnly );
-  double version = GlobalProperties::version;
-  QMap< quint64, QNEPort* > portMap;
-  for( GraphicElement *elm : serializationOrder ) {
-    elm->load( dataStream, portMap, version );
-  }
-  for( int i = 0; i < m_elements.size( ); ++i ) {
-    GraphicElement *elm = m_elements[ i ];
-    for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
-      QNEConnection *conn = ElementFactory::buildConnection( );
-      conn->load( dataStream, portMap );
-      scene->addItem( conn );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    const QVector< GraphicElement* > m_elements = findElements( elms ).toVector( );
+    const QVector< GraphicElement* > serializationOrder = findElements( order ).toVector( );
+    if( !m_elements.isEmpty( ) && m_elements.front( )->scene( ) ) {
+        scene->clearSelection( );
     }
-    elm->setSelected( true );
-  }
-  emit editor->circuitHasChanged( );
+    QDataStream dataStream( &m_oldData, QIODevice::ReadOnly );
+    double version = GlobalProperties::version;
+    QMap< quint64, QNEPort* > portMap;
+    for( GraphicElement *elm : serializationOrder ) {
+        elm->load( dataStream, portMap, version );
+    }
+    for( int i = 0; i < m_elements.size( ); ++i ) {
+        GraphicElement *elm = m_elements[ i ];
+        for( int in = m_newInputSize; in < elm->inputSize( ); ++in ) {
+            QNEConnection *conn = ElementFactory::buildConnection( );
+            conn->load( dataStream, portMap );
+            scene->addItem( conn );
+        }
+        elm->setSelected( true );
+    }
+    emit editor->circuitHasChanged( );
 
 }
 
 FlipCommand::FlipCommand( const QList< GraphicElement* > &aItems, int aAxis, QUndoCommand *parent ) :
-  QUndoCommand( parent ) {
-  axis = aAxis;
-  setText( tr( "Flip %1 elements in axis %2" ).arg( aItems.size( ) ).arg( aAxis ) );
-  ids.reserve( aItems.size( ) );
-  positions.reserve( aItems.size( ) );
-  double xmin, xmax, ymin, ymax;
-  if( aItems.size( ) > 0 ) {
-    xmin = xmax = aItems.first( )->pos( ).rx( );
-    ymin = ymax = aItems.first( )->pos( ).ry( );
-    for( GraphicElement *item : aItems ) {
-      positions.append( item->pos( ) );
-      item->setPos( item->pos( ) );
-      ids.append( item->id( ) );
-      xmin = qMin( xmin, item->pos( ).rx( ) );
-      xmax = qMax( xmax, item->pos( ).rx( ) );
-      ymin = qMin( ymin, item->pos( ).ry( ) );
-      ymax = qMax( ymax, item->pos( ).ry( ) );
+    QUndoCommand( parent ) {
+    axis = aAxis;
+    setText( tr( "Flip %1 elements in axis %2" ).arg( aItems.size( ) ).arg( aAxis ) );
+    ids.reserve( aItems.size( ) );
+    positions.reserve( aItems.size( ) );
+    double xmin, xmax, ymin, ymax;
+    if( aItems.size( ) > 0 ) {
+        xmin = xmax = aItems.first( )->pos( ).rx( );
+        ymin = ymax = aItems.first( )->pos( ).ry( );
+        for( GraphicElement *item : aItems ) {
+            positions.append( item->pos( ) );
+            item->setPos( item->pos( ) );
+            ids.append( item->id( ) );
+            xmin = qMin( xmin, item->pos( ).rx( ) );
+            xmax = qMax( xmax, item->pos( ).rx( ) );
+            ymin = qMin( ymin, item->pos( ).ry( ) );
+            ymax = qMax( ymax, item->pos( ).ry( ) );
+        }
+        minPos = QPointF( xmin, ymin );
+        maxPos = QPointF( xmax, ymax );
     }
-    minPos = QPointF( xmin, ymin );
-    maxPos = QPointF( xmax, ymax );
-  }
 }
 
 void FlipCommand::undo( ) {
-  COMMENT( "UNDO " + text( ).toStdString( ), 0 );
-  redo( );
+    COMMENT( "UNDO " + text( ).toStdString( ), 0 );
+    redo( );
 }
 
 void FlipCommand::redo( ) {
-  COMMENT( "REDO " + text( ).toStdString( ), 0 );
-  QList< GraphicElement* > list = findElements( ids );
-  QGraphicsScene *scn = list[ 0 ]->scene( );
-  scn->clearSelection( );
-  for( GraphicElement *elm : list ) {
-    QPointF pos = elm->pos( );
-    if( axis == 0 ) {
-      pos.setX( minPos.rx( ) + ( maxPos.rx( ) - pos.rx( ) ) );
+    COMMENT( "REDO " + text( ).toStdString( ), 0 );
+    //! TODO: this might detach the QList
+    QList< GraphicElement* > list = findElements( ids );
+    QGraphicsScene *scn = list[ 0 ]->scene( );
+    scn->clearSelection( );
+    for( GraphicElement *elm : list ) {
+        QPointF pos = elm->pos( );
+        if( axis == 0 ) {
+            pos.setX( minPos.rx( ) + ( maxPos.rx( ) - pos.rx( ) ) );
+        }
+        else {
+            pos.setY( minPos.ry( ) + ( maxPos.ry( ) - pos.ry( ) ) );
+        }
+        elm->setPos( pos );
+        elm->update( );
+        elm->setSelected( true );
+        if( elm->rotatable( ) ) {
+            elm->setRotation( elm->rotation( ) + 180 );
+        }
     }
-    else {
-      pos.setY( minPos.ry( ) + ( maxPos.ry( ) - pos.ry( ) ) );
-    }
-    elm->setPos( pos );
-    elm->update( );
-    elm->setSelected( true );
-    if( elm->rotatable( ) ) {
-      elm->setRotation( elm->rotation( ) + 180 );
-    }
-  }
 }

--- a/app/editor.cpp
+++ b/app/editor.cpp
@@ -121,7 +121,8 @@ void Editor::clear( ) {
     scene->clear( );
   }
   buildSelectionRect( );
-  if( !scene->views( ).isEmpty( ) ) {
+  //! carmesim: scene can be NULL here. Add a NULL check
+  if( scene && !scene->views( ).isEmpty( ) ) {
     scene->setSceneRect( scene->views( ).front( )->rect( ) );
   }
   updateTheme( );

--- a/app/editor.h
+++ b/app/editor.h
@@ -10,7 +10,7 @@
 
 #include <memory>
 #include <QObject>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QUndoCommand>
 
 class Box;
@@ -18,7 +18,7 @@ class MainWindow;
 
 class Editor : public QObject {
   Q_OBJECT
-  QTime timer;
+  QElapsedTimer timer;
 public:
   explicit Editor( QObject *parent = nullptr );
   virtual ~Editor( );

--- a/app/element/buzzer.cpp
+++ b/app/element/buzzer.cpp
@@ -11,12 +11,13 @@ Buzzer::Buzzer( QGraphicsItem *parent ) : GraphicElement( 1, 1, 0, 0, parent ) {
   updatePorts( );
   setHasLabel( true );
   setPortName( "Buzzer" );
-  setAudio( "C6" );
+  setAudio( "C6" ); //! TODO: Call to virtual function during construction
   play = 0;
 }
 
 void Buzzer::refresh( ) {
   if( isValid( ) ) {
+
     bool value = inputs( ).first( )->value( );
     if( value == 1 ) {
       playbuzzer( );

--- a/app/element/clock.cpp
+++ b/app/element/clock.cpp
@@ -8,7 +8,7 @@ Clock::Clock( QGraphicsItem *parent ) : GraphicElement( 0, 0, 1, 1, parent ) {
   setOutputsOnTop( false );
   setRotatable( false );
   /*  connect(&timer,&QTimer::timeout,this,&Clock::updateClock); */
-  setFrequency( 1.0 );
+  setFrequency( 1.0 );      //! TODO: call to virtual function during construction
   setHasFrequency( true );
   on = false;
   Clock::reset = true;
@@ -39,7 +39,7 @@ void Clock::setOn( bool value ) {
   else {
     setPixmap( ":/input/clock0.png" );
   }
-  outputs( ).first( )->setValue( on );
+  m_outputs.first( )->setValue( on );
 }
 
 void Clock::save( QDataStream &ds ) const {

--- a/app/element/display_14.cpp
+++ b/app/element/display_14.cpp
@@ -31,7 +31,8 @@ Display14::Display14( QGraphicsItem *parent ) : GraphicElement( 15, 15, 0, 0, pa
   dp = QPixmap( ":/output/counter/counter_dp.png" );
 
   setPortName( "Display14" );
-  for( QNEPort *in : inputs( ) ) {
+  const auto m_inputs = inputs();
+  for( QNEPort *in : m_inputs ) {
     in->setRequired( false );
     in->setDefaultValue( 0 );
   }

--- a/app/element/inputbutton.cpp
+++ b/app/element/inputbutton.cpp
@@ -7,7 +7,7 @@ InputButton::InputButton( QGraphicsItem *parent ) : GraphicElement( 0, 0, 1, 1, 
   setOutputsOnTop( false );
   setPixmap( ":/input/buttonOff.png" );
   setRotatable( false );
-  outputs( ).first( )->setValue( 0 );
+  m_outputs.first( )->setValue( 0 );
   setOn( false );
   setHasLabel( true );
   setHasTrigger( true );

--- a/app/element/inputgnd.cpp
+++ b/app/element/inputgnd.cpp
@@ -9,5 +9,5 @@ InputGnd::InputGnd( QGraphicsItem *parent ) : GraphicElement( 0, 0, 1, 1, parent
 }
 
 void InputGnd::updateLogic( ) {
-  outputs( ).first( )->setValue( false );
+  m_outputs.first( )->setValue( false );
 }

--- a/app/element/inputvcc.cpp
+++ b/app/element/inputvcc.cpp
@@ -9,5 +9,5 @@ InputVcc::InputVcc( QGraphicsItem *parent ) : GraphicElement( 0, 0, 1, 1, parent
 }
 
 void InputVcc::updateLogic( ) {
-  outputs( ).first( )->setValue( true );
+  m_outputs.first( )->setValue( true );
 }

--- a/app/element/jklatch.cpp
+++ b/app/element/jklatch.cpp
@@ -16,25 +16,25 @@ void JKLatch::updatePorts( ) {
 }
 
 void JKLatch::updateLogic( ) {
-  char res = outputs( ).first( )->value( );
-  char j = input( 0 )->value( );
-  char k = input( 1 )->value( );
-  if( !isValid( ) ) {
-    res = -1;
-  }
-  else {
-    if( res == -1 ) {
-      res = 0;
+    char res = m_outputs.first( )->value( );
+    char j = input( 0 )->value( );
+    char k = input( 1 )->value( );
+    if( !isValid( ) ) {
+        res = -1;
     }
-    if( ( j == 1 ) && ( k == 1 ) ) { /* IF J=K */
-      res = !res;
+    else {
+        if( res == -1 ) {
+            res = 0;
+        }
+        if( ( j == 1 ) && ( k == 1 ) ) { /* IF J=K */
+            res = !res;
+        }
+        else if( j != k ) { /* J */
+            res = j;
+        } /* else nothing happens */
     }
-    else if( j != k ) { /* J */
-      res = j;
-    } /* else nothing happens */
-  }
-  outputs( ).first( )->setValue( res );
-  outputs( ).last( )->setValue( !res );
+    m_outputs.first( )->setValue( res );
+    m_outputs.last( )->setValue( !res );
 }
 
 /* Reference: https://en.wikipedia.org/wiki/Flip-flop_(electronics)#Gated_latches_and_conditional_transparency */

--- a/app/element/led.cpp
+++ b/app/element/led.cpp
@@ -16,14 +16,18 @@ Led::Led( QGraphicsItem *parent ) : GraphicElement( 1, 4, 0, 0, parent ) {
 
 }
 
-static QVector< QString > led_2bits = {
-  ":/output/16colors/BlackLedOn.png", /* 00 */
-  ":/output/16colors/RedLedOn.png", /* 01 */
-  ":/output/16colors/GreenLedOn.png", /* 10 */
-  ":/output/16colors/RoyalLedOn.png" /* 11 */
+//! carmesim: changed these led_*bits from QVector< QString > into static constexpr std::array<const char *>
+//! This should improve performance, but makes me weary of stack overflow, since std::array is stack-alloc'd
+//! TODO: make ":/output/16colors/" it's own variable in order to remove repetition
+
+static constexpr std::array<const char *, 4> led_2bits = {
+    ":/output/16colors/BlackLedOn.png", /* 00 */
+    ":/output/16colors/RedLedOn.png", /* 01 */
+    ":/output/16colors/GreenLedOn.png", /* 10 */
+    ":/output/16colors/RoyalLedOn.png" /* 11 */
 };
 
-static QVector< QString > led_3bits = {
+static constexpr std::array<const char *, 8> led_3bits = {
   ":/output/16colors/BlackLedOn.png", /* 000 */
   ":/output/16colors/RoyalLedOn.png", /* 001 */
   ":/output/16colors/GreenLedOn.png", /* 010 */
@@ -34,7 +38,7 @@ static QVector< QString > led_3bits = {
   ":/output/16colors/WhiteLedOn.png", /* 111 */
 };
 
-static QVector< QString > led_4bits = {
+static constexpr std::array<const char *, 16> led_4bits = {
   ":/output/16colors/WhiteLedOn.png",
   ":/output/16colors/BlackLedOn.png",
   ":/output/16colors/NavyBlueLedOn.png",

--- a/app/element/ledgrid.cpp
+++ b/app/element/ledgrid.cpp
@@ -15,7 +15,7 @@ LedGrid::LedGrid( QGraphicsItem *parent ) : GraphicElement( 8, 8, 0, 0, parent )
 
   setPixmap( ":/output/LedGrid.png" );
   setPortName( "Led Grid" );
-  for( QNEPort *in : inputs( ) ) {
+  for( QNEPort *in : m_inputs ) {
     in->setRequired( false );
     in->setDefaultValue( 0 );
   }

--- a/app/element/nand.cpp
+++ b/app/element/nand.cpp
@@ -13,12 +13,12 @@ void Nand::updateLogic( ) {
     res = -1;
   }
   else {
-    for( QNEPort *input: inputs( ) ) {
+    for( QNEPort *input: m_inputs ) {
       if( input->value( ) == false ) {
         res = true;
         break;
       }
     }
   }
-  outputs( ).first( )->setValue( res );
+  m_outputs.first( )->setValue( res );
 }

--- a/app/element/not.cpp
+++ b/app/element/not.cpp
@@ -8,7 +8,7 @@ Not::Not( QGraphicsItem *parent ) : GraphicElement( 1, 1, 1, 1, parent ) {
 }
 
 void Not::updateLogic( ) {
-  char res = !inputs( ).first( )->value( );
+  char res = !m_inputs.first( )->value( );
   if( !isValid( ) ) {
     res = -1;
   }

--- a/app/graphicelement.cpp
+++ b/app/graphicelement.cpp
@@ -12,6 +12,7 @@
 #include <QStyleOptionGraphicsItem>
 #include <stdexcept>
 
+//! carmesim -- warning: non-POD static
 static QMap< QString, QPixmap > loadedPixmaps;
 
 
@@ -253,7 +254,7 @@ void GraphicElement::loadInputPort( QDataStream &ds, QMap< quint64, QNEPort* > &
   ds >> ptr;
   ds >> name;
   ds >> flags;
-  if( ( port < static_cast< size_t >( m_inputs.size( ) ) ) ) {
+  if( ( port < static_cast< size_t >( m_inputs.size() ) ) ) {
     if( elementType( ) == ElementType::BOX ) {
       m_inputs[ port ]->setName( name );
     }

--- a/app/graphicelement.cpp
+++ b/app/graphicelement.cpp
@@ -97,7 +97,13 @@ void GraphicElement::setPixmap( const QString &pixmapName, QRect size ) {
   }
   if( pixmapPath != currentPixmapName ) {
     if( !loadedPixmaps.contains( pixmapPath ) ) {
-      loadedPixmaps[ pixmapPath ] = QPixmap::fromImage( QImage( pixmapPath ) ).copy( size );
+        //! carmesim-TODO: use QPixmap::loadFromData() here
+        QPixmap pixmap;
+        if (!pixmap.load(pixmapPath))
+        {
+            throw std::runtime_error( ERRORMSG("Couldn't load pixmap.") );
+        }
+        loadedPixmaps[ pixmapPath ] = pixmap.copy( size );
     }
     pixmap = &loadedPixmaps[ pixmapPath ];
     setTransformOriginPoint( pixmap->rect( ).center( ) );

--- a/app/graphicelement.h
+++ b/app/graphicelement.h
@@ -8,14 +8,15 @@
 #include <QGraphicsItem>
 #include <QGraphicsPixmapItem>
 #include <QKeySequence>
+#include <cstdint>
 
-enum class ElementType {
+enum class ElementType : uint_fast8_t {
   UNKNOWN, BUTTON, SWITCH, LED, NOT, AND, OR, NAND, NOR, CLOCK, XOR, XNOR, VCC, GND, DISPLAY,
   DLATCH, JKLATCH, DFLIPFLOP, JKFLIPFLOP, SRFLIPFLOP, TFLIPFLOP, TLATCH, BOX, NODE, MUX, DEMUX,
   BUZZER, DISPLAY14, LEDGRID
 };
 
-enum class ElementGroup {
+enum class ElementGroup : uint_fast8_t {
   UNKNOWN, OTHER, BOX, INPUT, GATE, MEMORY, OUTPUT, MUX, STATICINPUT
 };
 

--- a/app/logicelement.cpp
+++ b/app/logicelement.cpp
@@ -14,7 +14,7 @@ void LogicElement::clearPredecessors( ) {
 }
 
 void LogicElement::clearSucessors( ) {
-  for( auto &elm : m_sucessors ) {
+  for( auto &elm : qAsConst(m_sucessors) ) {
     for( auto &input: elm->m_inputs ) {
       if( input.first == this ) {
         input.first = nullptr;
@@ -68,7 +68,7 @@ void LogicElement::validate( ) {
     }
   }
   if( !m_isValid ) {
-    for( LogicElement *elm : m_sucessors ) {
+    for( LogicElement *elm : qAsConst(m_sucessors) ) {
       elm->m_isValid = false;
     }
   }
@@ -87,10 +87,10 @@ int LogicElement::calculatePriority( ) {
   }
   beingVisited = true;
   int max = 0;
-  for( LogicElement *s : m_sucessors ) {
+  for( LogicElement *s : qAsConst(m_sucessors) ) {
     max = qMax( s->calculatePriority( ), max );
   }
-  int p = max + 1;
+  const int p = max + 1;
   priority = p;
   beingVisited = false;
   return( p );

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -56,7 +56,8 @@ MainWindow::MainWindow( QWidget *parent ) : QMainWindow( parent ), ui( new Ui::M
 
   /* THEME */
   QActionGroup *themeGroup = new QActionGroup( this );
-  for( QAction *action : ui->menuTheme->actions( ) ) {
+  auto const actions = ui->menuTheme->actions( );
+  for( QAction *action : actions ) {
     themeGroup->addAction( action );
   }
   themeGroup->setExclusive( true );
@@ -403,13 +404,13 @@ void MainWindow::on_actionSelect_all_triggered( ) {
 
 void MainWindow::updateRecentBoxes( ) {
   ui->scrollAreaWidgetContents_Box->layout( )->removeItem( ui->verticalSpacer_BOX );
-  for( ListItemWidget *item : boxItemWidgets ) {
+  for( ListItemWidget *item : qAsConst(boxItemWidgets) ) {
     item->deleteLater( );
   }
 /*  qDeleteAll( boxItemWidgets ); */
   boxItemWidgets.clear( );
 
-  QStringList files = rboxController->getFiles( );
+  const QStringList files = rboxController->getFiles( );
   for( auto file : files ) {
     QPixmap pixmap( QString::fromUtf8( ":/basic/box.png" ) );
     ListItemWidget *item = new ListItemWidget( pixmap, ElementType::BOX, file, this );
@@ -452,7 +453,7 @@ void MainWindow::on_actionOpen_Box_triggered( ) {
 
 void MainWindow::on_lineEdit_textChanged( const QString &text ) {
   ui->searchLayout->removeItem( ui->VSpacer );
-  for( ListItemWidget *item : searchItemWidgets ) {
+  for( ListItemWidget *item : qAsConst(searchItemWidgets)) {
     item->deleteLater( );
   }
   searchItemWidgets.clear( );
@@ -665,7 +666,8 @@ void MainWindow::on_actionPrint_triggered( ) {
   if( pdfFile.isEmpty( ) ) {
     return;
   }
-  if( !pdfFile.toLower( ).endsWith( ".pdf" ) ) {
+  //! carmesim: avoid unneeded heap allocation caused by toLower
+  if( !pdfFile.endsWith( ".pdf", Qt::CaseInsensitive ) ) {
     pdfFile.append( ".pdf" );
   }
   QPrinter printer( QPrinter::HighResolution );
@@ -694,7 +696,7 @@ void MainWindow::on_actionExport_to_Image_triggered( ) {
   if( pngFile.isEmpty( ) ) {
     return;
   }
-  if( !pngFile.toLower( ).endsWith( ".png" ) ) {
+  if( !pngFile.endsWith( ".png", Qt::CaseInsensitive ) ) {
     pngFile.append( ".png" );
   }
   QRectF s = editor->getScene( )->itemsBoundingRect( ).adjusted( -64, -64, 64, 64 );

--- a/app/recentfilescontroller.cpp
+++ b/app/recentfilescontroller.cpp
@@ -6,9 +6,6 @@
 #include <QFileInfo>
 #include <QSettings>
 
-RecentFilesController::RecentFilesController( QString attrName, QObject *parent ) : QObject( parent ) {
-  this->attrName = attrName;
-}
 
 void RecentFilesController::addFile( QString fname ) {
   qDebug( ) << "Setting recent file to : \"" << fname << "\"";

--- a/app/recentfilescontroller.cpp
+++ b/app/recentfilescontroller.cpp
@@ -7,7 +7,7 @@
 #include <QSettings>
 
 
-void RecentFilesController::addFile( QString fname ) {
+void RecentFilesController::addFile(const QString& fname ) {
   qDebug( ) << "Setting recent file to : \"" << fname << "\"";
   if( !QFile( fname ).exists( ) ) {
     return;

--- a/app/recentfilescontroller.h
+++ b/app/recentfilescontroller.h
@@ -9,12 +9,13 @@ class RecentFilesController : public QObject {
   QString attrName;
 public:
   static const int MaxRecentFiles = 10;
-  explicit RecentFilesController( QString attrName, QObject *parent = nullptr );
+  explicit RecentFilesController(QString _attrName, QObject *parent = nullptr ) : QObject( parent ), attrName(_attrName) {};
   void addFile( QString fname );
   QStringList getFiles( );
 
 signals:
   void recentFilesUpdated( );
 };
+
 
 #endif /* RECENTFILESCONTROLLER_H */

--- a/app/recentfilescontroller.h
+++ b/app/recentfilescontroller.h
@@ -8,9 +8,9 @@ class RecentFilesController : public QObject {
   Q_OBJECT
   QString attrName;
 public:
-  static const int MaxRecentFiles = 10;
+  static constexpr int MaxRecentFiles = 10;
   explicit RecentFilesController(QString _attrName, QObject *parent = nullptr ) : QObject( parent ), attrName(_attrName) {};
-  void addFile( QString fname );
+  void addFile(const QString & fname);
   QStringList getFiles( );
 
 signals:

--- a/app/scene.cpp
+++ b/app/scene.cpp
@@ -5,21 +5,14 @@
 #include <QGraphicsView>
 #include <QPainter>
 
-Scene::Scene( QObject *parent ) : QGraphicsScene( parent ) {
-  m_gridSize = 16;
-}
+//! TODO: stop using QGraphicsView *
 
-Scene::Scene( const QRectF &sceneRect, QObject *parent ) : QGraphicsScene( sceneRect, parent ) {
-  m_gridSize = 16;
-}
+Scene::Scene( QObject *parent ) : QGraphicsScene( parent ) {}
 
-Scene::Scene( qreal x, qreal y, qreal width, qreal height, QObject *parent ) : QGraphicsScene( x,
-                                                                                               y,
-                                                                                               width,
-                                                                                               height,
-                                                                                               parent ) {
-  m_gridSize = 16;
-}
+Scene::Scene( const QRectF &sceneRect, QObject *parent ) : QGraphicsScene( sceneRect, parent ) {}
+
+Scene::Scene( qreal x, qreal y, qreal width, qreal height, QObject *parent )
+    : QGraphicsScene( x, y, width, height, parent) {}
 
 int Scene::gridSize( ) const {
   return( m_gridSize );
@@ -29,8 +22,8 @@ void Scene::drawBackground( QPainter *painter, const QRectF &rect ) {
   painter->setRenderHint( QPainter::Antialiasing, true );
   QGraphicsScene::drawBackground( painter, rect );
   painter->setPen( m_dots );
-  qreal left = int( rect.left( ) ) - ( int( rect.left( ) ) % m_gridSize );
-  qreal top = int( rect.top( ) ) - ( int( rect.top( ) ) % m_gridSize );
+  qreal left = int(rect.left()) - (int(rect.left()) % m_gridSize );
+  qreal top  = int(rect.top())  - (int( rect.top()) % m_gridSize );
   QVector< QPointF > points;
   for( qreal x = left; x < rect.right( ); x += m_gridSize ) {
     for( qreal y = top; y < rect.bottom( ); y += m_gridSize ) {
@@ -46,7 +39,7 @@ void Scene::setDots( const QPen &dots ) {
 
 
 QVector< GraphicElement* > Scene::getVisibleElements( ) {
-    auto gviews = views();
+    const auto gviews = views();
     QGraphicsView *graphicsView = gviews.first( );
     if( !graphicsView->isActiveWindow( ) ) {
         graphicsView = gviews.last( );

--- a/app/scene.cpp
+++ b/app/scene.cpp
@@ -46,13 +46,14 @@ void Scene::setDots( const QPen &dots ) {
 
 
 QVector< GraphicElement* > Scene::getVisibleElements( ) {
-  QGraphicsView *graphicsView = views( ).first( );
-  if( !graphicsView->isActiveWindow( ) ) {
-    graphicsView = views( ).last( );
-  }
-  QRectF visibleRect = graphicsView->mapToScene( graphicsView->viewport( )->geometry( ) ).boundingRect( );
+    auto gviews = views();
+    QGraphicsView *graphicsView = gviews.first( );
+    if( !graphicsView->isActiveWindow( ) ) {
+        graphicsView = gviews.last( );
+    }
+    QRectF visibleRect = graphicsView->mapToScene( graphicsView->viewport( )->geometry( ) ).boundingRect( );
 
-  return( getElements( visibleRect ) );
+    return getElements( visibleRect ) ;
 }
 
 QVector< GraphicElement* > Scene::getElements( ) {
@@ -64,7 +65,7 @@ QVector< GraphicElement* > Scene::getElements( ) {
       elements.append( elm );
     }
   }
-  return( elements );
+  return elements;
 }
 
 QVector< GraphicElement* > Scene::getElements( QRectF rect ) {

--- a/app/scene.h
+++ b/app/scene.h
@@ -24,7 +24,7 @@ public:
   QVector< GraphicElement* > getVisibleElements( );
 protected:
   void drawBackground( QPainter *painter, const QRectF &rect );
-  int m_gridSize;
+  static constexpr int m_gridSize = 16;
   QPen m_dots;
 };
 

--- a/app/simplewaveform.cpp
+++ b/app/simplewaveform.cpp
@@ -358,11 +358,14 @@ void SimpleWaveform::showWaveform( ) {
 
 /*  chart.axisY( )->hide( ); */
   // Setting range and names to x, y axis.
-  QValueAxis *ax = dynamic_cast< QValueAxis* >( chart.axisX( ) );
+  /*! carmesim: QChart::axisX and QChart::axisY are deprecated.
+   *  Switching over to QList<QAbstractAxis*> axes(..) !*/
+
+  QValueAxis *ax = dynamic_cast< QValueAxis* >( chart.axes(Qt::Horizontal).back());
   ax->setRange( 0, num_iter );
   ax->setTickCount( num_iter + 1 );
   ax->setLabelFormat( QString( "%i" ) );
-  QValueAxis *ay = dynamic_cast< QValueAxis* >( chart.axisY( ) );
+  QValueAxis *ay = dynamic_cast< QValueAxis* >( chart.axes(Qt::Vertical).back());
 /*  ay->setShadesBrush( QBrush( Qt::lightGray ) ); */
 
   // Setting graphics waveform color.

--- a/app/simplewaveform.h
+++ b/app/simplewaveform.h
@@ -14,7 +14,7 @@ namespace Ui {
 
 class SimpleWaveform : public QDialog {
   Q_OBJECT
-  enum class SortingKind { INCREASING, DECREASING, POSITION };
+  enum class SortingKind : uint_fast8_t { INCREASING, DECREASING, POSITION };
 
 public:
   explicit SimpleWaveform( Editor *editor, QWidget *parent = nullptr );

--- a/includes.pri
+++ b/includes.pri
@@ -1,5 +1,5 @@
 QT       += core gui printsupport charts multimedia widgets
-VERSION = 5.7.0
+VERSION = 2.6.1
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 

--- a/includes.pri
+++ b/includes.pri
@@ -1,6 +1,5 @@
 QT       += core gui printsupport charts multimedia widgets
-
-VERSION = 2.6.0
+VERSION = 5.7.0
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 

--- a/test/testfiles.cpp
+++ b/test/testfiles.cpp
@@ -23,7 +23,7 @@ void TestFiles::testFiles( ) {
   QFileInfoList files = examplesDir.entryInfoList( entries );
   QVERIFY( files.size( ) > 0 );
 /*  int counter = 0; */
-  for( QFileInfo f : files ) {
+  for( QFileInfo f : qAsConst(files) ) {
 /*    qDebug( ) << "File " << counter++ << " from " << files.size( ) << ": " << f.fileName( ); */
     QVERIFY( f.exists( ) );
     QFile pandaFile( f.absoluteFilePath( ) );


### PR DESCRIPTION
In short, this PR consists of:

- Replacing deprecated functions by newer ones

This includes replacing `QTime` by [`QElapsedTimer`](https://doc.qt.io/qt-5/qelapsedtimer.html) and `QChart::axisX`/`QChart::axisY` by [`QChart::axes`](https://doc.qt.io/qt-5/qchart.html#axes).

- Improving memory safety

A current design choice within WiRed Panda is setting up protected members and then implementing getter methods to access them.¹ Those getter methods are then used within other methods of the same class, in scenarios where the protected variables could be accessed directly, removing the overhead of an additional copy. More importantly, these getter methods are used inside of range-loops, which could induce Qt container detachment issues.

This is still an ongoing effort, but I'm solving this problem by accessing the variables directly where possible and using [`qAsConst`](https://doc.qt.io/qt-5/qtglobal.html#qAsConst) on them when used in range-loops. `rvalue` issues can sometimes make `qAsConst` impossible, in which case a copy is made through `auto const Obj ...`.
 
- Performance improvements

Performance should be slightly better by using `constexpr` where applicable, reducing the usage of the aforementioned getter methods and modifying the pixmap-loading logic in `GraphicElement::setPixmap`. Related commits have more info.


¹ I don't think these variables should even be protected, since most of them are pointers or containers to pointers, which makes it possible for altering their original values even when their values are copied through a getter method.