### PR TITLE
Fix Linux build on stock distro CMake/packages + add weekly fresh-distro CI

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -19,7 +19,7 @@ This directory contains the configuration for a streamlined containerized develo
 ## 🛠️ What's Included
 
 ### Development Tools
-- **Build System**: CMake 3.22+ with Ninja generator
+- **Build System**: CMake 3.27+ with Ninja generator
 - **Compiler**: GCC 11+ with C++20 support
 - **Qt Framework**: Qt 6.2+ with core, widgets, multimedia, SVG modules
 - **Performance**: Mold linker and ccache for faster builds

--- a/.github/workflows/fresh-deps.yml
+++ b/.github/workflows/fresh-deps.yml
@@ -1,0 +1,122 @@
+# Copyright 2015 - 2026, GIBIS-Unifesp and the wiRedPanda contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Fresh distro build
+
+# Builds wiRedPanda from a *clean* distro image using only the packages the docs
+# tell users to apt-install. Its job is to catch package drift -- a Qt
+# dependency getting renamed or dropped from the apt repos (as libqt6svg6-dev
+# was) -- and to keep cmake_minimum_required honest. The main build.yml installs
+# a pinned Qt via aqtinstall on pre-provisioned runners, so it can detect
+# neither of those.
+on:
+  schedule:
+    # Mondays 07:00 UTC, staggered an hour after the CodeQL weekly run.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    # Run immediately when the documented dependencies, the CMake floor, or this
+    # workflow itself change, so a bad edit is caught in the PR -- not next week.
+    paths:
+      - .github/workflows/fresh-deps.yml
+      - BUILD.md
+      - BUILD_es.md
+      - BUILD_pt_BR.md
+      - CONTRIBUTING.md
+      - DEVELOPER_GUIDE.md
+      - CMakeLists.txt
+      - CMakePresets.json
+
+concurrency:
+  group: fresh-deps-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Build on stock distro images with exactly the documented apt packages.
+  distro:
+    name: fresh ${{ matrix.image }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.image }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:24.04
+          - debian:trixie
+
+    steps:
+      - name: Install toolchain + checkout plumbing
+        run: |
+          set -eu
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y cmake ninja-build git ca-certificates
+
+      - name: Install the documented Qt dependencies (drift tripwire)
+        # The exact `apt install` line from BUILD.md's Debian/Ubuntu section. If
+        # any of these package names is renamed or removed, this step fails loud.
+        run: |
+          set -eu
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get install -y build-essential qt6-base-dev qt6-multimedia-dev qt6-svg-dev
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Configure & build (documented preset flow)
+        # On ubuntu:24.04 this proves the project builds on stock apt CMake (3.28)
+        # after the duplicate-link fix; debian:trixie exercises a newer CMake (3.31).
+        run: |
+          set -eu
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          cmake --preset release
+          cmake --build --preset release
+
+      - name: Smoke-run the binary headless
+        run: |
+          set -eu
+          export QT_QPA_PLATFORM=offscreen
+          ./build-release/wiredpanda --version
+
+  # Build at the project's declared cmake_minimum_required to keep it honest.
+  minimum-cmake:
+    name: minimum CMake (3.27)
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    container: ubuntu:24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Install Qt + pin CMake to the declared minimum
+        # Keep this version in sync with cmake_minimum_required in CMakeLists.txt.
+        # If the project stops configuring/building here, the declared floor is a
+        # lie -- raise it to the lowest version this job passes at.
+        run: |
+          set -eu
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y build-essential ninja-build git ca-certificates python3-pip \
+            qt6-base-dev qt6-multimedia-dev qt6-svg-dev
+          python3 -m pip install --break-system-packages 'cmake==3.27.*'
+          cmake --version
+          cmake --version | head -1 | grep -q ' 3\.27\.' || { echo "ERROR: expected pinned CMake 3.27.x"; exit 1; }
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Configure & build at the declared minimum CMake
+        run: |
+          set -eu
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          cmake --preset release
+          cmake --build --preset release

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ On distros such as Arch Linux, Gentoo, Manjaro, Debian, etc., Qt 6.2+ can be ins
 * Debian/Ubuntu
 
 ```bash
-sudo apt install build-essential qt6-base-dev qt6-multimedia-dev libqt6svg6-dev
+sudo apt install build-essential qt6-base-dev qt6-multimedia-dev qt6-svg-dev
 ```
 
 * Arch Linux-based

