### PR TITLE
build: unify lupdate into update_translations target

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run lupdate to extract strings
         run: |
           cmake -B build_translations
-          cmake --build build_translations --target lupdate
+          cmake --build build_translations --target update_translations
 
       - name: Create PR for translation updates
         run: |

--- a/App/Resources/Translations/wpanda_ar.ts
+++ b/App/Resources/Translations/wpanda_ar.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_bg.ts
+++ b/App/Resources/Translations/wpanda_bg.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_bn.ts
+++ b/App/Resources/Translations/wpanda_bn.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_cs.ts
+++ b/App/Resources/Translations/wpanda_cs.ts
@@ -2706,6 +2706,19 @@ Navrhovaný název:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_da.ts
+++ b/App/Resources/Translations/wpanda_da.ts
@@ -2706,6 +2706,19 @@ Foreslået navn:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_de.ts
+++ b/App/Resources/Translations/wpanda_de.ts
@@ -2706,6 +2706,19 @@ Vorgeschlagener Name:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_el.ts
+++ b/App/Resources/Translations/wpanda_el.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_en.ts
+++ b/App/Resources/Translations/wpanda_en.ts
@@ -2706,6 +2706,19 @@ Suggested name:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_es.ts
+++ b/App/Resources/Translations/wpanda_es.ts
@@ -2705,6 +2705,19 @@ Nombre sugerido:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="22"/>

--- a/App/Resources/Translations/wpanda_et.ts
+++ b/App/Resources/Translations/wpanda_et.ts
@@ -2706,6 +2706,19 @@ Soovitatud nimi:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_fa.ts
+++ b/App/Resources/Translations/wpanda_fa.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_fi.ts
+++ b/App/Resources/Translations/wpanda_fi.ts
@@ -2706,6 +2706,19 @@ Ehdotettu nimi:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_fr.ts
+++ b/App/Resources/Translations/wpanda_fr.ts
@@ -2706,6 +2706,19 @@ Nom suggéré&#xa0;:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_he.ts
+++ b/App/Resources/Translations/wpanda_he.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_hi.ts
+++ b/App/Resources/Translations/wpanda_hi.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_hr.ts
+++ b/App/Resources/Translations/wpanda_hr.ts
@@ -2706,6 +2706,19 @@ Predloženi naziv:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_hu.ts
+++ b/App/Resources/Translations/wpanda_hu.ts
@@ -2706,6 +2706,19 @@ Javasolt név:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_id.ts
+++ b/App/Resources/Translations/wpanda_id.ts
@@ -2706,6 +2706,19 @@ Nama yang disarankan:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_it.ts
+++ b/App/Resources/Translations/wpanda_it.ts
@@ -2706,6 +2706,19 @@ Nome suggerito:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_ja.ts
+++ b/App/Resources/Translations/wpanda_ja.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_ko.ts
+++ b/App/Resources/Translations/wpanda_ko.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_lt.ts
+++ b/App/Resources/Translations/wpanda_lt.ts
@@ -2706,6 +2706,19 @@ Siūlomas pavadinimas:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_lv.ts
+++ b/App/Resources/Translations/wpanda_lv.ts
@@ -2706,6 +2706,19 @@ Ieteiktais nosaukums:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_ms.ts
+++ b/App/Resources/Translations/wpanda_ms.ts
@@ -2706,6 +2706,19 @@ Nama yang dicadangkan:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_nb.ts
+++ b/App/Resources/Translations/wpanda_nb.ts
@@ -2706,6 +2706,19 @@ Foreslått navn:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_nl.ts
+++ b/App/Resources/Translations/wpanda_nl.ts
@@ -2706,6 +2706,19 @@ Voorgestelde naam:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_pl.ts
+++ b/App/Resources/Translations/wpanda_pl.ts
@@ -2706,6 +2706,19 @@ Sugerowana nazwa:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_pt.ts
+++ b/App/Resources/Translations/wpanda_pt.ts
@@ -2706,6 +2706,19 @@ Nome sugerido:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_pt_BR.ts
+++ b/App/Resources/Translations/wpanda_pt_BR.ts
@@ -2706,6 +2706,19 @@ Nome sugerido:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_ro.ts
+++ b/App/Resources/Translations/wpanda_ro.ts
@@ -2706,6 +2706,19 @@ Nume sugerat:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_ru.ts
+++ b/App/Resources/Translations/wpanda_ru.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_sk.ts
+++ b/App/Resources/Translations/wpanda_sk.ts
@@ -2706,6 +2706,19 @@ Navrhovaný názov:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_sv.ts
+++ b/App/Resources/Translations/wpanda_sv.ts
@@ -2706,6 +2706,19 @@ Föreslaget namn:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_th.ts
+++ b/App/Resources/Translations/wpanda_th.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_tr.ts
+++ b/App/Resources/Translations/wpanda_tr.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_uk.ts
+++ b/App/Resources/Translations/wpanda_uk.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_vi.ts
+++ b/App/Resources/Translations/wpanda_vi.ts
@@ -2706,6 +2706,19 @@ Tên gợi ý:</translation>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_zh_Hans.ts
+++ b/App/Resources/Translations/wpanda_zh_Hans.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/App/Resources/Translations/wpanda_zh_Hant.ts
+++ b/App/Resources/Translations/wpanda_zh_Hant.ts
@@ -2706,6 +2706,19 @@ Suggested name:</source>
     </message>
 </context>
 <context>
