### PR TITLE
fix(ui): remove unused lambda capture in MainWindow

### DIFF
--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -995,7 +995,7 @@ void MainWindow::on_actionAboutQt_triggered()
 
 void MainWindow::on_actionReportTranslationError_triggered()
 {
-    Application::guardedSlot(this, [this] {
+    Application::guardedSlot(this, [] {
         QDesktopServices::openUrl(QUrl("https://hosted.weblate.org/projects/wiredpanda/wiredpanda"));
     });
 }


### PR DESCRIPTION
## Summary
- Remove unused `this` capture in `on_actionReportTranslationError_triggered` lambda, fixing `-Wunused-lambda-capture` warning on WASM/Emscripten builds.

## Test plan
- [x] Builds without warning on Clang/Emscripten
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)