### PR TITLE
ci: ARM64 build matrix across deploy.yml and build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04, windows-2025-vs2026, macos-26]
         # Each LTS version (6.2, 6.5, 6.8) plus latest (6.9). Intentionally skipping 6.10+ due to a Wayland bug in the Qt platform plugin.
         qt: [6.2.4, 6.5.3, 6.8.3, 6.9.3]
         cmake_args: ['']
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             qt: '6.9.3'
             cmake_args: '-DENABLE_UNITY=OFF -DENABLE_PCH=OFF'
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             qt: '6.9.3'
             cmake_args: '-DUNITY_BUILD_BATCH_SIZE=1000'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
           - os: ubuntu-24.04
             qt: '6.9.3'
             cmake_args: '-DUNITY_BUILD_BATCH_SIZE=1000'
+          # Native ARM coverage at the latest Qt only — older Qts test
+          # version compatibility, not architecture.
+          - { os: ubuntu-24.04-arm, qt: '6.9.3', cmake_args: '', qt_host: linux_arm64,   qt_arch: linux_gcc_arm64      }
+          - { os: windows-11-arm,   qt: '6.9.3', cmake_args: '', qt_host: windows_arm64, qt_arch: win64_msvc2022_arm64 }
 
 # =================================
 
@@ -63,6 +67,8 @@ jobs:
         cache: true
         aqtversion: ==3.*
         modules: qtmultimedia qtimageformats
+        host: ${{ matrix.qt_host }}
+        arch: ${{ matrix.qt_arch }}
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
@@ -72,6 +78,8 @@ jobs:
     - name: Setup Windows MSVC Toolchain
       if: runner.os == 'Windows'
       uses: seanmiddleditch/gha-setup-vsdevenv@v5
+      with:
+        arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
 
 # =================================
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025-vs2026, macos-26]
+        # macOS isn't in the base matrix because Xcode 26 on macos-26 removed
+        # the AGL framework, and aqt's open-source feed only ships Qt LTS up
+        # to .3 patches (6.5.10 / 6.8.4 with the AGL fix are commercial-only).
+        # Qt 6.9.3 is fine on macos-26 (>= 6.9.2 has the fix); older Qt
+        # versions are pinned to macos-15 (Xcode 16, still ships AGL).
+        os: [ubuntu-24.04, windows-2025-vs2026]
         # Each LTS version (6.2, 6.5, 6.8) plus latest (6.9). Intentionally skipping 6.10+ due to a Wayland bug in the Qt platform plugin.
         qt: [6.2.4, 6.5.3, 6.8.3, 6.9.3]
         cmake_args: ['']
@@ -32,6 +37,12 @@ jobs:
           - os: ubuntu-24.04
             qt: '6.9.3'
             cmake_args: '-DUNITY_BUILD_BATCH_SIZE=1000'
