### PR TITLE
refactor(versions): rename FileVersion → FormatRev and bump app to 5.1.0

### DIFF
--- a/App/Element/IC.cpp
+++ b/App/Element/IC.cpp
@@ -408,7 +408,7 @@ void IC::loadFileDirectly(const QFileInfo &fileInfo)
     const auto items = Serialization::deserialize(stream, subCtx);
     file.close(); // must be closed before QSaveFile can write on Windows (mandatory file locking)
 
-    if ((preamble.version < FileVersion::current) && Application::migrationEnabled) {
+    if ((preamble.version < FormatRev::current) && Application::migrationEnabled) {
         migrateFile(fileInfo, items, preamble.version, fileRegistry);
     }
 

--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -310,7 +310,7 @@ void Serialization::writePandaHeader(QDataStream &stream)
 {
     stream.setVersion(QDataStream::Qt_5_12);
     stream << MAGIC_HEADER_CIRCUIT;
-    stream << FileVersion::current;
+    stream << FormatRev::current;
 }
 
 QVersionNumber Serialization::readPandaHeader(QDataStream &stream)
@@ -372,7 +372,7 @@ void Serialization::writeDolphinHeader(QDataStream &stream)
 {
     stream.setVersion(QDataStream::Qt_5_12);
     stream << MAGIC_HEADER_WAVEFORM;
-    stream << FileVersion::current;
+    stream << FormatRev::current;
 }
 
 void Serialization::readDolphinHeader(QDataStream &stream)

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -120,7 +120,7 @@ Simulation *WorkSpace::simulation()
 
 bool WorkSpace::isFromNewerVersion() const
 {
-    return !m_loadedVersion.isNull() && m_loadedVersion > FileVersion::current;
+    return !m_loadedVersion.isNull() && m_loadedVersion > FormatRev::current;
 }
 
 QFileInfo WorkSpace::fileInfo()
@@ -141,7 +141,7 @@ void WorkSpace::save(const QString &fileName)
             const QString message = tr("This file was saved with a newer file format (version %1).\n"
                          "Your wiRedPanda version (%2) supports file format %3.\n\n"
                          "Please update wiRedPanda to save changes to this file.")
-                          .arg(m_loadedVersion.toString(), AppVersion::current.toString(), FileVersion::current.toString());
+                          .arg(m_loadedVersion.toString(), AppVersion::current.toString(), FormatRev::current.toString());
             QMessageBox::warning(this, tr("Cannot save."), message);
         }
         return;
@@ -396,7 +396,7 @@ void WorkSpace::load(const QString &fileName)
     QVersionNumber version = Serialization::readPandaHeader(stream);
     m_loadedVersion = version;
 
-    bool needsMigration = (version < FileVersion::current) && Application::migrationEnabled;
+    bool needsMigration = (version < FormatRev::current) && Application::migrationEnabled;
     if (needsMigration) {
         createVersionedBackup(fileName, version);
     }
