### PR TITLE
fix: resolve Translation Management workflow caching error

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -49,7 +49,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: 6.9.0
-          cache: true
+          cache: false
           aqtversion: ==3.2.*
           archives: 'qttools'
           no-qt-binaries: true
@@ -133,7 +133,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: 6.9.0
-          cache: true
+          cache: false
           aqtversion: ==3.2.*
           archives: 'qttools'
           no-qt-binaries: true
@@ -238,7 +238,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: 6.9.0
-          cache: true
+          cache: false
           aqtversion: ==3.2.*
           archives: 'qttools'
           no-qt-binaries: true


### PR DESCRIPTION
Disable cache for install-qt-action when using no-qt-binaries=true and archives=qttools only. The caching mechanism was trying to cache Qt installation paths that don't exist when only installing tools.

- Set cache: false for all three translation workflow jobs
- Fixes 'Path Validation Error: Path(s) specified in the action for caching do(es) not exist'
- Allows workflow to run on all branches for testing

🤖 Generated with [Claude Code](https://claude.ai/code)