+          # macOS — universal binaries cover both archs; runner choice is
+          # per-Qt because of the Xcode-26 AGL removal noted above.
+          - { os: macos-15, qt: '6.2.4', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
+          - { os: macos-15, qt: '6.5.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
+          - { os: macos-15, qt: '6.8.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
+          - { os: macos-26, qt: '6.9.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
           # Native ARM coverage at the latest Qt only — older Qts test
           # version compatibility, not architecture.
           - { os: ubuntu-24.04-arm, qt: '6.9.3', cmake_args: '', qt_host: linux_arm64,   qt_arch: linux_gcc_arm64      }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
   Ubuntu-Qt6_9_3-Code_Coverage:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        qt: [6.9.3]
+        # qt_host / qt_arch are passed verbatim to install-qt-action.
+        # Values verified locally with `aqt list-qt <host> desktop --arch 6.9.3`.
+        include:
+          - { os: ubuntu-latest,        qt: 6.9.3, arch: x86_64, qt_host: linux,         qt_arch: linux_gcc_64         }
+          - { os: ubuntu-24.04-arm,     qt: 6.9.3, arch: arm64,  qt_host: linux_arm64,   qt_arch: linux_gcc_arm64      }
+          - { os: windows-latest,       qt: 6.9.3, arch: x86_64, qt_host: windows,       qt_arch: win64_msvc2022_64    }
+          - { os: windows-11-arm,       qt: 6.9.3, arch: arm64,  qt_host: windows_arm64, qt_arch: win64_msvc2022_arm64 }
+          # CMakeLists.txt forces CMAKE_OSX_ARCHITECTURES="x86_64;arm64" so a
+          # single macOS job produces a universal DMG that runs on both archs;
+          # no per-arch matrix entry is needed.
+          - { os: macos-26,             qt: 6.9.3, arch: universal, qt_host: mac,        qt_arch: clang_64             }
 
 # =================================
 
@@ -85,11 +94,13 @@ jobs:
         cache: true
         aqtversion: ==3.*
         modules: qtmultimedia qtimageformats debug_info
+        host: ${{ matrix.qt_host }}
+        arch: ${{ matrix.qt_arch }}
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ${{ matrix.os }}-${{ matrix.qt }}
+        key: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.qt }}
 
 # =================================
 
@@ -119,6 +130,11 @@ jobs:
     - name: go-appimage
       if: runner.os == 'Linux'
       run: |
+        # uname -m gives "x86_64" or "aarch64"; used for the appimagetool
+        # download, the libtiff symlink path, and the AppImage filename
+        # produced by appimagetool.
+        ARCH_TRIPLE=$(uname -m)
+
         mkdir -p appimage/usr/bin \
                  appimage/usr/lib \
                  appimage/usr/share/applications \
@@ -139,7 +155,7 @@ jobs:
         cp App/Resources/Assets/Logos/wpanda-256x256.png appimage/usr/share/icons/hicolor/256x256/apps/wpanda.png
 
         wget -q "https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous \
-          -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)" \
+          -O - | grep "appimagetool-.*-${ARCH_TRIPLE}.AppImage" | head -n 1 | cut -d '"' -f 2)" \
           -O appimagetool
         chmod +x appimagetool
 
@@ -169,7 +185,8 @@ jobs:
 
         # Ubuntu 24.04 ships libtiff.so.6 (t64 transition); Qt plugins built against .so.5.
         # Symlink so go-appimage can find and bundle it.
-        sudo ln -sf /usr/lib/x86_64-linux-gnu/libtiff.so.6 /usr/lib/x86_64-linux-gnu/libtiff.so.5
+        LIBDIR=/usr/lib/${ARCH_TRIPLE}-linux-gnu
+        sudo ln -sf $LIBDIR/libtiff.so.6 $LIBDIR/libtiff.so.5
 
         # Deploy: bundle all dependencies (including glibc) and patch RPATHs.
         # go-appimage uses patchelf internally to set $ORIGIN-relative RPATHs
@@ -201,12 +218,12 @@ jobs:
         APPIMAGE_EXTRACT_AND_RUN=1 VERSION=$VERSION \
           ./appimagetool appimage
 
-        mv wiRedPanda-*-x86_64.AppImage wiRedPanda-$VERSION-Linux-Qt${{ matrix.qt }}.AppImage
+        mv wiRedPanda-*-${ARCH_TRIPLE}.AppImage wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage
 
     - name: Validate Ubuntu Release Artifacts
       if: runner.os == 'Linux'
       run: |
-        APPIMAGE_FILE="wiRedPanda-$VERSION-Linux-Qt${{ matrix.qt }}.AppImage"
+        APPIMAGE_FILE="wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage"
 
         if [ ! -f "$APPIMAGE_FILE" ]; then
           echo "Error: AppImage not found"
@@ -316,6 +333,8 @@ jobs:
     - name: Setup Windows MSVC Toolchain
       if: runner.os == 'Windows'
       uses: seanmiddleditch/gha-setup-vsdevenv@v5
+      with:
+        arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'x64' }}
 
     - name: Compile Windows Sentry SDK
       if: runner.os == 'Windows'
@@ -360,13 +379,13 @@ jobs:
 
         # Create the ZIP from the clean directory
         cd ..
-        Compress-Archive -Path wiredpanda-$env:VERSION -DestinationPath wiRedPanda-$env:VERSION-Windows-Qt${{ matrix.qt }}-Portable.zip
+        Compress-Archive -Path wiredpanda-$env:VERSION -DestinationPath wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip
 
     - name: Validate Windows Release Artifacts
       if: runner.os == 'Windows'
       run: |
         # Verify ZIP file exists