@@ -421,8 +421,8 @@ void WorkSpace::load(QDataStream &stream, const QVersionNumber &version, const Q
     qCDebug(zero) << "Version: " << version;
 
     if (Application::interactiveMode) {
-        if (version > FileVersion::current) {
-            const QString fmtVersion = FileVersion::current.toString();
+        if (version > FormatRev::current) {
+            const QString fmtVersion = FormatRev::current.toString();
             const QString fileVersion = version.toString();
             const QString message = tr("This file was saved with a newer file format (version %1).\n"
                          "Your version supports file format %2.\n\n"
@@ -430,11 +430,11 @@ void WorkSpace::load(QDataStream &stream, const QVersionNumber &version, const Q
                          "Please update wiRedPanda to edit and save this file.")
                           .arg(fileVersion, fmtVersion);
             QMessageBox::warning(this, tr("Newer version file."), message);
-        } else if (version < FileVersion::current) {
+        } else if (version < FormatRev::current) {
             const QString backupFileName = m_fileInfo.completeBaseName() + ".v" + version.toString() + "." + m_fileInfo.suffix();
             const QString message = tr("This file is in an older format (version %1) and will be automatically upgraded to the current format (version %2).\n"
                          "A backup of the original file has been created with name: %3")
-                         .arg(version.toString(), FileVersion::current.toString(), backupFileName);
+                         .arg(version.toString(), FormatRev::current.toString(), backupFileName);
             QMessageBox::information(this, tr("File upgraded."), message);
         }
     }

--- a/App/Versions.h
+++ b/App/Versions.h
@@ -38,13 +38,23 @@ inline const QVersionNumber V_5_1 = QVersionNumber(5, 1);
 
 } // namespace Versions
 
-/// File-format version, independent of the application release version.
-/// Only incremented when the on-disk binary format actually changes.
-namespace FileVersion {
+/// File-format revision, independent of the application release version.
+///
+/// Legacy revisions are the multi-segment `Versions::V_X_Y` constants above:
+/// historically they tracked the app version that introduced them, which made
+/// log/dialog output ambiguous once the two concepts drifted apart.
+///
+/// New revisions use **monotonic single-segment integers starting at 100**
+/// (`Rev100`, `Rev101`, ...).  Picking 100 as the boundary keeps the on-disk
+/// encoding (`QVersionNumber`) unchanged — `QVersionNumber(100)` compares
+/// greater than every legacy `Versions::V_X_Y` segment-by-segment, so existing
+/// readers and version comparisons keep working unmodified.  The next real
+/// format change should be `Rev100`.
+namespace FormatRev {
 
 inline const QVersionNumber current = Versions::V_5_1;
 
-} // namespace FileVersion
+} // namespace FormatRev
 
 /// Application version derived from the CMake-defined APP_VERSION string.
 namespace AppVersion {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
 # the WHOLE_ARCHIVE genex) into a single reference, which kills the macOS
 # "ld: warning: ignoring duplicate libraries" noise.
 cmake_policy(SET CMP0156 NEW)
-project(wiredpanda VERSION 5.0.1 LANGUAGES CXX)
+project(wiredpanda VERSION 5.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -986,7 +986,7 @@ void TestICInline::testBlobNamePreservation()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         ctx.blobRegistry = &registry;
         ic2->load(stream, ctx);
     }
@@ -1217,7 +1217,7 @@ void TestICInline::testBlobNameSpecialCharacters()
         {
             QDataStream stream(&serialized, QIODevice::ReadOnly);
             QMap<quint64, QNEPort *> portMap;
-            SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+            SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
             ctx.blobRegistry = &registry;
             loaded->load(stream, ctx);
         }
@@ -1715,7 +1715,7 @@ void TestICInline::testLoadV41MapDirectConstruct()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         ctx.blobRegistry = &registry;
         loaded->load(stream, ctx);
     }
@@ -1750,7 +1750,7 @@ void TestICInline::testLoadMismatchNoFileName()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         bool threw = false;
         try {
             loaded->load(stream, ctx);
@@ -2653,7 +2653,7 @@ void TestICInline::testSerializationMismatchFallback()
         {
             QDataStream stream(&serialized, QIODevice::ReadOnly);
             QMap<quint64, QNEPort *> portMap;
-            SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+            SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
             try {
                 loaded->load(stream, ctx);
             } catch (const Pandaception &) {
@@ -2682,7 +2682,7 @@ void TestICInline::testSerializationMismatchFallback()
         {
             QDataStream stream(&serialized, QIODevice::ReadOnly);
             QMap<quint64, QNEPort *> portMap;
-            SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+            SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
             try {
                 loaded->load(stream, ctx);
             } catch (const Pandaception &) {
@@ -2709,7 +2709,7 @@ void TestICInline::testSerializationMismatchFallback()
         {
             QDataStream stream(&embeddedData, QIODevice::ReadOnly);
             QMap<quint64, QNEPort *> portMap;
-            SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+            SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
             ctx.blobRegistry = &registry;
             loaded->load(stream, ctx);
         }
@@ -2743,7 +2743,7 @@ void TestICInline::testSerializationMismatchFallbackCase2State()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         bool threw = false;
         try {
             loaded->load(stream, ctx);
@@ -2918,7 +2918,7 @@ void TestICInline::testSetInlineDataEmptyBlobNameRoundTripFails()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         bool threw = false;
         try {
             loaded->load(stream, ctx);
@@ -3070,7 +3070,7 @@ void TestICInline::testCopyFileGuardDuringPaste()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         ctx.blobRegistry = &registry;
         ic2->load(stream, ctx);
     }
@@ -3108,7 +3108,7 @@ void TestICInline::testCopyPasteEmbeddedICRoundTrip()
     {
         QDataStream stream(&serialized, QIODevice::ReadOnly);
         QMap<quint64, QNEPort *> portMap;
-        SerializationContext ctx{portMap, FileVersion::current, m_fixtureDir};
+        SerializationContext ctx{portMap, FormatRev::current, m_fixtureDir};
         ctx.blobRegistry = &registry;
         pasted->load(stream, ctx);
     }
@@ -4723,7 +4723,7 @@ void TestICInline::testBlobRegistryEmptyRoundTrip()
     QVERIFY(!metadata.contains("embeddedICs"));
 
     // Deserializing metadata without the key must return an empty map
-    auto result = Serialization::deserializeBlobRegistry(metadata, FileVersion::current);
+    auto result = Serialization::deserializeBlobRegistry(metadata, FormatRev::current);
     QVERIFY(result.isEmpty());
 }
 

--- a/Tests/Integration/TestIc.cpp
+++ b/Tests/Integration/TestIc.cpp
@@ -831,7 +831,7 @@ void TestIC::testICFileMigrationCreatesBackup()
         QFile f(subDst); QVERIFY(f.open(QIODevice::ReadOnly));
         QDataStream s(&f);
         const QVersionNumber v = Serialization::readPandaHeader(s);
-        QVERIFY2(v < FileVersion::current, "Fixture must be older than current version for this test");
+        QVERIFY2(v < FormatRev::current, "Fixture must be older than current version for this test");
     }
 
     // Load the sub-circuit via IC::loadFile() with migration enabled
@@ -858,7 +858,7 @@ void TestIC::testICFileMigrationCreatesBackup()
 void TestIC::testICFileMigrationUpdatesSubcircuitVersion()
 {
     // After IC::loadFile() migrates a sub-circuit file, re-reading its header
-    // must return FileVersion::current.
+    // must return FormatRev::current.
 
     const QString srcDir = TestUtils::backwardCompatibilityDir() + "v4.2.0/";
     QTemporaryDir tempDir;
@@ -883,7 +883,7 @@ void TestIC::testICFileMigrationUpdatesSubcircuitVersion()
     QVERIFY(file.open(QIODevice::ReadOnly));
     QDataStream stream(&file);
     const QVersionNumber versionAfter = Serialization::readPandaHeader(stream);
-    QCOMPARE(versionAfter, FileVersion::current);
+    QCOMPARE(versionAfter, FormatRev::current);
 }
 
 void TestIC::testICFileMigrationDisabledSkips()

--- a/Tests/Integration/TestWorkspaceFileops.cpp
+++ b/Tests/Integration/TestWorkspaceFileops.cpp
@@ -607,7 +607,7 @@ void TestWorkspaceFileops::testMigrationEnabledCreatesBackup()
 void TestWorkspaceFileops::testMigrationUpdatesFileVersion()
 {
     // After migration, the original file must be re-saved in the current format:
-    // reading its header back must produce FileVersion::current.
+    // reading its header back must produce FormatRev::current.
 
     QVERIFY2(m_tempDir.isValid(), "Temp dir must be valid");
     const QString path = m_tempDir.path() + "/old_resaved.panda";
@@ -630,7 +630,7 @@ void TestWorkspaceFileops::testMigrationUpdatesFileVersion()
     QDataStream stream(&file);
     const QVersionNumber versionAfter = Serialization::readPandaHeader(stream);
 
-    QCOMPARE(versionAfter, FileVersion::current);
+    QCOMPARE(versionAfter, FormatRev::current);
 }
 
 void TestWorkspaceFileops::testMigrationCurrentVersionSkips()
@@ -654,7 +654,7 @@ void TestWorkspaceFileops::testMigrationCurrentVersionSkips()
         QFile file(path);
         QVERIFY(file.open(QIODevice::ReadOnly));
         QDataStream stream(&file);
-        QCOMPARE(Serialization::readPandaHeader(stream), FileVersion::current);
+        QCOMPARE(Serialization::readPandaHeader(stream), FormatRev::current);
     }
 
     Application::migrationEnabled = true;
@@ -670,7 +670,7 @@ void TestWorkspaceFileops::testMigrationCurrentVersionSkips()
     // No backup file should exist — version matched, no migration triggered
     // The backup pattern would be e.g. current_format.v4.4.panda
     const QString backupPattern = m_tempDir.path() + "/current_format.v"
-        + FileVersion::current.toString() + ".panda";
+        + FormatRev::current.toString() + ".panda";
     QVERIFY2(!QFile::exists(backupPattern),
              "No backup must be created for a current-version file");
 

--- a/Tests/Unit/Elements/TestAudioBox.cpp
+++ b/Tests/Unit/Elements/TestAudioBox.cpp
@@ -231,7 +231,7 @@ void TestAudioBox::testLoadVersionOld()
 
     QDataStream loadStream(data);
     QMap<quint64, QNEPort *> portMap;
-    SerializationContext context{portMap, FileVersion::current, {}};
+    SerializationContext context{portMap, FormatRev::current, {}};
     audioBox2->load(loadStream, context);
 
     // Audio path should be loaded correctly
@@ -253,7 +253,7 @@ void TestAudioBox::testLoadVersionNew()
 
     QDataStream loadStream(data);
     QMap<quint64, QNEPort *> portMap;
-    SerializationContext context{portMap, FileVersion::current, {}};
+    SerializationContext context{portMap, FormatRev::current, {}};
     audioBox2->load(loadStream, context);
 
     // Audio path should be loaded

--- a/Tests/Unit/Elements/TestBuzzer.cpp
+++ b/Tests/Unit/Elements/TestBuzzer.cpp
@@ -212,7 +212,7 @@ void TestBuzzer::testLoadVersionNew()
 
     QDataStream loadStream(data);
     QMap<quint64, QNEPort *> portMap;
-    SerializationContext context{portMap, FileVersion::current, {}};
+    SerializationContext context{portMap, FormatRev::current, {}};
 
     buzzer2->load(loadStream, context);
 

--- a/Tests/Unit/Nodes/TestConnectionSerialization.cpp
+++ b/Tests/Unit/Nodes/TestConnectionSerialization.cpp
@@ -60,7 +60,7 @@ void TestConnectionSerialization::testLoadWithEmptyPortMapDirectRestore()
     QDataStream loadStream(data);
     QMap<quint64, QNEPort *> emptyPortMap;
 
-    SerializationContext context{emptyPortMap, FileVersion::current, QString()};
+    SerializationContext context{emptyPortMap, FormatRev::current, QString()};
     conn2->load(loadStream, context);
 
     QVERIFY(conn2->startPort() == nullptr);
@@ -119,7 +119,7 @@ void TestConnectionSerialization::testLoadWithPortMapIndirectRestore()
     // Create new connection and load with port map
     auto conn2 = std::make_unique<QNEConnection>();
     QDataStream loadStream(data);
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
     conn2->load(loadStream, context);
 
     // Verify ports were correctly mapped
@@ -157,7 +157,7 @@ void TestConnectionSerialization::testLoadInvalidPortReferencesHandled()
     // Load with incomplete port map
     auto conn2 = std::make_unique<QNEConnection>();
     QDataStream loadStream(data);
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
     conn2->load(loadStream, context);
 
     // With missing port reference, load() returns early, both ports remain null
@@ -210,7 +210,7 @@ void TestConnectionSerialization::testLoadPortTypeResolution()
     // Load connection
     auto conn2 = std::make_unique<QNEConnection>();
     QDataStream loadStream(data);
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
     conn2->load(loadStream, context);
 
     // Verify ports are correctly identified despite being loaded from stream
@@ -271,7 +271,7 @@ void TestConnectionSerialization::testLoadMultipleConnectionsOnSamePorts()
     portMap[andIn1Serial] = andGate->inputPort(1);
 
     // Load both connections
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
 
     auto loadedConn1 = std::make_unique<QNEConnection>();
     {
@@ -338,7 +338,7 @@ void TestConnectionSerialization::testSaveLoadRoundTripPreservesPorts()
     portMap[andOutSerial] = outputPort;
     portMap[orInSerial] = inputPort;
 
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
 
     auto conn2 = std::make_unique<QNEConnection>();
     {
@@ -390,7 +390,7 @@ void TestConnectionSerialization::testSaveLoadPreservesConnectionStatus()
     portMap[swOutSerial] = sw->outputPort();
     portMap[ledInSerial] = led->inputPort();
 
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
 
     auto conn2 = std::make_unique<QNEConnection>();
     {
@@ -459,7 +459,7 @@ void TestConnectionSerialization::testSaveLoadWithStatusPropagation()
     portMap[and2In0Serial] = and2->inputPort(0);
 
     // Load connections
-    SerializationContext context{portMap, FileVersion::current, QString()};
+    SerializationContext context{portMap, FormatRev::current, QString()};
 
     auto loadedConn1 = std::make_unique<QNEConnection>();
     {


### PR DESCRIPTION
## Summary

- Rename `FileVersion` namespace to `FormatRev` (pure rename, no behaviour change). Going forward, new file-format revisions use monotonic single-segment integers starting at 100 (`Rev100`, `Rev101`, ...) so they're visually distinct from app semver. Legacy multi-segment `Versions::V_X_Y` constants stay frozen for files already in the wild.
- Bump app version 5.0.1 → 5.1.0 in `CMakeLists.txt`.

The file format itself is unchanged — `FormatRev::current` still points at `Versions::V_5_1`. The next real format change should be `Rev100`, at which point `QVersionNumber(100) >= QVersionNumber(5, 1)` keeps every existing comparison site working unmodified.

## Test plan

- [ ] `cmake --build --preset debug` succeeds (verified locally)
- [ ] `ctest --preset debug` passes
- [ ] Existing `.panda` files (at file-format V_5_1) still load and save round-trip cleanly