### PR TITLE
Fix clang format cmake call

### DIFF
--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -7,4 +7,5 @@ file(
     ${PROJECT_SOURCE_DIR}
     *.cpp *.h
 )
+
 kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -3,7 +3,8 @@ include(KDEClangFormat)
 file(
     GLOB_RECURSE
     ALL_CLANG_FORMAT_SOURCE_FILES
-        *.cpp *.h
+    RELATIVE
     ${PROJECT_SOURCE_DIR}
+    *.cpp *.h
 )
 kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})


### PR DESCRIPTION
From the documentation:

file(GLOB_RECURSE <variable> [FOLLOW_SYMLINKS]
     [LIST_DIRECTORIES true|false] [RELATIVE <path>]
     [<globbing-expressions>...])

Path comes before the list of files, and should be marked as RELATIVE