### PR TITLE
fix(i18n): search bundle paths for qtbase_*.qm before QLibraryInfo

### DIFF
--- a/App/UI/LanguageManager.cpp
+++ b/App/UI/LanguageManager.cpp
@@ -92,10 +92,31 @@ void LanguageManager::loadTranslation(const QString &language)
     }
 
     m_qtTranslator = new QTranslator(this);
-    const QString qtBase  = QStringLiteral("qtbase_") + language;
-    const bool    qtFound = m_qtTranslator->load(qtBase, QLibraryInfo::path(QLibraryInfo::TranslationsPath));
+    const QString qtBase = QStringLiteral("qtbase_") + language;
+
+    // Deployed binaries bundle qtbase_<lang>.qm next to the application but
+    // QLibraryInfo::TranslationsPath returns the build-host path baked into
+    // libQt6Core, which doesn't exist on user machines.  Try the platform
+    // bundle layouts first, then fall back to the system Qt install for dev
+    // builds.
+    const QStringList searchPaths = {
+        QCoreApplication::applicationDirPath() + QStringLiteral("/../translations"),           // Linux AppImage (usr/translations)
+        QCoreApplication::applicationDirPath() + QStringLiteral("/translations"),              // Windows windeployqt
+        QCoreApplication::applicationDirPath() + QStringLiteral("/../Resources/translations"), // macOS bundle
+        QLibraryInfo::path(QLibraryInfo::TranslationsPath),                                    // System Qt install
+    };
+
+    bool qtFound = false;
+    for (const QString &dir : searchPaths) {
+        if (m_qtTranslator->load(qtBase, dir)) {
+            qtFound = true;
+            break;
+        }
+    }
+
     if (!qtFound || !Application::instance()->installTranslator(m_qtTranslator)) {
-        qWarning() << "Failed to load Qt translation for" << language << ", continuing without Qt translation";
+        qWarning() << "Failed to load Qt translation for" << language
+                   << "— tried:" << searchPaths;
         delete m_qtTranslator;
         m_qtTranslator = nullptr;
     }


### PR DESCRIPTION
## Summary

The 5.1.0 marquee i18n feature (Qt-owned dialogs in 27 languages + automatic RTL for ar/he/fa via `QT_LAYOUT_DIRECTION`) is broken on every shipped artifact because `QLibraryInfo::path(QLibraryInfo::TranslationsPath)` returns the GitHub Actions runner's compile-time Qt prefix (e.g. `/home/runner/work/wiRedPanda/Qt/6.9.3/gcc_64/translations/`), which doesn't exist on user machines.

The 5.1.0 AppImage was inspected directly: 26 `qtbase_*.qm` files are correctly bundled at `usr/translations/`, but the code never looks there. Commit `4ed13ba8d`'s message advertised "fallback to `applicationDirPath()`" but the diff only added the single `QLibraryInfo` call — that fallback was never written.

This PR adds the missing fallback as an explicit search-path list covering the four layouts that ship:

| Layout | Path tried |
| --- | --- |
| Linux AppImage | `applicationDirPath/../translations` |
| Windows windeployqt | `applicationDirPath/translations` |
| macOS bundle | `applicationDirPath/../Resources/translations` |
| Dev / system Qt install | `QLibraryInfo::TranslationsPath` (now last, as fallback) |

The failure `qWarning` is also expanded to print the paths tried, so the next regression is diagnosable from a single log line instead of requiring AppImage extraction.

After this lands, the 5.1.0 release will be deleted and re-cut from master so the published artifacts actually work.

## Test plan

- [x] `cmake --build --preset debug` succeeds locally
- [ ] Switch the dev build to Arabic / Hebrew / Persian → file picker translated + layout flips RTL
- [ ] AppImage built from this branch loads `qtbase_<lang>.qm` from `usr/translations/`
- [ ] Windows portable from this branch loads `qtbase_<lang>.qm` from `translations/`