### PR TITLE
fix(ci): drop Qt 6.2 and 6.5 from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2025-vs2026]
-        qt: [6.2.4, 6.5.3, 6.8.3, 6.9.3]
+        qt: [6.8.3, 6.9.3]
         cmake_args: ['']
         include:
           - { os: ubuntu-24.04, qt: '6.9.3', cmake_args: '-DENABLE_UNITY=OFF -DENABLE_PCH=OFF' }
           - { os: ubuntu-24.04, qt: '6.9.3', cmake_args: '-DUNITY_BUILD_BATCH_SIZE=1000' }
-          - { os: macos-15, qt: '6.2.4', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
-          - { os: macos-15, qt: '6.5.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
           - { os: macos-15, qt: '6.8.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
           - { os: macos-26, qt: '6.9.3', cmake_args: '', qt_host: mac, qt_arch: clang_64 }
           - { os: ubuntu-24.04-arm, qt: '6.9.3', cmake_args: '', qt_host: linux_arm64,   qt_arch: linux_gcc_arm64      }


### PR DESCRIPTION
## Summary

- Remove Qt 6.2.4 and 6.5.3 from the CI build matrix (Ubuntu, Windows, macOS)
- MSVC 14.51 (VS 2026) removed `stdext::checked_array_iterator`, which both Qt versions reference in `qvarlengtharray.h` — Qt fixed this in 6.6+
- The `windows-2025-vs2026` runner pool is mid-rollout between MSVC 14.50 (has `stdext`) and 14.51 (removed), causing intermittent failures

## Test plan

- [x] Verify the excluded jobs no longer appear in the CI matrix
- [x] Confirm remaining jobs (Qt 6.8.3, 6.9.3 on all platforms) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)