### PR TITLE
feat: prevent duplicate tabs when opening and saving panda files

### DIFF
--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -704,6 +704,17 @@ void MainWindow::on_actionRotateLeft_triggered()
 
 void MainWindow::loadPandaFile(const QString &fileName)
 {
+    const QFileInfo newFileInfo(fileName);
+
+    for (int i = 0; i < m_ui->tab->count(); ++i) {
+        if (auto *workspace = qobject_cast<WorkSpace *>(m_ui->tab->widget(i))) {
+            if (workspace->fileInfo() == newFileInfo) {
+                m_ui->tab->setCurrentIndex(i);
+                return;
+            }
+        }
+    }
+
     createNewTab();
     qCDebug(zero) << "Loading in editor.";
     m_currentTab->load(fileName);
@@ -812,6 +823,21 @@ void MainWindow::on_actionSave_triggered()
         ensureFileExtension(fileName, ".panda");
     }
 
+    const int conflictTab = findTabWithFile(fileName);
+    if (conflictTab != -1) {
+        QMessageBox msgBox(QMessageBox::Warning,
+                           tr("File Conflict"),
+                           tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
+                           QMessageBox::Ok,
+                           this);
+        QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
+        msgBox.exec();
+        if (msgBox.clickedButton() == switchBtn) {
+            m_ui->tab->setCurrentIndex(conflictTab);
+        }
+        return;
+    }
+
     save(fileName);
 #endif
 }
@@ -848,8 +874,36 @@ void MainWindow::on_actionSaveAs_triggered()
 
     ensureFileExtension(fileName, ".panda");
 
+    const int conflictTab = findTabWithFile(fileName);
+    if (conflictTab != -1) {
+        QMessageBox msgBox(QMessageBox::Warning,
+                           tr("File Conflict"),
+                           tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
+                           QMessageBox::Ok,
+                           this);
+        QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
+        msgBox.exec();
+        if (msgBox.clickedButton() == switchBtn) {
+            m_ui->tab->setCurrentIndex(conflictTab);
+        }
+        return;
+    }
+
     save(fileName);
 #endif
+}
+
+int MainWindow::findTabWithFile(const QString &fileName) const
+{
+    const QFileInfo newFileInfo(fileName);
+    for (int i = 0; i < m_ui->tab->count(); ++i) {
+        if (auto *workspace = qobject_cast<WorkSpace *>(m_ui->tab->widget(i))) {
+            if (workspace != m_currentTab && workspace->fileInfo() == newFileInfo) {
+                return i;
+            }
+        }
+    }
+    return -1;
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -307,6 +307,8 @@ private:
     WorkSpace *m_currentTab = nullptr;
     int m_tabIndex = -1;
 
+    [[nodiscard]] int findTabWithFile(const QString &fileName) const;
+
     // Scene-level shortcuts created once in setupShortcuts(), reconnected on tab switch.
     QShortcut *m_prevMainPropShortcut  = nullptr;
     QShortcut *m_nextMainPropShortcut  = nullptr;

--- a/Tests/Integration/TestMainWindowGui.cpp
+++ b/Tests/Integration/TestMainWindowGui.cpp
@@ -134,6 +134,22 @@ static void autoCloseNextMessageBox()
     });
 }
 
+static void clickNextMessageBoxButton(const QString &text)
+{
+    QTimer::singleShot(0, [text] {
+        if (auto *w = QApplication::activeModalWidget()) {
+            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
+                for (auto *btn : msgBox->buttons()) {
+                    if (btn->text() == text) {
+                        btn->click();
+                        return;
+                    }
+                }
+            }
+        }
+    });
+}
+
 } // namespace MainWindowGuiHelpers
 
 using namespace MainWindowGuiHelpers;
@@ -277,6 +293,54 @@ void TestMainWindowGui::testSaveAndReload()
     }
 
     QFile::remove(savePath);