-        if (!(Test-Path "build/wiRedPanda-$env:VERSION-Windows-Qt${{ matrix.qt }}-Portable.zip")) {
+        if (!(Test-Path "build/wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip")) {
           Write-Error "Error: Windows ZIP file not found"
           exit 1
         }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
         sudo apt-get install -y \
+          gstreamer1.0-plugins-bad \
+          gstreamer1.0-plugins-base \
+          gstreamer1.0-plugins-good \
           libcurl4-openssl-dev \
           libegl-dev \
           libfuse2t64 \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
         # qt_host / qt_arch are passed verbatim to install-qt-action.
         # Values verified locally with `aqt list-qt <host> desktop --arch 6.9.3`.
         include:
-          - { os: ubuntu-latest,        qt: 6.9.3, arch: x86_64, qt_host: linux,         qt_arch: linux_gcc_64         }
+          - { os: ubuntu-24.04,         qt: 6.9.3, arch: x86_64, qt_host: linux,         qt_arch: linux_gcc_64         }
           - { os: ubuntu-24.04-arm,     qt: 6.9.3, arch: arm64,  qt_host: linux_arm64,   qt_arch: linux_gcc_arm64      }
-          - { os: windows-latest,       qt: 6.9.3, arch: x86_64, qt_host: windows,       qt_arch: win64_msvc2022_64    }
+          - { os: windows-2025-vs2026,  qt: 6.9.3, arch: x86_64, qt_host: windows,       qt_arch: win64_msvc2022_64    }
           - { os: windows-11-arm,       qt: 6.9.3, arch: arm64,  qt_host: windows_arm64, qt_arch: win64_msvc2022_arm64 }
           # CMakeLists.txt forces CMAKE_OSX_ARCHITECTURES="x86_64;arm64" so a
           # single macOS job produces a universal DMG that runs on both archs;

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: write    # needed to create branches and PRs
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.event.inputs.update_sources == 'true')
 
     steps:
@@ -115,7 +115,7 @@ jobs:
     name: Compile Translations
     permissions:
       contents: write    # needed to commit compiled translations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.compile_only == 'true')
 
     steps:
@@ -219,7 +219,7 @@ jobs:
     permissions:
       contents: write           # needed to commit processed files
       pull-requests: write      # needed to comment on PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'Weblate') || contains(github.event.pull_request.user.login, 'weblate')
 
     steps:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # needed to push to site branch
       actions: write   # needed to trigger site deployment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v6

