### PR TITLE
Remove elementType and elementGroup virtual calls

### DIFF
--- a/app/element/and.cpp
+++ b/app/element/and.cpp
@@ -4,7 +4,7 @@
 #include "and.h"
 
 And::And(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::AND, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/and.png");
     setOutputsOnTop(true);

--- a/app/element/and.h
+++ b/app/element/and.h
@@ -14,16 +14,6 @@ public:
     explicit And(QGraphicsItem *parent = nullptr);
     ~And() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::AND;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/buzzer.cpp
+++ b/app/element/buzzer.cpp
@@ -19,7 +19,7 @@ static constexpr std::array<const char *, 2> defaultSkins {
 };
 
 Buzzer::Buzzer(QGraphicsItem *parent)
-    : GraphicElement(1, 1, 0, 0, parent)
+    : GraphicElement(ElementType::BUZZER, ElementGroup::OUTPUT, 1, 1, 0, 0, parent)
 {
     //  pixmapSkinName.append( ":/output/BuzzerOff.png" );
     //  pixmapSkinName.append( ":/output/BuzzerOn.png" );

--- a/app/element/buzzer.h
+++ b/app/element/buzzer.h
@@ -18,22 +18,15 @@ public:
     ~Buzzer() override = default;
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
 
-public:
-    /* GraphicElement interface */
-    ElementType elementType() override
-    {
-        return ElementType::BUZZER;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::OUTPUT;
-    }
     void refresh() override;
 
     void setAudio(QString note) override;
     QString getAudio() const override;
 
     void mute(bool _mute = true);
+    void save(QDataStream &ds) const override;
+    void load(QDataStream &ds, QMap<quint64, QNEPort *> &portMap, double version) override;
+    void setSkin(bool defaultSkin, QString filename) override;
 
 private:
     void playbuzzer();
@@ -43,11 +36,6 @@ private:
     int play;
     QSoundEffect m_audio;
     QString m_note;
-    // GraphicElement interface
-public:
-    void save(QDataStream &ds) const override;
-    void load(QDataStream &ds, QMap<quint64, QNEPort *> &portMap, double version) override;
-    void setSkin(bool defaultSkin, QString filename) override;
 };
 
 #endif // BUZZER_H

--- a/app/element/clock.cpp
+++ b/app/element/clock.cpp
@@ -11,7 +11,7 @@ int Clock::current_id_number = 0;
 Clock::~Clock() = default;
 
 Clock::Clock(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 1, 1, parent)
+    : GraphicElement(ElementType::CLOCK, ElementGroup::INPUT, 0, 0, 1, 1, parent)
 {
     pixmapSkinName.append(":/input/clock0.png");
     pixmapSkinName.append(":/input/clock1.png");

--- a/app/element/clock.h
+++ b/app/element/clock.h
@@ -24,18 +24,6 @@ public:
     ~Clock() override;
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
     static bool reset;
-public slots:
-    ElementType elementType() override
-    {
-        return ElementType::CLOCK;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::INPUT;
-    }
-    //  void updateClock();
-
-    // GraphicElement interface
 public:
     void save(QDataStream &ds) const override;
     void load(QDataStream &ds, QMap<quint64, QNEPort *> &portMap, double version) override;

--- a/app/element/demux.cpp
+++ b/app/element/demux.cpp
@@ -4,7 +4,7 @@
 #include "demux.h"
 
 Demux::Demux(QGraphicsItem *parent)
-    : GraphicElement(2, 2, 2, 2, parent)
+    : GraphicElement(ElementType::DEMUX, ElementGroup::MUX, 2, 2, 2, 2, parent)
 {
     pixmapSkinName.append(":/basic/demux.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/demux.h
+++ b/app/element/demux.h
@@ -16,17 +16,6 @@ public:
     explicit Demux(QGraphicsItem *parent = nullptr);
     ~Demux() override = default;
 
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MUX;
-    }
-
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::DEMUX;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/dflipflop.cpp
+++ b/app/element/dflipflop.cpp
@@ -4,7 +4,7 @@
 #include "dflipflop.h"
 
 DFlipFlop::DFlipFlop(QGraphicsItem *parent)
-    : GraphicElement(4, 4, 2, 2, parent)
+    : GraphicElement(ElementType::DFLIPFLOP, ElementGroup::MEMORY, 4, 4, 2, 2, parent)
 {
     pixmapSkinName.append(":/memory/D-flipflop.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/dflipflop.h
+++ b/app/element/dflipflop.h
@@ -17,16 +17,6 @@ public:
     explicit DFlipFlop(QGraphicsItem *parent = nullptr);
     ~DFlipFlop() override = default;
 
-    // GraphicElement interface
-public:
-    ElementType elementType() override
-    {
-        return ElementType::DFLIPFLOP;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/display.cpp
+++ b/app/element/display.cpp
@@ -11,7 +11,7 @@
 int Display::current_id_number = 0;
 
 Display::Display(QGraphicsItem *parent)
-    : GraphicElement(8, 8, 0, 0, parent)
+    : GraphicElement(ElementType::DISPLAY, ElementGroup::OUTPUT, 8, 8, 0, 0, parent)
 {
     pixmapSkinName.append(":/output/counter/counter_off.png");
     pixmapSkinName.append(":/output/counter/counter_a.png");

--- a/app/element/display.h
+++ b/app/element/display.h
@@ -15,15 +15,6 @@ public:
     ~Display() override = default;
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
 
-public:
-    ElementType elementType() override
-    {
-        return ElementType::DISPLAY;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::OUTPUT;
-    }
     void refresh() override;
     void updatePorts() override;
     QPixmap bkg, a, b, c, d, e, f, g, dp;

--- a/app/element/display_14.cpp
+++ b/app/element/display_14.cpp
@@ -11,7 +11,7 @@
 int Display14::current_id_number = 0;
 
 Display14::Display14(QGraphicsItem *parent)
-    : GraphicElement(15, 15, 0, 0, parent)
+    : GraphicElement(ElementType::DISPLAY14, ElementGroup::OUTPUT, 15, 15, 0, 0, parent)
 {
     pixmapSkinName.append(":/output/counter/counter_14_off.png");
     pixmapSkinName.append(":/output/counter/counter_a.png");

--- a/app/element/display_14.h
+++ b/app/element/display_14.h
@@ -15,15 +15,6 @@ public:
     ~Display14() override = default;
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
 
-public:
-    ElementType elementType() override
-    {
-        return ElementType::DISPLAY14;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::OUTPUT;
-    }
     void refresh() override;
     void updatePorts() override;
     QPixmap bkg, a, b, c, d, e, f, g1, g2, h, j, k, l, m, n, dp;

--- a/app/element/dlatch.cpp
+++ b/app/element/dlatch.cpp
@@ -4,7 +4,7 @@
 #include "dlatch.h"
 
 DLatch::DLatch(QGraphicsItem *parent)
-    : GraphicElement(2, 2, 2, 2, parent)
+    : GraphicElement(ElementType::DLATCH, ElementGroup::MEMORY, 2, 2, 2, 2, parent)
 {
     pixmapSkinName.append(":/memory/D-latch.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/dlatch.h
+++ b/app/element/dlatch.h
@@ -14,16 +14,6 @@ public:
     explicit DLatch(QGraphicsItem *parent = nullptr);
     ~DLatch() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::DLATCH;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/inputbutton.cpp
+++ b/app/element/inputbutton.cpp
@@ -9,7 +9,7 @@
 int InputButton::current_id_number = 0;
 
 InputButton::InputButton(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 1, 1, parent)
+    : GraphicElement(ElementType::BUTTON, ElementGroup::INPUT, 0, 0, 1, 1, parent)
 {
     pixmapSkinName.append(":/input/buttonOff.png");
     pixmapSkinName.append(":/input/buttonOn.png");

--- a/app/element/inputbutton.h
+++ b/app/element/inputbutton.h
@@ -17,23 +17,10 @@ public:
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
     bool on;
 
-    /* QGraphicsItem interface */
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::BUTTON;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::INPUT;
-    }
-
-    // Input interface
 public:
     bool getOn() const override;
     void setOn(const bool value) override;

--- a/app/element/inputgnd.cpp
+++ b/app/element/inputgnd.cpp
@@ -4,7 +4,7 @@
 #include "inputgnd.h"
 
 InputGnd::InputGnd(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 1, 1, parent)
+    : GraphicElement(ElementType::GND, ElementGroup::STATICINPUT, 0, 0, 1, 1, parent)
 {
     pixmapSkinName.append(":/input/0.png");
     setOutputsOnTop(false);

--- a/app/element/inputgnd.h
+++ b/app/element/inputgnd.h
@@ -13,16 +13,7 @@ class InputGnd : public GraphicElement
 public:
     explicit InputGnd(QGraphicsItem *parent = nullptr);
     ~InputGnd() override = default;
-    /* GraphicElement interface */
 public:
-    ElementType elementType() override
-    {
-        return ElementType::GND;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::STATICINPUT;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/inputswitch.cpp
+++ b/app/element/inputswitch.cpp
@@ -8,7 +8,7 @@
 int InputSwitch::current_id_number = 0;
 
 InputSwitch::InputSwitch(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 1, 1, parent)
+    : GraphicElement(ElementType::SWITCH, ElementGroup::INPUT, 0, 0, 1, 1, parent)
 {
     pixmapSkinName.append(":/input/switchOff.png");
     pixmapSkinName.append(":/input/switchOn.png");

--- a/app/element/inputswitch.h
+++ b/app/element/inputswitch.h
@@ -23,17 +23,6 @@ protected:
 
     /* GraphicElement interface */
 public:
-    ElementType elementType() override
-    {
-        return ElementType::SWITCH;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::INPUT;
-    }
-
-    /* GraphicElement interface */
-public:
     void save(QDataStream &ds) const override;
     void load(QDataStream &ds, QMap<quint64, QNEPort *> &portMap, double version) override;
     bool getOn() const override;

--- a/app/element/inputvcc.cpp
+++ b/app/element/inputvcc.cpp
@@ -4,7 +4,7 @@
 #include "inputvcc.h"
 
 InputVcc::InputVcc(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 1, 1, parent)
+    : GraphicElement(ElementType::VCC, ElementGroup::STATICINPUT, 0, 0, 1, 1, parent)
 {
     pixmapSkinName.append(":/input/1.png");
     setOutputsOnTop(false);

--- a/app/element/inputvcc.h
+++ b/app/element/inputvcc.h
@@ -13,16 +13,6 @@ class InputVcc : public GraphicElement
 public:
     explicit InputVcc(QGraphicsItem *parent = nullptr);
     ~InputVcc() override = default;
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::VCC;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::STATICINPUT;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/jkflipflop.cpp
+++ b/app/element/jkflipflop.cpp
@@ -6,7 +6,7 @@
 #include <QDebug>
 
 JKFlipFlop::JKFlipFlop(QGraphicsItem *parent)
-    : GraphicElement(5, 5, 2, 2, parent)
+    : GraphicElement(ElementType::JKFLIPFLOP, ElementGroup::MEMORY, 5, 5, 2, 2, parent)
 {
     pixmapSkinName.append(":/memory/JK-flipflop.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/jkflipflop.h
+++ b/app/element/jkflipflop.h
@@ -16,16 +16,6 @@ public:
     explicit JKFlipFlop(QGraphicsItem *parent = nullptr);
     ~JKFlipFlop() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::JKFLIPFLOP;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/jklatch.cpp
+++ b/app/element/jklatch.cpp
@@ -4,7 +4,7 @@
 #include "jklatch.h"
 
 JKLatch::JKLatch(QGraphicsItem *parent)
-    : GraphicElement(2, 2, 2, 2, parent)
+    : GraphicElement(ElementType::JKLATCH, ElementGroup::MEMORY, 2, 2, 2, 2, parent)
 {
     setPixmap(":/memory/JK-latch.png");
     setRotatable(false);

--- a/app/element/jklatch.h
+++ b/app/element/jklatch.h
@@ -16,14 +16,6 @@ public:
 
     /* GraphicElement interface */
 public:
-    ElementType elementType() override
-    {
-        return ElementType::JKLATCH;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
 };
 

--- a/app/element/led.cpp
+++ b/app/element/led.cpp
@@ -17,7 +17,7 @@ int Led::current_id_number = 0;
  *         1000: dark gray, 1001: light blue, 1010: light green, 1011: cyan,   1100: light red, 1101: pink,    1110: yellow, 1111: white
  */
 Led::Led(QGraphicsItem *parent)
-    : GraphicElement(1, 4, 0, 0, parent)
+    : GraphicElement(ElementType::LED, ElementGroup::OUTPUT, 1, 4, 0, 0, parent)
 {
     pixmapSkinName.append(":/output/WhiteLedOff.png"); // Single input values: 0
     pixmapSkinName.append(":/output/WhiteLedOn.png"); // 1

--- a/app/element/led.h
+++ b/app/element/led.h
@@ -15,15 +15,6 @@ public:
     ~Led() override = default;
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
 
-    /* GraphicElement interface */
-    ElementType elementType() override
-    {
-        return ElementType::LED;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::OUTPUT;
-    }
     void refresh() override;
     void setColor(QString getColor) override;
     QString getColor() const override;

--- a/app/element/ledgrid.cpp
+++ b/app/element/ledgrid.cpp
@@ -10,7 +10,7 @@
 int LedGrid::current_id_number = 0;
 
 LedGrid::LedGrid(QGraphicsItem *parent)
-    : GraphicElement(8, 8, 0, 0, parent)
+    : GraphicElement(ElementType::LEDGRID, ElementGroup::OUTPUT, 8, 8, 0, 0, parent)
 {
     pixmapSkinName.append(":/output/LedGrid.png"); // 0
     pixmapSkinName.append(":/output/WhiteLedOff.png"); // 1

--- a/app/element/ledgrid.h
+++ b/app/element/ledgrid.h
@@ -16,16 +16,6 @@ public:
     virtual ~LedGrid();
     static int current_id_number; // Number used to create distinct labels for each instance of this element.
 
-    virtual ElementType elementType() override
-    {
-        return ElementType::LEDGRID;
-    }
-
-    virtual ElementGroup elementGroup() override
-    {
-        return ElementGroup::OUTPUT;
-    }
-
     void setColor(QString getColor) override;
     QString getColor() const override;
     virtual void refresh() override;

--- a/app/element/mux.cpp
+++ b/app/element/mux.cpp
@@ -4,7 +4,7 @@
 #include "mux.h"
 
 Mux::Mux(QGraphicsItem *parent)
-    : GraphicElement(3, 3, 1, 1, parent)
+    : GraphicElement(ElementType::MUX, ElementGroup::MUX, 3, 3, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/mux.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/mux.h
+++ b/app/element/mux.h
@@ -18,14 +18,6 @@ public:
 
     /* GraphicElement interface */
 public:
-    ElementType elementType() override
-    {
-        return ElementType::MUX;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MUX;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/nand.cpp
+++ b/app/element/nand.cpp
@@ -4,7 +4,7 @@
 #include "nand.h"
 
 Nand::Nand(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::NAND, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/nand.png");
     setOutputsOnTop(true);

--- a/app/element/nand.h
+++ b/app/element/nand.h
@@ -14,16 +14,6 @@ public:
     explicit Nand(QGraphicsItem *parent = nullptr);
     ~Nand() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::NAND;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/node.cpp
+++ b/app/element/node.cpp
@@ -6,7 +6,7 @@
 #include <QPainter>
 
 Node::Node(QGraphicsItem *parent)
-    : GraphicElement(1, 1, 1, 1, parent)
+    : GraphicElement(ElementType::NODE, ElementGroup::GATE, 1, 1, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/node.png");
     setPixmap(pixmapSkinName[0], QRect(QPoint(16, 16), QPoint(48, 48)));
@@ -20,11 +20,6 @@ void Node::updatePorts()
 {
     input()->setPos(0, 16);
     output()->setPos(32, 16);
-}
-
-ElementType Node::elementType()
-{
-    return ElementType::NODE;
 }
 
 void Node::setSkin(bool defaultSkin, QString filename)

--- a/app/element/node.h
+++ b/app/element/node.h
@@ -15,13 +15,6 @@ public:
     ~Node() override = default;
 
     void updatePorts() override;
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/nor.cpp
+++ b/app/element/nor.cpp
@@ -4,7 +4,7 @@
 #include "nor.h"
 
 Nor::Nor(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::NOR, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/nor.png");
     setOutputsOnTop(true);

--- a/app/element/nor.h
+++ b/app/element/nor.h
@@ -14,16 +14,6 @@ public:
     explicit Nor(QGraphicsItem *parent = nullptr);
     ~Nor() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::NOR;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/not.cpp
+++ b/app/element/not.cpp
@@ -4,7 +4,7 @@
 #include "not.h"
 
 Not::Not(QGraphicsItem *parent)
-    : GraphicElement(1, 1, 1, 1, parent)
+    : GraphicElement(ElementType::NOT, ElementGroup::GATE, 1, 1, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/not.png");
     setOutputsOnTop(true);

--- a/app/element/not.h
+++ b/app/element/not.h
@@ -13,17 +13,6 @@ class Not : public GraphicElement
 public:
     explicit Not(QGraphicsItem *parent = nullptr);
     ~Not() override = default;
-
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::NOT;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/or.cpp
+++ b/app/element/or.cpp
@@ -4,7 +4,7 @@
 #include "or.h"
 
 Or::Or(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::OR, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/or.png");
     setOutputsOnTop(true);

--- a/app/element/or.h
+++ b/app/element/or.h
@@ -14,16 +14,6 @@ public:
     explicit Or(QGraphicsItem *parent = nullptr);
     ~Or() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::OR;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/srflipflop.cpp
+++ b/app/element/srflipflop.cpp
@@ -4,7 +4,7 @@
 #include "srflipflop.h"
 
 SRFlipFlop::SRFlipFlop(QGraphicsItem *parent)
-    : GraphicElement(5, 5, 2, 2, parent)
+    : GraphicElement(ElementType::SRFLIPFLOP, ElementGroup::MEMORY, 5, 5, 2, 2, parent)
 {
     pixmapSkinName.append(":/memory/SR-flipflop.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/srflipflop.h
+++ b/app/element/srflipflop.h
@@ -17,15 +17,6 @@ public:
     ~SRFlipFlop() override = default;
 
     /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::SRFLIPFLOP;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/tflipflop.cpp
+++ b/app/element/tflipflop.cpp
@@ -4,7 +4,7 @@
 #include "tflipflop.h"
 
 TFlipFlop::TFlipFlop(QGraphicsItem *parent)
-    : GraphicElement(4, 4, 2, 2, parent)
+    : GraphicElement(ElementType::TFLIPFLOP, ElementGroup::MEMORY, 4, 4, 2, 2, parent)
 {
     pixmapSkinName.append(":/memory/T-flipflop.png");
     setPixmap(pixmapSkinName[0]);

--- a/app/element/tflipflop.h
+++ b/app/element/tflipflop.h
@@ -17,17 +17,6 @@ class TFlipFlop : public GraphicElement
 public:
     explicit TFlipFlop(QGraphicsItem *parent = nullptr);
     ~TFlipFlop() override = default;
-
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::TFLIPFLOP;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::MEMORY;
-    }
     void updatePorts() override;
     void setSkin(bool defaultSkin, QString filename) override;
 };

--- a/app/element/xnor.cpp
+++ b/app/element/xnor.cpp
@@ -4,7 +4,7 @@
 #include "xnor.h"
 
 Xnor::Xnor(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::XNOR, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/xnor.png");
     setOutputsOnTop(true);

--- a/app/element/xnor.h
+++ b/app/element/xnor.h
@@ -13,17 +13,6 @@ class Xnor : public GraphicElement
 public:
     explicit Xnor(QGraphicsItem *parent = nullptr);
     ~Xnor() override = default;
-
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::XNOR;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/element/xor.cpp
+++ b/app/element/xor.cpp
@@ -4,7 +4,7 @@
 #include "xor.h"
 
 Xor::Xor(QGraphicsItem *parent)
-    : GraphicElement(2, 8, 1, 1, parent)
+    : GraphicElement(ElementType::XOR, ElementGroup::GATE, 2, 8, 1, 1, parent)
 {
     pixmapSkinName.append(":/basic/xor.png");
     setOutputsOnTop(true);

--- a/app/element/xor.h
+++ b/app/element/xor.h
@@ -14,16 +14,6 @@ public:
     explicit Xor(QGraphicsItem *parent = nullptr);
     ~Xor() override = default;
 
-    /* GraphicElement interface */
-public:
-    ElementType elementType() override
-    {
-        return ElementType::XOR;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::GATE;
-    }
     void setSkin(bool defaultSkin, QString filename) override;
 };
 

--- a/app/graphicelement.cpp
+++ b/app/graphicelement.cpp
@@ -11,6 +11,7 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
+#include <QPixmap>
 
 #include "graphicelement.h"
 #include "nodes/qneconnection.h"
@@ -20,16 +21,37 @@
 // TODO - WARNING: non-POD static
 static QMap<QString, QPixmap> loadedPixmaps;
 
-GraphicElement::GraphicElement(int minInputSz, int maxInputSz, int minOutputSz, int maxOutputSz, QGraphicsItem *parent)
-    : QGraphicsObject(parent)
+GraphicElement::GraphicElement(
+    ElementType type,
+    ElementGroup group,
+    int minInputSz,
+    int maxInputSz,
+    int minOutputSz,
+    int maxOutputSz,
+    QGraphicsItem *parent):
+    QGraphicsObject(parent)
+    , m_pixmap(nullptr)
     , m_label(new QGraphicsTextItem(this))
+    , m_topPosition(0)
+    , m_bottomPosition(64)
+    , m_maxInputSz(maxInputSz)
+    , m_maxOutputSz(maxOutputSz)
+    , m_minInputSz(minInputSz)
+    , m_minOutputSz(minOutputSz)
+    , m_outputsOnTop(true)
+    , m_rotatable(true)
+    , m_hasLabel(false)
+    , m_canChangeSkin(false)
+    , m_hasFrequency(false)
+    , m_hasColors(false)
+    , m_hasTrigger(false)
+    , m_hasAudio(false)
+    , m_disabled(false)
+    , m_elementType(type)
+    , m_elementGroup(group)
 {
-    m_pixmap = nullptr;
     COMMENT("Setting flags of elements. ", 4);
-    setFlag(QGraphicsItem::ItemIsMovable);
-    setFlag(QGraphicsItem::ItemIsSelectable);
-    /*  setFlag(QGraphicsItem::ItemSendsScenePositionChanges); */
-    setFlag(QGraphicsItem::ItemSendsGeometryChanges);
+    setFlags(QGraphicsItem::ItemIsMovable | QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemSendsGeometryChanges);
 
     COMMENT("Setting attributes. ", 4);
     m_label->hide();
@@ -39,24 +61,6 @@ GraphicElement::GraphicElement(int minInputSz, int maxInputSz, int minOutputSz, 
     m_label->setPos(64, 30);
     m_label->setParentItem(this);
     m_label->setDefaultTextColor(Qt::black);
-    m_bottomPosition = 64;
-    m_topPosition = 0;
-    m_minInputSz = minInputSz;
-    m_minOutputSz = minOutputSz;
-    m_maxInputSz = maxInputSz;
-    m_maxOutputSz = maxOutputSz;
-    /*
-     *  m_visited = false;
-     *  m_beingVisited = false;
-     */
-    m_rotatable = true;
-    m_hasColors = false;
-    m_hasTrigger = false;
-    m_hasFrequency = false;
-    m_hasLabel = false;
-    m_hasAudio = false;
-    m_disabled = false;
-    m_outputsOnTop = true;
 
     COMMENT("Including input and output ports.", 4);
     for (int i = 0; i < minInputSz; i++) {
@@ -68,12 +72,21 @@ GraphicElement::GraphicElement(int minInputSz, int maxInputSz, int minOutputSz, 
     updateTheme();
 }
 
-QPixmap GraphicElement::getPixmap() const
-{
+QPixmap GraphicElement::getPixmap() const {
     if (m_pixmap) {
         return *m_pixmap;
     }
-    return QPixmap();
+    return {};
+}
+
+ElementType GraphicElement::elementType() const
+{
+    return m_elementType;
+}
+
+ElementGroup GraphicElement::elementGroup() const
+{
+    return m_elementGroup;
 }
 
 void GraphicElement::disable()

--- a/app/graphicelement.h
+++ b/app/graphicelement.h
@@ -68,23 +68,16 @@ class GraphicElement : public QGraphicsObject, public ItemWithId
 public:
     enum : uint32_t { Type = QGraphicsItem::UserType + 3 };
 
-    explicit GraphicElement(int minInputSz, int maxInputSz, int minOutputSz, int maxOutputSz, QGraphicsItem *parent = nullptr);
-
-private:
-    QPixmap *m_pixmap;
-    QString m_currentPixmapName;
-    QColor m_selectionBrush;
-    QColor m_selectionPen;
+    GraphicElement(ElementType type, ElementGroup group, int minInputSz, int maxInputSz, int minOutputSz, int maxOutputSz, QGraphicsItem *parent = nullptr);
 
 protected:
     QVector<QString> pixmapSkinName;
 
     /* GraphicElement interface. */
 public:
-    virtual ElementType elementType() = 0;
-    bool usingDefaultSkin;
+    ElementType elementType() const;
 
-    virtual ElementGroup elementGroup() = 0;
+    ElementGroup elementGroup() const;
 
     virtual void save(QDataStream &ds) const;
 
@@ -173,15 +166,6 @@ public:
 
     virtual void setAudio(QString audio);
     virtual QString getAudio() const;
-    /*
-     *  bool beingVisited( ) const;
-     *  void setBeingVisited( bool beingVisited );
-     */
-
-    /*
-     *  bool visited( ) const;
-     *  void setVisited( bool visited );
-     */
 
     bool isValid();
 
@@ -224,8 +208,13 @@ protected:
 
     /*  virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *e); */
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+    bool usingDefaultSkin;
 
 private:
+    QPixmap *m_pixmap;
+    QString m_currentPixmapName;
+    QColor m_selectionBrush;
+    QColor m_selectionPen;
     QGraphicsTextItem *m_label;
     int m_topPosition;
     int m_bottomPosition;
@@ -242,6 +231,8 @@ private:
     bool m_hasTrigger;
     bool m_hasAudio;
     bool m_disabled;
+    ElementType m_elementType;
+    ElementGroup m_elementGroup;
     QString m_labelText;
     QKeySequence m_trigger;
 

--- a/app/ic.cpp
+++ b/app/ic.cpp
@@ -24,7 +24,7 @@
 #include "serializationfunctions.h"
 
 IC::IC(QGraphicsItem *parent)
-    : GraphicElement(0, 0, 0, 0, parent)
+    : GraphicElement(ElementType::IC, ElementGroup::IC, 0, 0, 0, 0, parent)
 {
     pixmapSkinName.append(":/basic/box.png");
     setHasLabel(true);

--- a/app/ic.h
+++ b/app/ic.h
@@ -29,15 +29,6 @@ public:
     IC(QGraphicsItem *parent = nullptr);
     ~IC() override;
 
-    /* GraphicElement interface */
-    ElementType elementType() override
-    {
-        return ElementType::IC;
-    }
-    ElementGroup elementGroup() override
-    {
-        return ElementGroup::IC;
-    }
     void save(QDataStream &ds) const override;
     void load(QDataStream &ds, QMap<quint64, QNEPort *> &portMap, double version) override;
     void loadFile(QString fname);


### PR DESCRIPTION
This is uneeded, we can set this directly on the constructor.
The element will be sligtly bigger as it's holding the two
values, but the overall code is simpler to reason with and smaller