--- a/BUILD_es.md
+++ b/BUILD_es.md
@@ -18,7 +18,7 @@ En distribuciones como Arch Linux, Gentoo, Manjaro, Debian, etc., Qt 6.2+ se pue
 * Debian/Ubuntu
 
 ```bash
-sudo apt install build-essential qt6-base-dev qt6-multimedia-dev libqt6svg6-dev
+sudo apt install build-essential qt6-base-dev qt6-multimedia-dev qt6-svg-dev
 ```
 
 * Basado en Arch Linux

--- a/BUILD_pt_BR.md
+++ b/BUILD_pt_BR.md
@@ -18,7 +18,7 @@ Em distribuições como Arch Linux, Gentoo, Manjaro, Debian, etc., o Qt 6.2+ pod
 * Debian/Ubuntu
 
 ```bash
-sudo apt install build-essential qt6-base-dev qt6-multimedia-dev libqt6svg6-dev
+sudo apt install build-essential qt6-base-dev qt6-multimedia-dev qt6-svg-dev
 ```
 
 * Baseado em Arch Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,9 @@
-cmake_minimum_required(VERSION 3.27)
+# Minimum 3.27: $<COMPILE_ONLY> on the test helper libs below needs it. The
+# ...3.31 upper bound keeps policy defaults current on newer CMake, so CMP0156
+# (link-line de-duplication) still defaults to NEW on CMake >= 3.29 with no
+# explicit cmake_policy(SET) needed.
+cmake_minimum_required(VERSION 3.27...3.31)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
-
-# CMP0156 (3.27+): de-duplicate libraries on the link line using the new
-# algorithm. NEW collapses transitive PUBLIC links of the same archive (e.g.
-# wiredpanda_lib reaching test_wiredpanda via test_utils AND memory_helpers AND
-# the WHOLE_ARCHIVE genex) into a single reference, which kills the macOS
-# "ld: warning: ignoring duplicate libraries" noise.
-cmake_policy(SET CMP0156 NEW)
 project(wiredpanda VERSION 5.1.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -535,12 +532,18 @@ enable_testing()
 
 # Test utilities library (shared helpers for all tests)
 add_library(test_utils STATIC ${TEST_UTILS_SOURCES} ${TEST_UTILS_HEADERS})
-target_link_libraries(test_utils PUBLIC wiredpanda_lib)
+# Headers only: every test executable whole-archives wiredpanda_lib itself
+# (link_wiredpanda_whole_archive), so re-linking it here would put the archive on
+# the link line a second time and, with a different link feature, collide with
+# WHOLE_ARCHIVE on CMake < 3.29 ("already occurred with feature WHOLE_ARCHIVE").
+# $<COMPILE_ONLY> propagates wiredpanda_lib's include/define/feature usage
+# requirements without adding it to the link.
+target_link_libraries(test_utils PUBLIC "$<COMPILE_ONLY:wiredpanda_lib>")
 target_compile_definitions(test_utils PRIVATE CURRENTDIR=${CMAKE_CURRENT_SOURCE_DIR}/Tests)
 
 # Helper library for shared circuit builders (register file, memory tests)
 add_library(memory_helpers STATIC ${MEMORY_HELPERS_SOURCES} ${MEMORY_HELPERS_HEADERS})
-target_link_libraries(memory_helpers PUBLIC wiredpanda_lib test_utils)
+target_link_libraries(memory_helpers PUBLIC "$<COMPILE_ONLY:wiredpanda_lib>" test_utils)
 
 # ---- Single consolidated test executable ----
 # All test classes in one binary; CTest registers per-class entries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ cmake --build --preset release
 ### General Requirements
 
 - **C++ Standard**: C++20
-- **Build System**: CMake 3.16+ with Ninja generator (auto-selected)
+- **Build System**: CMake 3.27+ with Ninja generator (auto-selected)
 - **Trailing Newlines**: All source files must end with a trailing newline
 - **Line Trimming**: Remove trailing whitespace from all lines
 - **File Types**: Apply style to `.cpp`, `.h`, `.cmake`, `CMakeLists.txt`, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ If you prefer local development, see our detailed [BUILD.md](BUILD.md) instructi
 
 ```bash
 # Install dependencies (example for Ubuntu)
-sudo apt install build-essential qt6-base-dev qt6-multimedia-dev libqt6svg6-dev
+sudo apt install build-essential qt6-base-dev qt6-multimedia-dev qt6-svg-dev
 
 # Clone and build
 git clone https://github.com/GIBIS-UNIFESP/wiRedPanda.git

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -76,7 +76,7 @@ The project is maintained by [GIBIS-UNIFESP](https://github.com/GIBIS-UNIFESP) a
 |------------------|--------------------------------------|
 | Language         | C++20                                |
 | UI Framework     | Qt 6.2+                              |
-| Build System     | CMake 3.16+ with Ninja               |
+| Build System     | CMake 3.27+ with Ninja               |
 | Tests            | Qt Test Framework + CTest            |
 | CI/CD            | GitHub Actions                       |
 | Crash Reporting  | Sentry (Crashpad/Breakpad)           |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -118,7 +118,7 @@ See [BUILD.md](BUILD.md) for platform-specific instructions. The short version:
 
 ```bash
 sudo apt install build-essential cmake ninja-build \
-    qt6-base-dev qt6-multimedia-dev libqt6svg6-dev \
+    qt6-base-dev qt6-multimedia-dev qt6-svg-dev \
     ccache mold
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Compiled binaries for Windows, Linux and macOS are available on the [releases pa
 
 **Requirements**:
 
-- CMake 3.16+
+- CMake 3.27+
 - Qt 6.2+ (with Multimedia, Svg modules)
 - C++ compiler with C++20 support
 - Ninja build system:

--- a/README_es.md
+++ b/README_es.md
@@ -22,7 +22,7 @@ Los binarios compilados para Windows, Linux y macOS están disponibles en la [p�
 
 **Requisitos**:
 
-- CMake 3.16+
+- CMake 3.27+
 - Qt 6.2+ (con módulos Multimedia, Svg)
 - Compilador C++ con soporte para C++20
 - Sistema de compilación Ninja:

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -22,7 +22,7 @@ Binários compilados para Windows, Linux e macOS estão disponíveis na [página
 
 **Requisitos**:
 
-- CMake 3.16+
+- CMake 3.27+
 - Qt 6.2+ (com módulos Multimedia, Svg)
 - Compilador C++ com suporte a C++20
 - Sistema de compilação Ninja:


### PR DESCRIPTION
## What & why

Verifying a build under WSL (stock Ubuntu 24.04) surfaced two defects that hit anyone building from a clean Debian/Ubuntu, plus a CI gap that let them go unnoticed.

### 1. `fix(cmake)`: link `wiredpanda_lib` once instead of relying on CMP0156
`test_wiredpanda` linked `wiredpanda_lib` **twice** — whole-archived explicitly (`link_wiredpanda_whole_archive`) and again plain/transitively via the `test_utils`/`memory_helpers` static libs (`PUBLIC wiredpanda_lib`). The same archive with two link features (WHOLE_ARCHIVE vs DEFAULT) is fatal before CMP0156 (CMake 3.29), so `cmake_policy(SET CMP0156 NEW)` — set unconditionally — both papered over the duplicate **and** hard-errored on stock apt CMake (Ubuntu 24.04 ships 3.28: *"Policy CMP0156 is not known"*).

Root-cause fix: the helper libs only need `wiredpanda_lib`'s **headers** (each test exe whole-archives it directly), so they now link `$<COMPILE_ONLY:wiredpanda_lib>` — compile usage requirements, no link. `wiredpanda_lib` reaches the link line exactly once, the collision is gone, and CMP0156 is no longer needed. `$<COMPILE_ONLY>` needs CMake 3.27, so the declared minimum becomes `3.27...3.31` (3.27 was already the declared floor; the range keeps CMP0156 NEW on ≥ 3.29).

### 2. `fix(docs)`: correct the Qt6 SVG package name
`apt install … libqt6svg6-dev` fails on current Debian/Ubuntu — the package is `qt6-svg-dev` (already used by the i386 CI job). Updated BUILD.md (+ es/pt_BR), CONTRIBUTING.md, DEVELOPER_GUIDE.md. Arch's `qt6-svg` is correct and unchanged.

### 3. `ci`: weekly fresh-distro build
New `fresh-deps.yml` builds from clean `ubuntu:24.04` + `debian:trixie` containers using only the documented apt packages, so a renamed/removed package fails the run loudly. A `minimum-cmake` job pins CMake to the declared floor (3.27). Runs weekly, on demand, and on PRs touching the documented deps / CMakeLists / the workflow.

## Verification
Built on stock CMake **3.28** in WSL Ubuntu 24.04:
- `PRIVATE` (instead of `PUBLIC`) **still collides** — static-lib `PRIVATE` deps propagate as `$<LINK_ONLY>`, so it's not a fix.
- `$<COMPILE_ONLY>` configures, builds, and `test_wiredpanda TestSimulation` passes (39/39) — confirming the whole-archive static-init registrations survive dropping the redundant link.

Modern toolchains are unaffected (`wiredpanda_lib` just loses a redundant link entry), so the existing `build.yml` matrix (Linux/macOS/Windows + i386) should stay green.
