### PR TITLE
ci: add codecov.yml with components, status thresholds, and ignores

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+codecov:
+  max_report_age: off
+  require_ci_to_pass: true
+
+coverage:
+  precision: 1
+  round: nearest
+  range: "60...90"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: app
+      name: App
+      paths:
+        - App/**
+    - component_id: tests
+      name: Tests
+      paths:
+        - Tests/**
+
+ignore:
+  - "**/moc_*.cpp"
+  - "**/qrc_*.cpp"
+  - "**/ui_*.h"
+  - "**/*_autogen/**"
+  - "build/**"
+  - "MCP/**"
+  - "third-party/**"
+  - "App/Resources/**"
+  - ".devcontainer/**"
+
+comment:
+  layout: "header, diff, components, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
Adds a project-level Codecov config (`codecov.yml`) so the coverage report reflects what we actually care about:

- **Project status**: `auto` target with a 1% threshold — small regressions don't fail the check, but meaningful drops do.
- **Patch status**: 80% target — requires decent coverage on new code in PRs.
- **Components**: `App` and `Tests`, each with its own project status so PR comments show per-area coverage.
- **Ignore**: autogenerated files (`moc_*`, `qrc_*`, `ui_*`, `*_autogen/`), `build/`, `MCP/` (not compiled into releases), `third-party/`, `App/Resources/`, `.devcontainer/`.
- **Comment layout**: header, diff, components, files.

## Test plan
- [x] `codecov.yml` validates (`curl --data-binary @codecov.yml https://codecov.io/validate` → `Valid!`)
- [ ] First post-merge push to master produces a Codecov report that shows `App` and `Tests` components
- [ ] PR comments on future PRs show per-component coverage