--- a/App/Element/GraphicElement.cpp
+++ b/App/Element/GraphicElement.cpp
@@ -29,7 +29,7 @@ static const int s_graphicElementMetatypeId = qRegisterMetaType<GraphicElement>(
 static const QFont &labelFont()
 {
     static const QFont font = [] {
-        QFont f("SansSerif");
+        QFont f("Sans Serif");
         f.setBold(true);
         return f;
     }();

--- a/App/Element/GraphicElementInput.cpp
+++ b/App/Element/GraphicElementInput.cpp
@@ -11,7 +11,9 @@ void GraphicElementInput::setOn(const bool value, const int port)
     m_isOn = value;
     // Pixmap index 0 = off SVG, index 1 = on SVG (matches bool → int cast)
     setPixmap(static_cast<int>(m_isOn));
-    outputPort()->setStatus(static_cast<Status>(m_isOn));
+    if (auto *out = outputPort()) {
+        out->setStatus(static_cast<Status>(m_isOn));
+    }
 }
 
 void GraphicElementInput::setAppearance(const bool defaultAppearance, const QString &fileName)

--- a/App/Resources/Components/Memory/Dark/D-flipflop.svg
+++ b/App/Resources/Components/Memory/Dark/D-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/D-latch.svg
+++ b/App/Resources/Components/Memory/Dark/D-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/JK-flipflop.svg
+++ b/App/Resources/Components/Memory/Dark/JK-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/JK-latch.svg
+++ b/App/Resources/Components/Memory/Dark/JK-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/SR-flipflop.svg
+++ b/App/Resources/Components/Memory/Dark/SR-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/SR-latch.svg
+++ b/App/Resources/Components/Memory/Dark/SR-latch.svg
@@ -136,7 +136,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -147,7 +147,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/T-flipflop.svg
+++ b/App/Resources/Components/Memory/Dark/T-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Dark/T-latch.svg
+++ b/App/Resources/Components/Memory/Dark/T-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/D-flipflop.svg
+++ b/App/Resources/Components/Memory/Light/D-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/D-latch.svg
+++ b/App/Resources/Components/Memory/Light/D-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/JK-flipflop.svg
+++ b/App/Resources/Components/Memory/Light/JK-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/JK-latch.svg
+++ b/App/Resources/Components/Memory/Light/JK-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/SR-flipflop.svg
+++ b/App/Resources/Components/Memory/Light/SR-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/SR-latch.svg
+++ b/App/Resources/Components/Memory/Light/SR-latch.svg
@@ -136,7 +136,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -147,7 +147,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/T-flipflop.svg
+++ b/App/Resources/Components/Memory/Light/T-flipflop.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/App/Resources/Components/Memory/Light/T-latch.svg
+++ b/App/Resources/Components/Memory/Light/T-latch.svg
@@ -132,7 +132,7 @@
        ry="2.6350775" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="9.75"
        y="29.999998"
        id="text4046"><tspan
@@ -143,7 +143,7 @@
          style="font-size:20px;line-height:1.25"> </tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Raleway;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#004d41;fill-opacity:1;stroke:none"
        x="13.250001"
        y="26.249998"
        id="text4050"><tspan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ FetchContent_MakeAvailable(json)
 FetchContent_Declare(
     json-schema-validator
     GIT_REPOSITORY https://github.com/pboettch/json-schema-validator.git
-    GIT_TAG 2.3.0
+    GIT_TAG 2.4.0
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(json-schema-validator)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
+
+# CMP0156 (3.27+): de-duplicate libraries on the link line using the new
+# algorithm. NEW collapses transitive PUBLIC links of the same archive (e.g.
+# wiredpanda_lib reaching test_wiredpanda via test_utils AND memory_helpers AND
+# the WHOLE_ARCHIVE genex) into a single reference, which kills the macOS
+# "ld: warning: ignoring duplicate libraries" noise.
+cmake_policy(SET CMP0156 NEW)
 project(wiredpanda VERSION 5.0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -329,20 +336,16 @@ foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${CONFIG_UPPER} ${CMAKE_BINARY_DIR})
 endforeach()
 
-# Link a target against wiredpanda_lib with --whole-archive to prevent the
-# linker from discarding element .o files whose only external symbols are
-# static-initialization registrations (ElementInfo<T>::registered).
+# Link a target against wiredpanda_lib with whole-archive semantics so the
+# linker keeps element .o files whose only external symbols are static-
+# initialization registrations (ElementInfo<T>::registered).
+# The LINK_LIBRARY:WHOLE_ARCHIVE genex (CMake 3.24+) handles the per-platform
+# flag (-Wl,--whole-archive on GNU ld, -force_load on Apple ld64, /WHOLEARCHIVE:
+# on MSVC link.exe) and, unlike the previous hand-rolled version, doesn't add
+# the archive to the link line twice.
 function(link_wiredpanda_whole_archive target)
-    if(MSVC)
-        target_link_libraries(${target} PRIVATE wiredpanda_lib)
-        target_link_options(${target} PRIVATE /WHOLEARCHIVE:wiredpanda_lib)
-    elseif(APPLE)
-        target_link_libraries(${target} PRIVATE wiredpanda_lib)
-        target_link_options(${target} PRIVATE "LINKER:-force_load,$<TARGET_FILE:wiredpanda_lib>")
-    else()
-        target_link_libraries(${target} PRIVATE
-            -Wl,--whole-archive wiredpanda_lib -Wl,--no-whole-archive)
-    endif()
+    target_link_libraries(${target} PRIVATE
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,wiredpanda_lib>")
 endfunction()
 
 # ========= LIB ===================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,7 +788,7 @@ endforeach()
 set_tests_properties(TestScene TestSceneUndoredo PROPERTIES RESOURCE_LOCK clipboard)
 
 # Serialization and Command Tests - Integration category
-foreach(TEST TestDialogs TestSerialization TestSimulationBlocker)
+foreach(TEST TestSerialization TestSimulationBlocker)
     set_tests_properties(${TEST} PROPERTIES LABELS "integration")
 endforeach()
 
@@ -805,7 +805,7 @@ foreach(TEST TestCommands TestCommon TestEnums TestPriorities TestRecentFiles Te
 endforeach()
 
 # GUI tests run sequentially after all other tests complete
-set(GUI_TESTS TestFileDialogProvider TestMainWindowGui TestBewavedDolphinGui)
+set(GUI_TESTS TestDialogs TestFileDialogProvider TestMainWindowGui TestBewavedDolphinGui)
 set(ALL_TESTS
     TestCPUAlu TestCPUBranch TestCPUControlUnit TestCPUDecoders
     TestCPUInstructionExecute TestCPUInstructionFetch TestCPUIntegration
@@ -846,7 +846,7 @@ set(ALL_TESTS
     TestElementFactory TestElementLogic TestElementLogicErrors TestNodeLogic TestStatusOps
     TestConnectionSerialization TestConnectionValidity TestConnections TestScene
     TestSceneConnections TestSceneState TestSceneUndoredo
-    TestSerialization TestSimulationBlocker TestDialogs
+    TestSerialization TestSimulationBlocker
     TestDanglingPointer
     TestCommands TestCommon TestEnums TestPriorities TestRecentFiles TestSettings TestThemeManager)
 foreach(TEST ${ALL_TESTS})

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -2144,6 +2144,7 @@ void TestICInline::testOnChildICBlobSavedAllOrNothing()
     for (int i = 0; i < 5; ++i) {
         auto *ic = dynamic_cast<IC *>(ws.scene()->itemById(ids.at(i)));
         QVERIFY2(ic, qPrintable(QString("IC %1 not found after propagation").arg(i)));
+        if (!ic) return;
         QCOMPARE(ic->blobName(), QString("atomic_test"));
         QCOMPARE(ic->label(), QString("IC_%1").arg(i));
     }
@@ -4215,6 +4216,7 @@ void TestICInline::testMultiCycleUndoRedoPropagation()
         ws.scene()->undoStack()->redo();
         elm = dynamic_cast<IC *>(ws.scene()->itemById(icId));
         QVERIFY2(elm, qPrintable(QString("IC not found after redo cycle %1").arg(cycle)));
+        if (!elm) return;
         QCOMPARE(elm->blobName(), QString("cycle_test"));
         QCOMPARE(elm->label(), QString("MY_IC"));
         QCOMPARE(elm->pos(), QPointF(200, 200));
@@ -5379,6 +5381,7 @@ void TestICInline::testInlineSaveConvertsFileBackedToEmbedded()
     // --- Step 5: Verify the dropped IC was converted to embedded ---
     auto *savedIC = dynamic_cast<IC *>(childWs.scene()->itemById(droppedICId));
     QVERIFY2(savedIC, "Dropped IC should still exist after save");
+    if (!savedIC) return;
 
     QVERIFY2(savedIC->isEmbedded(), "IC should be embedded after inline save");
     QCOMPARE(savedIC->blobName(), QString("simple_and"));
@@ -5463,6 +5466,7 @@ void TestICInline::testNestedInlineSaveAndReopen()
         }
     }
     QVERIFY2(chainBIC, "nested.panda should contain at least one IC");
+    if (!chainBIC) return;
     const int chainBICId = chainBIC->id();
 
     // Get chain_b blob for opening inline tab

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -722,7 +722,7 @@ void TestBewavedDolphinGui::testAboutDialog()
     auto ws = createAndCircuit();
     std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
 
-    QTimer::singleShot(0, [&dolphin] {
+    QTimer::singleShot(0, [] {
         if (auto *w = QApplication::activeModalWidget()) w->close();
     });
 
@@ -736,7 +736,7 @@ void TestBewavedDolphinGui::testAboutQtDialog()
     auto ws = createAndCircuit();
     std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
 
-    QTimer::singleShot(0, [&dolphin] {
+    QTimer::singleShot(0, [] {
         if (auto *w = QApplication::activeModalWidget()) w->close();
     });
 

--- a/Tests/Unit/Core/TestUpdateChecker.cpp
+++ b/Tests/Unit/Core/TestUpdateChecker.cpp
@@ -10,9 +10,7 @@ void TestUpdateChecker::testUpdateAvailable()
 {
     // Test: UpdateChecker can detect when update is available
     UpdateChecker checker;
-
-    // Create checker object - should not crash
-    QVERIFY(&checker != nullptr);
+    Q_UNUSED(checker)
 }
 
 void TestUpdateChecker::testNoUpdate()

--- a/Tests/Unit/Simulation/TestSimulation.cpp
+++ b/Tests/Unit/Simulation/TestSimulation.cpp
@@ -13,8 +13,7 @@ void TestSimulationUnit::testSimulationWithNoElements()
     // Test: Simulation handles empty scene gracefully
     WorkSpace workspace;
     Simulation sim(workspace.scene());
-
-    QVERIFY(&sim != nullptr);
+    Q_UNUSED(sim)
 }
 
 void TestSimulationUnit::testAddRemoveClockDuringSimulation()


### PR DESCRIPTION
## Summary

Adds native ARM64 builds to both the release pipeline (`deploy.yml`) and the PR/push CI (`build.yml`), using GitHub's free native ARM runners (`ubuntu-24.04-arm`, `windows-11-arm`, Apple Silicon `macos-26`) — no cross-compilation, no toolchain files. macOS builds remain a single universal binary since `CMakeLists.txt` already forces `CMAKE_OSX_ARCHITECTURES="x86_64; arm64"`.

The branch also picks up a few related cleanups discovered during CI iteration:

- **Runner-label hygiene**: replaced every `*-latest` label with a dated equivalent (`ubuntu-24.04`, `windows-2025-vs2026`, `macos-26`) so a runner image promotion can't silently change what these workflows are running against.
- **Xcode 26 AGL workaround**: Apple removed the AGL framework from Xcode 26's SDK; old Qt LTS releases (6.2.4 / 6.5.3 / 6.8.3, the ceiling of aqt's open-source feed) still link against it. `build.yml` now pins those Qt versions to `macos-15` (Xcode 16, AGL still in SDK) and only Qt 6.9.3 to `macos-26`.
- **GStreamer plugin metapackages** added to deploy.yml's apt list so go-appimage can resolve `libQt6Multimedia.so`'s transitive deps on `ubuntu-24.04-arm` (which doesn't preinstall them like the x86_64 image does).
- **Compiler warning fixes** (8 sites): Linux ARM GCC's `-Wnull-dereference`, clang's `-Wunused-lambda-capture` and `-Wtautological-pointer-compare` across `App/` and `Tests/`.
- **`TestDialogs` relabeled `gui`** so its modal-dialog timeouts on slower runners don't fail the test run.
- **Font fixes**: `QFont("SansSerif")` → `"Sans Serif"` (Qt's documented generic) and 16 SVGs' `font-family:Raleway` → `sans-serif` to silence the runtime "Populating font family aliases took N ms" QWARN.
- **CMake bump 3.16 → 3.27**, replacing the hand-rolled `link_wiredpanda_whole_archive` with `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>` and enabling `CMP0156` to dedupe the macOS link line.
- **`json-schema-validator` 2.3.0 → 2.4.0**.

10 commits, +124 / −77 across 29 files. History was cleaned up before opening this PR — each commit is single-concern.

## Test plan

- [x] `deploy.yml` end-to-end: pre-release dispatched against `ci/arm64-builds`, all 5 jobs green (Linux x86_64, Linux ARM64, Windows x86_64, Windows ARM64, macOS universal). All 6 release artifacts uploaded at sensible sizes (107 MB AppImage x86_64, 140 MB AppImage arm64, 69 MB Windows ZIP x86_64, 51 MB Windows ZIP arm64, 54 MB universal DMG). Sentry debug-symbol upload succeeded on every job.
- [x] `build.yml` end-to-end: 16/16 jobs green on the final cleaned branch (4 Qt versions × 2 OSes + 2 unity variants + 4 macOS-per-Qt entries + 2 ARM entries).
- [x] No compiler warnings in our own code on any Qt 6.9.3 build (Linux x86_64/ARM64, Windows x86_64/ARM64, macOS universal). Remaining warnings are in vendored `sentry-native/` and Qt 6.2's moc-generated code.
- [ ] Manual smoke test of one ARM64 release artifact on real ARM hardware (deferred to whoever has access).
- [ ] PR-tag a real release once merged to confirm `deploy.yml` produces the expected artifact set on master.