### PR TITLE
fix: clear element pixmap cache on theme change to update memory elem…

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1642,6 +1642,9 @@ void MainWindow::on_actionDarkTheme_triggered()
 
 void MainWindow::updateTheme()
 {
+    // Clear the pixmap cache so elements will regenerate their pixmaps for the new theme
+    ElementFactory::clearCache();
+
     switch (ThemeManager::theme()) {
     case Theme::Dark:  m_ui->actionDarkTheme->setChecked(true); break;
     case Theme::Light: m_ui->actionLightTheme->setChecked(true); break;
@@ -1658,6 +1661,7 @@ void MainWindow::updateTheme()
         m_ui->tabElements->setTabIcon(memoryTabIndex, QIcon(DFlipFlop::pixmapPath()));
     }
 
+    // Update memory tab element labels (only tab with theme-dependent icons)
     const auto labels = m_ui->memory->findChildren<ElementLabel *>();
 
     for (auto *label : labels) {


### PR DESCRIPTION
…ent icons

Memory elements (D-Flip-Flop, JK-Flip-Flop, T-Flip-Flop, D-Latch, SR-Latch) have theme-dependent pixmaps that change between light and dark themes. The pixmapPath is cached in ElementFactory, but the cache was not being invalidated when the theme changed, causing the memory element icons in the left panel to not update.

This fix clears the ElementFactory pixmap cache at the start of updateTheme(), forcing elements to regenerate their pixmapPaths with the new theme.

Fixes: flip-flop and latch icons not updating when switching themes in the left element selector panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)