### PR TITLE
style: improve translation workflow description clarity

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
         default: false
       compile_only:
-        description: 'Only compile translations (lrelease)'
+        description: 'Compile translations (lrelease)'
         type: boolean
         default: true
 


### PR DESCRIPTION
Remove redundant 'Only' from compile_only option description for better clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)