### PR TITLE
release: 5.0.1 with i18n and MCP schema fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  Ubuntu-Qt6_9_0-Code_Coverage:
+  Ubuntu-Qt6_9_3-Code_Coverage:
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,13 +43,18 @@ jobs:
       run: |
         ctest --preset coverage -V -LE gui
 
-    - name: Upload coverage data
+    - name: Generate gcov reports
       run: |
         cd build
         gcov -abcfu $(find . -name "*.gcno")
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x ./codecov
-        ./codecov
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: build
+        fail_ci_if_error: true
+        verbose: true
 
     - name: Upload build artifacts on failure
       if: failure()

--- a/App/Resources/Translations/Translations.qrc
+++ b/App/Resources/Translations/Translations.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/translations">
+    <qresource prefix="/Translations">
         <file>qt_pt_BR.qm</file>
         <file>wpanda_ar.qm</file>
         <file>wpanda_bg.qm</file>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ file(GLOB QM_FILES \"${CMAKE_SOURCE_DIR}/App/Resources/Translations/*.qm\")
 list(SORT QM_FILES)
 
 # Start QRC content
-set(QRC_CONTENT \"<RCC>\\n    <qresource prefix=\\\"/translations\\\">\\n\")
+set(QRC_CONTENT \"<RCC>\\n    <qresource prefix=\\\"/Translations\\\">\\n\")
 
 # Add each .qm file
 foreach(qm_file \${QM_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
-project(wiredpanda VERSION 5.0.0 LANGUAGES CXX)
+project(wiredpanda VERSION 5.0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/MCP/schema-mcp.json
+++ b/MCP/schema-mcp.json
@@ -59,8 +59,7 @@
       "description": "Valid export formats for circuit images",
       "enum": [
         "png",
-        "svg",
-        "pdf"
+        "svg"
       ]
     },
     "WaveformExportFormat": {
@@ -561,8 +560,7 @@
                 },
                 "source_port": {
                   "type": "integer",
-                  "minimum": 0,
-                  "maximum": 63
+                  "minimum": 0
                 },
                 "target_id": {
                   "type": "integer",
@@ -570,8 +568,7 @@
                 },
                 "target_port": {
                   "type": "integer",
-                  "minimum": 0,
-                  "maximum": 63
+                  "minimum": 0
                 },
                 "x": {
                   "type": "number"
@@ -858,6 +855,10 @@
                 "element_id": {
                   "type": "integer",
                   "minimum": 1
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 0
                 }
               },
               "required": [
@@ -1167,6 +1168,94 @@
           ],
           "additionalProperties": false
         },
+        "export_arduino": {
+          "type": "object",
+          "description": "Export circuit as Arduino code",
+          "properties": {
+            "jsonrpc": {
+              "type": "string",
+              "const": "2.0"
+            },
+            "method": {
+              "const": "export_arduino"
+            },
+            "params": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "filename"
+              ],
+              "additionalProperties": false
+            },
+            "id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "jsonrpc",
+            "method"
+          ],
+          "additionalProperties": false
+        },
+        "export_systemverilog": {
+          "type": "object",
+          "description": "Export circuit as SystemVerilog code",
+          "properties": {
+            "jsonrpc": {
+              "type": "string",
+              "const": "2.0"
+            },
+            "method": {
+              "const": "export_systemverilog"
+            },
+            "params": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "filename"
+              ],
+              "additionalProperties": false
+            },
+            "id": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "jsonrpc",
+            "method"
+          ],
+          "additionalProperties": false
+        },
         "create_waveform": {
           "type": "object",
           "description": "Create waveform analysis for the current circuit",
@@ -1181,19 +1270,11 @@
             "params": {
               "type": "object",
               "properties": {
-                "elements": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer",
-                    "minimum": 1
-                  },
-                  "description": "Optional list of element IDs to analyze"
-                },
                 "duration": {
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 1024,
-                  "default": 64,
+                  "default": 32,
                   "description": "Number of simulation steps"
                 },
                 "input_patterns": {
@@ -1439,7 +1520,7 @@
             "params": {
               "type": "object",
               "properties": {
-                "element_id": { "type": "integer", "description": "Element ID of the file-backed IC to embed" },
+                "element_id": { "type": "integer", "minimum": 1, "description": "Element ID of the file-backed IC to embed" },
                 "blob_name": { "type": "string", "description": "Optional blob name override (defaults to file basename)" }
               },
               "required": ["element_id"],
@@ -1737,14 +1818,6 @@
                 "label": {
                   "type": "string",
                   "description": "Element label"
-                },
-                "input_size": {
-                  "type": "integer",
-                  "description": "Number of input ports"
-                },
-                "output_size": {
-                  "type": "integer",
-                  "description": "Number of output ports"
                 },
                 "color": {
                   "type": "string",
@@ -2303,9 +2376,6 @@
                       "type": "string"
                     },
                     "status": {
-                      "type": "string"
-                    },
-                    "warning": {
                       "type": "string"
                     },
                     "waveform_data": {
@@ -2907,6 +2977,252 @@
                     }
                   },
                   "required": ["effective_theme"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "close_circuit_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "connect_elements_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "delete_element_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "disconnect_elements_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "load_circuit_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "new_circuit_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "save_circuit_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "set_input_value_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "simulation_control_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "split_connection_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            { "properties": { "result": { "type": "object", "additionalProperties": false } } }
+          ]
+        },
+        "export_arduino_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "exported_file": { "type": "string" },
+                    "format": { "type": "string", "const": "arduino" }
+                  },
+                  "required": ["exported_file", "format"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "export_systemverilog_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "exported_file": { "type": "string" },
+                    "format": { "type": "string", "const": "systemverilog" }
+                  },
+                  "required": ["exported_file", "format"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "get_tab_count_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "tab_count": { "type": "integer", "minimum": 0 }
+                  },
+                  "required": ["tab_count"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "get_server_info_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "server_name": { "type": "string" },
+                    "version": { "type": "string" },
+                    "protocol_version": { "type": "string" },
+                    "status": { "type": "string" },
+                    "capabilities": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "required": ["server_name", "version", "protocol_version", "status", "capabilities"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "embed_ic_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "blob_name": { "type": "string" },
+                    "converted_count": { "type": "integer", "minimum": 0 },
+                    "input_count": { "type": "integer", "minimum": 0 },
+                    "output_count": { "type": "integer", "minimum": 0 },
+                    "blob_size": { "type": "integer", "minimum": 0 },
+                    "message": { "type": "string" }
+                  },
+                  "required": ["blob_name", "converted_count", "input_count", "output_count", "blob_size", "message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "extract_ic_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "blob_name": { "type": "string" },
+                    "file_name": { "type": "string" },
+                    "converted_count": { "type": "integer", "minimum": 0 },
+                    "message": { "type": "string" }
+                  },
+                  "required": ["blob_name", "file_name", "converted_count", "message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "undo_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "message": { "type": "string" },
+                    "can_undo": { "type": "boolean", "description": "Only present on success" },
+                    "can_redo": { "type": "boolean", "description": "Only present on success" },
+                    "undo_text": { "type": "string", "description": "Only present on success" },
+                    "redo_text": { "type": "string", "description": "Only present on success" }
+                  },
+                  "required": ["success", "message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "redo_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "message": { "type": "string" },
+                    "can_undo": { "type": "boolean", "description": "Only present on success" },
+                    "can_redo": { "type": "boolean", "description": "Only present on success" },
+                    "undo_text": { "type": "string", "description": "Only present on success" },
+                    "redo_text": { "type": "string", "description": "Only present on success" }
+                  },
+                  "required": ["success", "message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          ]
+        },
+        "get_undo_stack_response": {
+          "allOf": [
+            { "$ref": "#/definitions/CommandResponse" },
+            {
+              "properties": {
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "can_undo": { "type": "boolean" },
+                    "can_redo": { "type": "boolean" },
+                    "undo_text": { "type": "string" },
+                    "redo_text": { "type": "string" },
+                    "undo_limit": { "type": "integer", "minimum": 0 },
+                    "undo_count": { "type": "integer", "minimum": 0 },
+                    "undo_index": { "type": "integer", "minimum": 0 }
+                  },
+                  "required": ["can_undo", "can_redo", "undo_text", "redo_text", "undo_limit", "undo_count", "undo_index"],
                   "additionalProperties": false
                 }
               }


### PR DESCRIPTION
## Summary
- **i18n fix (critical):** restore PascalCase resource prefix in `Translations.qrc` so translations load on all builds (including the WASM site, which tag `5.0.0` shipped broken — prefix `/translations` no longer matched the `:/Translations/...` lookups in `LanguageManager.cpp`). Also fix the generator in `CMakeLists.txt` so future regenerations stay PascalCase.
- **MCP schema audit:** comprehensive sync of `MCP/schema-mcp.json` against server reality. Adds two undocumented commands (`export_arduino`, `export_systemverilog`), removes server-rejected fields (`input_size`/`output_size` from `update_element`; `pdf` from `ImageExportFormat`), fixes a default mismatch (`create_waveform.duration` 64 → 32), tightens constraints for consistency, and documents the result shape for every command (41/41 covered; was 22/41).
- **CI:** switch codecov upload to `codecov-action@v6` in `coverage.yml`.
- **Release:** bump project version `5.0.0` → `5.0.1`.

## Test plan
- [ ] MCP client test suite passes (`MCP/Client/run_tests.py`: 106/106)
- [ ] Build + launch on desktop and confirm language switcher loads non-English translations
- [ ] Redeploy WASM site and confirm languages render beyond English
- [ ] CI: coverage job completes and uploads to Codecov successfully