### PR TITLE
Fix translation workflow to handle Weblate fork PRs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -178,7 +178,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-          # For PRs, checkout the PR branch
+          # For PRs, checkout the PR branch from the correct repository
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
       - name: Install Qt
@@ -324,6 +325,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          # For cross-repository PRs (like from Weblate fork), use the PR head repository
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Install Qt


### PR DESCRIPTION
- Update checkout actions to use PR head repository for cross-repository PRs
- Fix issue where workflow failed when trying to checkout weblate-wiredpanda-wiredpanda branch
- Ensure both compile-translations and weblate-pr-handler jobs work with Weblate fork

🤖 Generated with [Claude Code](https://claude.ai/code)