+}
+
+void TestMainWindowGui::testSaveAsConflictBlocksSave()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString path1 = tmpDir.path() + "/file_a.panda";
+    const QString path2 = tmpDir.path() + "/file_b.panda";
+    createMWFixture(path1);
+    createMWFixture(path2);
+
+    std::unique_ptr<MainWindow> window(createMW());
+    window->loadPandaFile(path1);
+    window->loadPandaFile(path2);
+
+    // Active tab is path2; attempt Save As into path1 which is open in another tab.
+    ScopedFileDialogStub guard;
+    guard.stub.saveResult = {path1, "Panda files (*.panda)"};
+
+    autoCloseNextMessageBox(); // dismiss conflict dialog with OK
+    QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier | Qt::ShiftModifier);
+
+    // Save was blocked: active tab is still path2.
+    QCOMPARE(window->currentFile().absoluteFilePath(), QFileInfo(path2).absoluteFilePath());
+}
+
+void TestMainWindowGui::testSaveAsConflictSwitchToTab()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString path1 = tmpDir.path() + "/file_a.panda";
+    const QString path2 = tmpDir.path() + "/file_b.panda";
+    createMWFixture(path1);
+    createMWFixture(path2);
+
+    std::unique_ptr<MainWindow> window(createMW());
+    window->loadPandaFile(path1);
+    window->loadPandaFile(path2);
+
+    // Active tab is path2; attempt Save As into path1 — a conflict.
+    ScopedFileDialogStub guard;
+    guard.stub.saveResult = {path1, "Panda files (*.panda)"};
+
+    clickNextMessageBoxButton("Switch to Tab");
+    QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier | Qt::ShiftModifier);
+
+    // "Switch to Tab" was clicked: the tab for path1 is now active.
+    QCOMPARE(window->currentFile().absoluteFilePath(), QFileInfo(path1).absoluteFilePath());
 }
 
 void TestMainWindowGui::testReloadFile()
@@ -2224,19 +2288,37 @@ void TestMainWindowGui::testOpenSameFileTwice()
 {
     std::unique_ptr<MainWindow> window(createMW());
     auto *tabs = findTabs(window.get());
-    int initialCount = tabs->count();
+    const int initialCount = tabs->count();
 
-    // Load file directly
     window->loadPandaFile(m_fixtureDir + "/test_circuit.panda");
-    int countAfterFirst = tabs->count();
-    QCOMPARE(countAfterFirst, initialCount + 1);
+    QCOMPARE(tabs->count(), initialCount + 1);
+    const int firstTabIndex = tabs->currentIndex();
 
-    // Load same file again
+    // Loading the same file again must reuse the existing tab, not open a new one.
     window->loadPandaFile(m_fixtureDir + "/test_circuit.panda");
-    int countAfterSecond = tabs->count();
+    QCOMPARE(tabs->count(), initialCount + 1);
+    QCOMPARE(tabs->currentIndex(), firstTabIndex);
+}
 
-    // Should either reuse the existing tab or create a new one without crash
-    QVERIFY(countAfterSecond >= countAfterFirst);
+void TestMainWindowGui::testOpenSameFileFromDifferentDirs()
+{
+    QTemporaryDir dir1, dir2;
+    QVERIFY(dir1.isValid() && dir2.isValid());
+    const QString path1 = dir1.path() + "/circuit.panda";
+    const QString path2 = dir2.path() + "/circuit.panda";
+    createMWFixture(path1);
+    createMWFixture(path2);
+
+    std::unique_ptr<MainWindow> window(createMW());
+    auto *tabs = findTabs(window.get());
+    const int initialCount = tabs->count();
+
+    window->loadPandaFile(path1);
+    QCOMPARE(tabs->count(), initialCount + 1);
+
+    // A different file that shares only the basename must open a separate tab.
+    window->loadPandaFile(path2);
+    QCOMPARE(tabs->count(), initialCount + 2);
 }
 
 // ===========================================================================

--- a/Tests/Integration/TestMainWindowGui.h
+++ b/Tests/Integration/TestMainWindowGui.h
@@ -28,6 +28,8 @@ private slots:
     void testOpenFile();
     void testOpenCreatesNewTab();
     void testSaveAndReload();
+    void testSaveAsConflictBlocksSave();
+    void testSaveAsConflictSwitchToTab();
     void testReloadFile();
 
     // --- Simulation controls ---
@@ -141,6 +143,7 @@ private slots:
     void testInputButtonMomentary();
     void testRapidSimulationToggle();
     void testOpenSameFileTwice();
+    void testOpenSameFileFromDifferentDirs();
 
     // --- Context menu operations ---
 


### PR DESCRIPTION
## Summary

- When opening a file already loaded in another tab, switches to that tab instead of creating a duplicate
- When saving to a path already open in another tab, shows a **File Conflict** warning with a **Switch to Tab** button so the user can navigate directly to the conflicting tab
- Fixes the comparison in `loadPandaFile` to use full `QFileInfo` equality (not basename only), so files with the same name from different directories open as separate tabs

## Test plan

- [x] `testOpenSameFileTwice` — reuse existing tab when loading the same file twice
- [x] `testOpenSameFileFromDifferentDirs` — files with identical basenames from different directories open as separate tabs
- [x] `testSaveAsConflictBlocksSave` — saving to a conflicting path is blocked; active tab does not change
- [x] `testSaveAsConflictSwitchToTab` — clicking "Switch to Tab" in the conflict dialog activates the correct tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)