+    <name>TestNotifyCatch</name>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="59"/>
+        <source>notify-catch test throw (no dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../Tests/Unit/Core/TestNotifyCatch.cpp" line="92"/>
+        <source>notify-catch test throw (with dialog)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Text</name>
     <message>
         <location filename="../../Element/GraphicElements/Text.cpp" line="23"/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ Advanced development features supported:
   - `ctest --preset ubsan` - Undefined Behavior Sanitizer
   - Parallel execution and output on failure are automatic via CMakeLists.txt configuration
 
+### Translations
+
+- **CRITICAL**: Always use `cmake --build --preset debug --target update_translations` to refresh `.ts` files — never call `lupdate` directly or use any other target.
+- This target passes `-tr-function-alias tr+=PANDACEPTION` so strings wrapped in the `PANDACEPTION()` macro are correctly extracted. Using any other invocation silently discards those strings.
+
 ## Project Structure
 
 - Main project file: `CMakeLists.txt`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,16 +281,6 @@ include_directories(
 
 # ========= TRANSLATIONS ===========================
 
-# lupdate target — refreshes .ts files from source.  Manual invocation only;
-# unrelated to the build-time .qm compilation handled by qt_add_translations.
-if(Qt6LinguistTools_FOUND)
-    add_custom_target(lupdate
-        COMMAND Qt6::lupdate -tr-function-alias tr+=PANDACEPTION -extensions cpp,h,ui -I ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/App -ts ${TS_FILES} -no-obsolete
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMENT "Updating translation source files"
-    )
-endif()
-
 list(LENGTH TS_FILES TS_FILES_COUNT)
 message(STATUS "Found ${TS_FILES_COUNT} translation files:")
 foreach(ts_file ${TS_FILES})
@@ -389,9 +379,18 @@ if(Qt6LinguistTools_FOUND)
     if(Qt6_VERSION VERSION_GREATER_EQUAL "6.9.0")
         set(_merge_qt_translations MERGE_QT_TRANSLATIONS)
     endif()
+    set(_lupdate_opts)
+    if(Qt6_VERSION VERSION_GREATER_EQUAL "6.7.0")
+        set(_lupdate_opts LUPDATE_OPTIONS
+            -tr-function-alias tr+=PANDACEPTION
+            -extensions cpp,h,ui
+            -no-obsolete
+        )
+    endif()
     qt_add_translations(wiredpanda
         TS_FILES ${TS_FILES}
         ${_merge_qt_translations}
+        ${_lupdate_opts}
     )
 endif()
 


### PR DESCRIPTION
## Summary

- Removes the hand-written `lupdate` custom target from `CMakeLists.txt`
- Passes `-tr-function-alias tr+=PANDACEPTION -extensions cpp,h,ui -no-obsolete` via `LUPDATE_OPTIONS` to `qt_add_translations` (Qt ≥ 6.7 guard)
- Updates the CI translation workflow to call `--target update_translations` instead of the now-removed `--target lupdate`
- Documents the canonical target in `CLAUDE.md`

## Root cause fixed

Using `--target update_translations` previously silently discarded all strings wrapped in `PANDACEPTION()` (which expands to `tr()`), because lupdate didn't know about the macro alias. Only `--target lupdate` worked correctly. This caused the three `BeWavedDolphin` error strings to be stripped from the `.ts` files whenever a developer ran the wrong target.

## Test plan

- [ ] `cmake --build --preset debug --target update_translations` extracts `PANDACEPTION` strings correctly (e.g. `BeWavedDolphin.cpp` lines 159/171/181 appear as `unfinished` entries in `.ts` files)
- [ ] `cmake --build --preset debug --target lupdate` returns `ninja: error: unknown target 'lupdate'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)