### PR TITLE
refactor: decompose MainWindow, Scene, and GraphicElement god-classes

### DIFF
--- a/App/Element/ElementAppearance.cpp
+++ b/App/Element/ElementAppearance.cpp
@@ -1,0 +1,409 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Element/ElementAppearance.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QPainter>
+#include <QPen>
+#include <QRegularExpression>
+#include <QSvgRenderer>
+
+#include "App/Core/Common.h"
+#include "App/Core/ThemeManager.h"
+#include "App/Element/GraphicElement.h"
+#include "App/Scene/Scene.h"
+
+namespace {
+
+/// Cache decoded pixmaps by resolved path so each image is loaded from disk only once.
+QHash<QString, QPixmap> &pixmapCache()
+{
+    static QHash<QString, QPixmap> cache;
+    return cache;
+}
+
+/// Cache of orientation-variant pixmaps keyed by "<resolvedPath>|<canonicalAngle>|<flipX><flipY>"
+/// so the SVG text correction is rendered only once per appearance and rotation/flip state.
+/// Both this and pixmapCache() are plain static QHashes with no locking: GraphicElement pixmaps are
+/// only built and read on the GUI thread, so concurrent access does not occur.
+QHash<QString, QPixmap> &orientedPixmapCache()
+{
+    static QHash<QString, QPixmap> cache;
+    return cache;
+}
+
+/// Rewrites \a svgBytes so every <text> element is counter-oriented about its own centre for the
+/// element's current rotation \a angle and \a flipX / \a flipY. Pre-applying the inverse of the
+/// item transform (Rotate(-angle) after the flip) means that after the element's own item-level
+/// rotation + flip the glyphs end up upright and unmirrored, while still travelling to the
+/// rotated/mirrored side. Transforming about each text's *own* centre composes cleanly with any
+/// parent transform, so it is correct regardless of how the text is nested. Returns the input
+/// unchanged on any parse failure.
+QByteArray orientSvgTextNodes(const QByteArray &svgBytes, const qreal angle, const bool flipX, const bool flipY)
+{
+    static const QRegularExpression textTag(QStringLiteral("<text\\b[^>]*>"));
+    static const QRegularExpression idAttr(QStringLiteral("\\bid\\s*=\\s*\"([^\"]*)\""));
+    static const QRegularExpression transformAttr(QStringLiteral("\\btransform\\s*="));
+
+    QString svg = QString::fromUtf8(svgBytes);
+
+    // Pass 1: ensure every <text> opening tag carries an id so boundsOnElement() can address it.
+    // Inkscape already ids these, but be defensive for hand-written assets.
+    {
+        QString out;
+        int last = 0;
+        int generated = 0;
+        auto matches = textTag.globalMatch(svg);
+        while (matches.hasNext()) {
+            const auto match = matches.next();
+            out += svg.mid(last, match.capturedStart() - last);
+            QString tag = match.captured(0);
+            if (!idAttr.match(tag).hasMatch()) {
+                // Insert after "<text" (5 chars) so the new attribute precedes the existing ones.
+                tag.insert(5, QStringLiteral(" id=\"wpflip-text-%1\"").arg(generated++));
+            }
+            out += tag;
+            last = match.capturedEnd();
+        }
+        out += svg.mid(last);
+        svg = out;
+    }
+
+    QSvgRenderer probe(svg.toUtf8());
+    if (!probe.isValid()) {
+        return svgBytes;
+    }
+
+    const qreal sx = flipX ? -1.0 : 1.0;
+    const qreal sy = flipY ? -1.0 : 1.0;
+
+    // Pass 2: inject a counter-orientation transform on each <text>, pivoting about that text's
+    // own centre. The item applies Flip ∘ Rotate(angle) to the pixmap content, so the inverse the
+    // glyph must carry is Rotate(-angle) ∘ Flip (rotate outer, scale inner). The rotate term is
+    // omitted at angle 0 and the scale term when unflipped, so the flip-only output is unchanged.
+    QString out;
+    int last = 0;
+    auto matches = textTag.globalMatch(svg);
+    while (matches.hasNext()) {
+        const auto match = matches.next();
+        out += svg.mid(last, match.capturedStart() - last);
+        QString tag = match.captured(0);
+
+        const auto idMatch = idAttr.match(tag);
+        if (idMatch.hasMatch() && !transformAttr.match(tag).hasMatch()) {
+            const QRectF bounds = probe.boundsOnElement(idMatch.captured(1));
+            if (!bounds.isEmpty()) {
+                const QPointF c = bounds.center();
+                QString ops;
+                if (angle != 0.0) {
+                    ops += QStringLiteral("rotate(%1) ").arg(-angle);
+                }
+                if (flipX || flipY) {
+                    ops += QStringLiteral("scale(%1,%2) ").arg(sx).arg(sy);
+                }
+                const QString transform =
+                    QStringLiteral(" transform=\"translate(%1,%2) %3translate(%4,%5)\"")
+                        .arg(c.x()).arg(c.y()).arg(ops).arg(-c.x()).arg(-c.y());
+                tag.insert(5, transform);
+            }
+        }
+
+        out += tag;
+        last = match.capturedEnd();
+    }
+    out += svg.mid(last);
+
+    return out.toUtf8();
+}
+
+/// Renders an orientation-variant pixmap for the SVG at \a resolvedPath with its <text> labels
+/// counter-oriented for the current rotation \a angle and flip, cached per path + angle + flip
+/// state. Returns a null pixmap on failure so callers can fall back to the plain base pixmap
+/// (which the item transform then rotates/flips).
+QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const bool flipX, const bool flipY)
+{
+    // Canonicalize to [0,360) so equivalent rotations (e.g. -90 and 270, which render identically)
+    // share one cache entry instead of growing the key space without bound — MCP can request any
+    // angle and rotate-left produces negatives.
+    const qreal canonAngle = std::fmod(std::fmod(angle, 360.0) + 360.0, 360.0);
+    const QString key = resolvedPath + QLatin1Char('|')
+        + QString::number(canonAngle) + QLatin1Char('|')
+        + (flipX ? QLatin1Char('1') : QLatin1Char('0'))
+        + (flipY ? QLatin1Char('1') : QLatin1Char('0'));
+
+    auto &cache = orientedPixmapCache();
+    const auto it = cache.constFind(key);
+    if (it != cache.constEnd()) {
+        return *it;
+    }
+
+    QFile file(resolvedPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    const QByteArray raw = file.readAll();
+    // No baked-in <text> → nothing to correct; return null so the caller keeps the plain
+    // item-flipped base pixmap (identical to legacy behaviour, no redundant re-render).
+    if (!raw.contains("<text")) {
+        return {};
+    }
+    const QByteArray modified = orientSvgTextNodes(raw, canonAngle, flipX, flipY);
+
+    QSvgRenderer renderer(modified);
+    if (!renderer.isValid()) {
+        return {};
+    }
+
+    QPixmap pixmap(renderer.defaultSize());
+    pixmap.fill(Qt::transparent);
+    QPainter painter(&pixmap);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+    renderer.render(&painter);
+    painter.end();
+
+    cache.insert(key, pixmap);
+    return pixmap;
+}
+
+} // namespace
+
+ElementAppearance::ElementAppearance(GraphicElement *owner)
+    : m_owner(owner)
+{
+}
+
+ElementAppearance::~ElementAppearance() = default;
+
+void ElementAppearance::seedFromMetadata(const QStringList &defaultAppearances,
+                                         const QStringList &alternativeAppearances,
+                                         const QString &pixmapPath)
+{
+    m_defaultAppearances = defaultAppearances;
+    m_pixmapPath = pixmapPath;
+
+    // For elements whose pixmapPath is theme-dependent (e.g. memory elements),
+    // defaultAppearances may be left empty in the metadata to avoid evaluating the
+    // theme path during static initialisation (before QApplication exists).
+    // Populate it lazily here from the now-correct pixmapPath.
+    if (m_defaultAppearances.isEmpty() && !m_pixmapPath.isEmpty()) {
+        m_defaultAppearances = QStringList({m_pixmapPath});
+    }
+
+    m_alternativeAppearances = alternativeAppearances.isEmpty() ? m_defaultAppearances : alternativeAppearances;
+}
+
+QPointF ElementAppearance::pixmapCenter() const
+{
+    return QRectF(m_pixmap.rect()).center();
+}
+
+void ElementAppearance::setPixmap(const int index)
+{
+    setPixmap(m_usingDefaultAppearance ? m_defaultAppearances.at(index) : m_alternativeAppearances.at(index));
+}
+
+void ElementAppearance::setPixmap(const QString &pixmapPath)
+{
+    // Skip if unchanged to avoid redundant loads and cache invalidation
+    if (pixmapPath.isEmpty() || (pixmapPath == m_currentPixmapPath)) {
+        return;
+    }
+
+    QString path = pixmapPath;
+
+    // Qt resource paths start with ":/"; anything else is a filesystem path
+    // relative to the project's working directory (where the .panda file lives).
+    // Try the path as-is against contextDir first; if not found, fall back to
+    // just the filename — handles cross-platform absolute paths from old files.
+    if (!path.startsWith(":/")) {
+        const QString contextDir = Scene::resolveContextDir(m_owner);
+        if (contextDir.isEmpty()) {
+            return;
+        }
+        const QDir dir(contextDir);
+        const QString resolved = dir.filePath(path);
+
+        if (!QFileInfo::exists(resolved)) {
+            path = dir.filePath(QFileInfo(QString(path).replace('\\', '/')).fileName());
+        } else {
+            path = resolved;
+        }
+    }
+
+    auto &cache = pixmapCache();
+    auto it = cache.constFind(path);
+    if (it != cache.constEnd()) {
+        m_basePixmap = *it;
+    } else if (m_basePixmap.load(path)) {
+        cache.insert(path, m_basePixmap);
+    } else {
+        const QFileInfo info(path);
+        const QString reason = !info.exists()
+                                   ? tr("File does not exist")
+                                   : !info.isReadable()
+                                         ? tr("File is not readable")
+                                         : tr("Unknown reason");
+
+        // Load the default appearance so the element remains renderable before the exception unwinds
+        m_basePixmap.load(m_defaultAppearances.constFirst());
+        m_pixmap = m_basePixmap;
+        qCDebug(zero) << "Problem loading pixmapPath: " << path;
+        throw PANDACEPTION("Couldn't load pixmap: %1 (%2)", path, reason);
+    }
+
+    m_resolvedPixmapPath = path;
+    // Derive the displayed pixmap from the base, swapping in a text-corrected variant when the
+    // element is rotated or flipped.
+    applyOrientation();
+
+    // The transform origin must be updated whenever the pixmap changes so that
+    // rotation and scale operations remain centred on the new image
+    m_owner->setTransformOriginPoint(pixmapCenter());
+    m_owner->update();
+
+    m_currentPixmapPath = pixmapPath;
+}
+
+void ElementAppearance::applyOrientation()
+{
+    // Only rotatable elements transform their graphic, so only they need the baked <text> labels
+    // counter-oriented. A non-rotatable element keeps its icon upright (it moves only its ports),
+    // so its text — if any — must render as authored and never be counter-oriented.
+    const bool oriented = m_owner->rotatesGraphic()
+        && (m_owner->isFlippedX() || m_owner->isFlippedY() || (m_owner->rotation() != 0.0));
+    if (oriented && m_resolvedPixmapPath.endsWith(QLatin1String(".svg"), Qt::CaseInsensitive)) {
+        const QPixmap variant = orientedSvgPixmap(m_resolvedPixmapPath, m_owner->rotation(), m_owner->isFlippedX(), m_owner->isFlippedY());
+        m_pixmap = variant.isNull() ? m_basePixmap : variant;
+    } else {
+        m_pixmap = m_basePixmap;
+    }
+    rebuildSvgRenderer();
+    m_owner->update();
+}
+
+void ElementAppearance::rebuildSvgRenderer()
+{
+    // render() draws this vector renderer so SVG elements stay crisp at any zoom; raster (PNG/JPG)
+    // appearances leave it null and fall back to drawing the rasterised m_pixmap.
+    if (!m_resolvedPixmapPath.endsWith(QLatin1String(".svg"), Qt::CaseInsensitive)) {
+        m_svgRenderer.reset();
+        return;
+    }
+
+    QFile file(m_resolvedPixmapPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        m_svgRenderer.reset();
+        return;
+    }
+    QByteArray svg = file.readAll();
+
+    // Counter-orient each <text> while rotated/flipped so pin labels stay upright — the same
+    // correction orientedSvgPixmap() bakes into the rasterised variant. Gated on rotatesGraphic()
+    // because a non-rotatable element never transforms its graphic, so its text stays as authored.
+    const bool oriented = m_owner->rotatesGraphic()
+        && (m_owner->isFlippedX() || m_owner->isFlippedY() || (m_owner->rotation() != 0.0));
+    if (oriented && svg.contains("<text")) {
+        svg = orientSvgTextNodes(svg, m_owner->rotation(), m_owner->isFlippedX(), m_owner->isFlippedY());
+    }
+
+    auto renderer = std::make_unique<QSvgRenderer>(svg);
+    m_svgRenderer = renderer->isValid() ? std::move(renderer) : nullptr;
+}
+
+void ElementAppearance::setAppearance(const bool defaultAppearance, const QString &fileName)
+{
+    if (defaultAppearance) {
+        m_alternativeAppearances = m_defaultAppearances;
+    } else {
+        m_alternativeAppearances[0] = fileName;
+    }
+
+    m_usingDefaultAppearance = defaultAppearance;
+    setPixmap(0);
+}
+
+void ElementAppearance::setAppearanceAt(const int index, const QString &fileName)
+{
+    if (index < 0 || index >= m_alternativeAppearances.size()) {
+        return;
+    }
+
+    if (fileName.isEmpty()) {
+        m_alternativeAppearances[index] = m_defaultAppearances.at(index);
+    } else {
+        m_alternativeAppearances[index] = fileName;
+    }
+
+    m_usingDefaultAppearance = (m_alternativeAppearances == m_defaultAppearances);
+    setPixmap(index);
+}
+
+void ElementAppearance::setAlternativeAppearanceAt(const int index, const QString &path)
+{
+    if (index < 0 || index >= m_alternativeAppearances.size()) {
+        return;
+    }
+    m_alternativeAppearances[index] = path;
+}
+
+void ElementAppearance::recomputeUsingDefault()
+{
+    m_usingDefaultAppearance = std::equal(
+        m_defaultAppearances.begin(), m_defaultAppearances.end(),
+        m_alternativeAppearances.begin(), m_alternativeAppearances.end()
+        );
+}
+
+QStringList ElementAppearance::externalFiles() const
+{
+    QStringList result;
+    for (int i = 0; i < m_alternativeAppearances.size() && i < m_defaultAppearances.size(); ++i) {
+        const QString &appearance = m_alternativeAppearances.at(i);
+        if (appearance != m_defaultAppearances.at(i) && !appearance.startsWith(":/")) {
+            result.append(appearance);
+        }
+    }
+    return result;
+}
+
+void ElementAppearance::render(QPainter *painter, const QRectF &boundingRect, const bool selected) const
+{
+    if (selected) {
+        painter->save();
+        painter->setBrush(m_selectionBrush);
+        // 0.5 pen width keeps the selection outline thin regardless of zoom level
+        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
+        // Corner radius of 5 matches the visual rounding used on element bodies
+        painter->drawRoundedRect(boundingRect, 5, 5);
+        painter->restore();
+    }
+
+    // Draw the body from vector data (crisp at any zoom) when the appearance is an SVG; fall back to
+    // the rasterised pixmap for raster (PNG/JPG) appearances. DeviceCoordinateCache re-renders this
+    // per zoom level, so the SVG stays sharp instead of scaling a fixed-size bitmap.
+    if (m_svgRenderer && m_svgRenderer->isValid()) {
+        painter->save();
+        painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing |
+                                QPainter::SmoothPixmapTransform, true);
+        // Render into the SVG's native box at the origin — the same 0,0..defaultSize the raster occupied.
+        m_svgRenderer->render(painter, QRectF(QPointF(0, 0), QSizeF(m_svgRenderer->defaultSize())));
+        painter->restore();
+    } else {
+        // Pixmap origin is always (0,0) in item coordinates; the transform origin
+        // (centre of the pixmap) is set separately via setTransformOriginPoint().
+        painter->drawPixmap(QPoint(0, 0), m_pixmap);
+    }
+}
+
+void ElementAppearance::applyTheme(const ThemeAttributes &theme)
+{
+    m_selectionBrush = theme.m_selectionBrush;
+    m_selectionPen = theme.m_selectionPen;
+}

--- a/App/Element/ElementAppearance.h
+++ b/App/Element/ElementAppearance.h
@@ -1,0 +1,140 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief Owns a GraphicElement's pixmap / SVG appearance, appearance list, and selection paint.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <QColor>
+#include <QCoreApplication>
+#include <QPixmap>
+#include <QStringList>
+
+class GraphicElement;
+class QPainter;
+class QSvgRenderer;
+class ThemeAttributes;
+
+/**
+ * \class ElementAppearance
+ * \brief Owns the visual appearance of a GraphicElement: the displayed pixmap, its SVG
+ * renderer, the default/alternative appearance lists, and the selection-highlight colors.
+ *
+ * \details Extracted from GraphicElement so the rendering bulk (pixmap loading, SVG text
+ * counter-orientation, the per-appearance caches, and the paint body) lives in one cohesive
+ * unit.  Orientation state (rotation/flip) stays on the owning element; this type reads it
+ * back through a narrow owner reference, which it also uses to trigger repaints and resolve
+ * the element's context directory.
+ */
+class ElementAppearance
+{
+    Q_DECLARE_TR_FUNCTIONS(ElementAppearance)
+
+public:
+    /// Constructs the appearance bound to its owning \a owner element.
+    explicit ElementAppearance(GraphicElement *owner);
+
+    /// Out-of-line so the unique_ptr to the forward-declared QSvgRenderer can be destroyed.
+    ~ElementAppearance();
+
+    /// Seeds the appearance lists from element metadata (lazily deriving defaults from
+    /// \a pixmapPath when \a defaultAppearances is empty; alternatives default to the defaults).
+    void seedFromMetadata(const QStringList &defaultAppearances,
+                          const QStringList &alternativeAppearances,
+                          const QString &pixmapPath);
+
+    // --- Pixmap access ---
+
+    /// Returns the pixmap currently displayed.
+    QPixmap pixmap() const { return m_pixmap; }
+
+    /// Returns the centre point of the displayed pixmap in local coordinates.
+    QPointF pixmapCenter() const;
+
+    /// Returns true if at least one default appearance is available.
+    bool hasDefaultAppearances() const { return !m_defaultAppearances.isEmpty(); }
+
+    /// Loads and applies the appearance at position \a index in the active list.
+    void setPixmap(const int index);
+
+    /// Loads and applies the pixmap located at \a pixmapPath.
+    void setPixmap(const QString &pixmapPath);
+
+    /// Replaces the displayed pixmap with a procedurally-built one (Mux/Demux/TruthTable/IC).
+    void setRenderPixmap(const QPixmap &pixmap) { m_pixmap = pixmap; }
+
+    /// Re-derives the displayed pixmap (and SVG renderer) from the owner's current orientation.
+    void applyOrientation();
+
+    // --- Appearance list ---
+
+    /// Switches the appearance: restores defaults or applies \a fileName at slot 0.
+    void setAppearance(const bool defaultAppearance, const QString &fileName);
+
+    /// Sets a custom appearance at \a index (empty \a fileName restores that slot's default).
+    void setAppearanceAt(const int index, const QString &fileName);
+
+    /// Returns the built-in default appearance paths.
+    const QStringList &defaultAppearances() const { return m_defaultAppearances; }
+
+    /// Returns the active (possibly user-customised) appearance paths.
+    const QStringList &alternativeAppearances() const { return m_alternativeAppearances; }
+
+    /// Copies the default appearances over the alternative list (restore-to-default).
+    void resetAlternativeToDefault() { m_alternativeAppearances = m_defaultAppearances; }
+
+    /// Sets one alternative-appearance slot without reloading the pixmap (serializer / subclass use).
+    void setAlternativeAppearanceAt(const int index, const QString &path);
+
+    /// Sets the "using built-in default appearance" flag.
+    void setUsingDefaultAppearance(const bool value) { m_usingDefaultAppearance = value; }
+
+    /// Returns true when the active appearance still matches the built-in default.
+    bool usingDefaultAppearance() const { return m_usingDefaultAppearance; }
+
+    /// Recomputes the using-default flag by comparing the alternative and default lists.
+    void recomputeUsingDefault();
+
+    /// Returns the external (non-resource) appearance file paths the element depends on.
+    QStringList externalFiles() const;
+
+    // --- Painting ---
+
+    /// Draws the selection highlight (when \a selected) and the SVG/pixmap body onto \a painter.
+    void render(QPainter *painter, const QRectF &boundingRect, const bool selected) const;
+
+    /// Applies the selection-highlight colors from \a theme.
+    void applyTheme(const ThemeAttributes &theme);
+
+    /// Fill color of the selection highlight rectangle.
+    QColor selectionBrush() const { return m_selectionBrush; }
+
+    /// Border color of the selection highlight rectangle.
+    QColor selectionPen() const { return m_selectionPen; }
+
+private:
+    /// Rebuilds m_svgRenderer from the resolved SVG path and the owner's orientation, or clears
+    /// it for non-SVG (raster) appearances.
+    void rebuildSvgRenderer();
+
+    GraphicElement *m_owner = nullptr;
+
+    QPixmap m_pixmap;     ///< Currently displayed pixmap.
+    QPixmap m_basePixmap; ///< Upright, unflipped pixmap; m_pixmap is derived from this.
+    std::unique_ptr<QSvgRenderer> m_svgRenderer; ///< Vector renderer for the current SVG appearance (null for raster).
+
+    QString m_pixmapPath;         ///< Resource/file path of the default pixmap (from metadata).
+    QString m_currentPixmapPath;  ///< Path last requested via setPixmap() (change guard).
+    QString m_resolvedPixmapPath; ///< Resolved path of m_basePixmap; used to build orientation variants.
+
+    QStringList m_defaultAppearances;     ///< Built-in appearance paths (resource files).
+    QStringList m_alternativeAppearances; ///< Active appearance paths (user paths override defaults).
+    bool m_usingDefaultAppearance = true; ///< True while the active appearance matches the default.
+
+    QColor m_selectionBrush; ///< Fill color for the selection highlight rectangle.
+    QColor m_selectionPen;   ///< Border color for the selection highlight rectangle.
+};

--- a/App/Element/ElementSimState.cpp
+++ b/App/Element/ElementSimState.cpp
@@ -1,0 +1,94 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Element/ElementSimState.h"
+
+#include "App/Element/GraphicElement.h"
+#include "App/Nodes/QNEPort.h"
+
+void ElementSimState::reset(const QVector<QNEOutputPort *> &outputPorts)
+{
+    // Reset each output slot to the port's power-on default so that the next
+    // BeWavedDolphin sweep starts from a known, reproducible state.
+    // Subclasses with internal edge-detection variables (flip-flops) override
+    // GraphicElement::resetSimState() to also clear those fields.
+    for (int i = 0; i < m_outputs.size(); ++i) {
+        const Status def = (i < outputPorts.size())
+                               ? outputPorts.at(i)->defaultValue()
+                               : Status::Inactive;
+        m_outputs[i] = (def == Status::Unknown) ? Status::Inactive : def;
+    }
+    m_outputChanged = true;
+}
+
+void ElementSimState::connectPredecessor(int inputIndex, GraphicElement *source, int outputPort)
+{
+    if (inputIndex >= m_connections.size()) {
+        return;
+    }
+    m_connections[inputIndex] = {source, outputPort};
+}
+
+void ElementSimState::initVectors(int inputCount, int outputCount, const QVector<QNEOutputPort *> &outputPorts)
+{
+    m_connections.fill({}, inputCount);
+    m_inputs.fill(Status::Inactive, inputCount);
+    m_outputs.resize(outputCount);
+    // Initialize outputs from port default statuses when they're explicitly set
+    // (e.g., flip-flop Q'=Active), otherwise default to Inactive.
+    // Using Inactive (not Unknown) ensures gate-level feedback loops can settle.
+    for (int i = 0; i < outputCount; ++i) {
+        if (i < outputPorts.size()) {
+            const Status def = outputPorts.at(i)->defaultValue();
+            m_outputs[i] = (def == Status::Unknown) ? Status::Inactive : def;
+        } else {
+            m_outputs[i] = Status::Inactive;
+        }
+    }
+    m_outputChanged = false;
+}
+
+bool ElementSimState::updateInputs(bool allowUnknown, const QVector<QNEInputPort *> &inputPorts)
+{
+    for (int index = 0; index < m_connections.size(); ++index) {
+        auto *pred = m_connections.at(index).sourceElement;
+        Status val;
+        if (pred) {
+            val = pred->outputValue(m_connections.at(index).sourceOutputIndex);
+        } else {
+            if (index < inputPorts.size() && inputPorts.at(index)->connections().size() > 1) {
+                val = Status::Error;  // multi-driver bus conflict
+            } else {
+                // Unconnected input: use port's default status (replaces global GND/VCC).
+                val = (index < inputPorts.size()) ? inputPorts.at(index)->defaultValue() : Status::Unknown;
+            }
+        }
+
+        // allowUnknown: only fail for truly unconnected inputs that return Unknown.
+        // !allowUnknown: fail for any Unknown or Error value.
+        const bool shouldFail = allowUnknown ? (val == Status::Unknown && !pred)
+                                             : (val == Status::Unknown || val == Status::Error);
+        if (shouldFail) {
+            for (auto &out : m_outputs) {
+                if (out != Status::Unknown) {
+                    m_outputChanged = true;
+                }
+                out = Status::Unknown;
+            }
+            return false;
+        }
+        m_inputs[index] = val;
+    }
+    return true;
+}
+
+int ElementSimState::decodeSelectValue(int offset, int count) const
+{
+    int selectValue = 0;
+    for (int i = 0; i < count; i++) {
+        if (m_inputs.at(offset + i) == Status::Active) {
+            selectValue |= (1 << i);
+        }
+    }
+    return selectValue;
+}

--- a/App/Element/ElementSimState.h
+++ b/App/Element/ElementSimState.h
@@ -1,0 +1,93 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief Per-element simulation runtime state (input/output values and the connection graph).
+ */
+
+#pragma once
+
+#include <QVector>
+
+#include "App/Core/Enums.h"
+
+class GraphicElement;
+class QNEInputPort;
+class QNEOutputPort;
+
+/**
+ * \class ElementSimState
+ * \brief Owns a GraphicElement's simulation runtime state, decoupled from its graphics.
+ *
+ * \details Holds the cached input/output four-state values, the output-changed flag, and
+ * the simulation-graph edges feeding each input.  The propagation logic reads the owning
+ * element's ports only through parameters (no back-pointer), so this type carries no Qt
+ * graphics dependency.  GraphicElement holds one as a value member and forwards its
+ * direct-simulation interface to it.
+ */
+class ElementSimState
+{
+public:
+    /// A single simulation-graph edge: which element/output port feeds one input slot.
+    struct InputConnection {
+        GraphicElement *sourceElement = nullptr;
+        int sourceOutputIndex = 0;
+    };
+
+    /// Allocates the I/O vectors and seeds outputs from \a outputPorts default statuses.
+    void initVectors(int inputCount, int outputCount, const QVector<QNEOutputPort *> &outputPorts);
+
+    /// Resets each output slot to its port's power-on default (Unknown coerced to Inactive).
+    void reset(const QVector<QNEOutputPort *> &outputPorts);
+
+    /// Records that simulation input \a inputIndex is driven by \a source output \a outputPort.
+    void connectPredecessor(int inputIndex, GraphicElement *source, int outputPort);
+
+    /**
+     * \brief Snapshots each predecessor's output into the input cache, reading \a inputPorts
+     * for unconnected-input defaults and multi-driver conflict detection.
+     * \param allowUnknown When true, only a truly unconnected Unknown input fails (combinational
+     * domination rules can still short-circuit); when false any Unknown/Error fails.
+     * \return true if simulation can proceed; false (all outputs set Unknown) otherwise.
+     */
+    bool updateInputs(bool allowUnknown, const QVector<QNEInputPort *> &inputPorts);
+
+    /// Decodes \a count select-line statuses starting at \a offset into a binary index.
+    int decodeSelectValue(int offset, int count) const;
+
+    /// Returns the four-state value on output slot \a index (Unknown if out of range).
+    Status outputValue(const int index = 0) const
+    {
+        if (index >= m_outputs.size()) { return Status::Unknown; }
+        return m_outputs.at(index);
+    }
+
+    /// Sets output slot \a index to \a value, flagging a change when it differs.
+    void setOutputValue(const int index, const Status value)
+    {
+        if (index >= m_outputs.size()) { return; }
+        if (m_outputs[index] != value) { m_outputChanged = true; }
+        m_outputs[index] = value;
+    }
+
+    /// Returns the number of simulation output slots.
+    qsizetype outputSize() const { return m_outputs.size(); }
+
+    /// Returns true if any output changed since the flag was last cleared.
+    bool outputChanged() const { return m_outputChanged; }
+
+    /// Clears the output-changed flag.
+    void clearOutputChanged() { m_outputChanged = false; }
+
+    /// Read-only view of the cached simulation input values.
+    const QVector<Status> &inputs() const { return m_inputs; }
+
+    /// Read-only view of the current simulation output values.
+    const QVector<Status> &outputs() const { return m_outputs; }
+
+private:
+    QVector<InputConnection> m_connections;
+    QVector<Status> m_inputs;
+    QVector<Status> m_outputs;
+    bool m_outputChanged = false;
+};

--- a/App/Element/GraphicElement.cpp
+++ b/App/Element/GraphicElement.cpp
@@ -39,173 +39,12 @@ static const QFont &labelFont()
     return font;
 }
 
-/// Cache decoded pixmaps by resolved path so each image is loaded from disk only once.
-static QHash<QString, QPixmap> &pixmapCache()
-{
-    static QHash<QString, QPixmap> cache;
-    return cache;
-}
-
-/// Cache of orientation-variant pixmaps keyed by "<resolvedPath>|<canonicalAngle>|<flipX><flipY>"
-/// so the SVG text correction is rendered only once per appearance and rotation/flip state.
-/// Both this and pixmapCache() are plain static QHashes with no locking: GraphicElement pixmaps are
-/// only built and read on the GUI thread, so concurrent access does not occur.
-static QHash<QString, QPixmap> &orientedPixmapCache()
-{
-    static QHash<QString, QPixmap> cache;
-    return cache;
-}
-
-/// Rewrites \a svgBytes so every <text> element is counter-oriented about its own centre for the
-/// element's current rotation \a angle and \a flipX / \a flipY. Pre-applying the inverse of the
-/// item transform (Rotate(-angle) after the flip) means that after the element's own item-level
-/// rotation + flip the glyphs end up upright and unmirrored, while still travelling to the
-/// rotated/mirrored side. Transforming about each text's *own* centre composes cleanly with any
-/// parent transform, so it is correct regardless of how the text is nested. Returns the input
-/// unchanged on any parse failure.
-static QByteArray orientSvgTextNodes(const QByteArray &svgBytes, const qreal angle, const bool flipX, const bool flipY)
-{
-    static const QRegularExpression textTag(QStringLiteral("<text\\b[^>]*>"));
-    static const QRegularExpression idAttr(QStringLiteral("\\bid\\s*=\\s*\"([^\"]*)\""));
-    static const QRegularExpression transformAttr(QStringLiteral("\\btransform\\s*="));
-
-    QString svg = QString::fromUtf8(svgBytes);
-
-    // Pass 1: ensure every <text> opening tag carries an id so boundsOnElement() can address it.
-    // Inkscape already ids these, but be defensive for hand-written assets.
-    {
-        QString out;
-        int last = 0;
-        int generated = 0;
-        auto matches = textTag.globalMatch(svg);
-        while (matches.hasNext()) {
-            const auto match = matches.next();
-            out += svg.mid(last, match.capturedStart() - last);
-            QString tag = match.captured(0);
-            if (!idAttr.match(tag).hasMatch()) {
-                // Insert after "<text" (5 chars) so the new attribute precedes the existing ones.
-                tag.insert(5, QStringLiteral(" id=\"wpflip-text-%1\"").arg(generated++));
-            }
-            out += tag;
-            last = match.capturedEnd();
-        }
-        out += svg.mid(last);
-        svg = out;
-    }
-
-    QSvgRenderer probe(svg.toUtf8());
-    if (!probe.isValid()) {
-        return svgBytes;
-    }
-
-    const qreal sx = flipX ? -1.0 : 1.0;
-    const qreal sy = flipY ? -1.0 : 1.0;
-
-    // Pass 2: inject a counter-orientation transform on each <text>, pivoting about that text's
-    // own centre. The item applies Flip ∘ Rotate(angle) to the pixmap content, so the inverse the
-    // glyph must carry is Rotate(-angle) ∘ Flip (rotate outer, scale inner). The rotate term is
-    // omitted at angle 0 and the scale term when unflipped, so the flip-only output is unchanged.
-    QString out;
-    int last = 0;
-    auto matches = textTag.globalMatch(svg);
-    while (matches.hasNext()) {
-        const auto match = matches.next();
-        out += svg.mid(last, match.capturedStart() - last);
-        QString tag = match.captured(0);
-
-        const auto idMatch = idAttr.match(tag);
-        if (idMatch.hasMatch() && !transformAttr.match(tag).hasMatch()) {
-            const QRectF bounds = probe.boundsOnElement(idMatch.captured(1));
-            if (!bounds.isEmpty()) {
-                const QPointF c = bounds.center();
-                QString ops;
-                if (angle != 0.0) {
-                    ops += QStringLiteral("rotate(%1) ").arg(-angle);
-                }
-                if (flipX || flipY) {
-                    ops += QStringLiteral("scale(%1,%2) ").arg(sx).arg(sy);
-                }
-                const QString transform =
-                    QStringLiteral(" transform=\"translate(%1,%2) %3translate(%4,%5)\"")
-                        .arg(c.x()).arg(c.y()).arg(ops).arg(-c.x()).arg(-c.y());
-                tag.insert(5, transform);
-            }
-        }
-
-        out += tag;
-        last = match.capturedEnd();
-    }
-    out += svg.mid(last);
-
-    return out.toUtf8();
-}
-
-/// Renders an orientation-variant pixmap for the SVG at \a resolvedPath with its <text> labels
-/// counter-oriented for the current rotation \a angle and flip, cached per path + angle + flip
-/// state. Returns a null pixmap on failure so callers can fall back to the plain base pixmap
-/// (which the item transform then rotates/flips).
-static QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const bool flipX, const bool flipY)
-{
-    // Canonicalize to [0,360) so equivalent rotations (e.g. -90 and 270, which render identically)
-    // share one cache entry instead of growing the key space without bound — MCP can request any
-    // angle and rotate-left produces negatives.
-    const qreal canonAngle = std::fmod(std::fmod(angle, 360.0) + 360.0, 360.0);
-    const QString key = resolvedPath + QLatin1Char('|')
-        + QString::number(canonAngle) + QLatin1Char('|')
-        + (flipX ? QLatin1Char('1') : QLatin1Char('0'))
-        + (flipY ? QLatin1Char('1') : QLatin1Char('0'));
-
-    auto &cache = orientedPixmapCache();
-    const auto it = cache.constFind(key);
-    if (it != cache.constEnd()) {
-        return *it;
-    }
-
-    QFile file(resolvedPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        return {};
-    }
-    const QByteArray raw = file.readAll();
-    // No baked-in <text> → nothing to correct; return null so the caller keeps the plain
-    // item-flipped base pixmap (identical to legacy behaviour, no redundant re-render).
-    if (!raw.contains("<text")) {
-        return {};
-    }
-    const QByteArray modified = orientSvgTextNodes(raw, canonAngle, flipX, flipY);
-
-    QSvgRenderer renderer(modified);
-    if (!renderer.isValid()) {
-        return {};
-    }
-
-    QPixmap pixmap(renderer.defaultSize());
-    pixmap.fill(Qt::transparent);
-    QPainter painter(&pixmap);
-    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
-    renderer.render(&painter);
-    painter.end();
-
-    cache.insert(key, pixmap);
-    return pixmap;
-}
-
 GraphicElement::GraphicElement(ElementType type, QGraphicsItem *parent)
     : QGraphicsObject(parent)
     , m_elementType(type)
 {
     const auto &metadata = ElementMetadataRegistry::metadata(type);
-    m_defaultAppearances = metadata.defaultAppearances;
-    m_pixmapPath = metadata.pixmapPath();
-
-    // For elements whose pixmapPath is theme-dependent (e.g. memory elements),
-    // defaultAppearances may be left empty in the metadata to avoid evaluating the
-    // theme path during static initialisation (before QApplication exists).
-    // Populate it lazily here from the now-correct pixmapPath.
-    if (m_defaultAppearances.isEmpty() && !m_pixmapPath.isEmpty()) {
-        m_defaultAppearances = QStringList({m_pixmapPath});
-    }
-
-    m_alternativeAppearances = metadata.alternativeAppearances.isEmpty() ? m_defaultAppearances : metadata.alternativeAppearances;
+    m_appearance.seedFromMetadata(metadata.defaultAppearances, metadata.alternativeAppearances, metadata.pixmapPath());
     m_titleText = QCoreApplication::translate(metadata.trContext, metadata.titleText);
     m_translatedName = QCoreApplication::translate(metadata.trContext, metadata.translatedName);
     m_elementGroup = metadata.group;
@@ -243,8 +82,8 @@ GraphicElement::GraphicElement(ElementType type, QGraphicsItem *parent)
     // giving a large speedup for elements that don't redraw on every pan/zoom
     setCacheMode(QGraphicsItem::DeviceCoordinateCache);
 
-    if (!m_defaultAppearances.isEmpty()) {
-        setPixmap(0);
+    if (m_appearance.hasDefaultAppearances()) {
+        m_appearance.setPixmap(0);
     }
 }
 
@@ -262,86 +101,22 @@ ElementGroup GraphicElement::elementGroup() const
 
 QPixmap GraphicElement::pixmap() const
 {
-    return m_pixmap;
+    return m_appearance.pixmap();
 }
 
 QStringList GraphicElement::externalFiles() const
 {
-    QStringList result;
-    for (int i = 0; i < m_alternativeAppearances.size() && i < m_defaultAppearances.size(); ++i) {
-        const QString &appearance = m_alternativeAppearances.at(i);
-        if (appearance != m_defaultAppearances.at(i) && !appearance.startsWith(":/")) {
-            result.append(appearance);
-        }
-    }
-    return result;
+    return m_appearance.externalFiles();
 }
 
 void GraphicElement::setPixmap(const int index)
 {
-    setPixmap(m_usingDefaultAppearance ? m_defaultAppearances.at(index) : m_alternativeAppearances.at(index));
+    m_appearance.setPixmap(index);
 }
 
 void GraphicElement::setPixmap(const QString &pixmapPath)
 {
-    // Skip if unchanged to avoid redundant loads and cache invalidation
-    if (pixmapPath.isEmpty() || (pixmapPath == m_currentPixmapPath)) {
-        return;
-    }
-
-    QString path = pixmapPath;
-
-    // Qt resource paths start with ":/"; anything else is a filesystem path
-    // relative to the project's working directory (where the .panda file lives).
-    // Try the path as-is against contextDir first; if not found, fall back to
-    // just the filename — handles cross-platform absolute paths from old files.
-    if (!path.startsWith(":/")) {
-        const QString contextDir = Scene::resolveContextDir(this);
-        if (contextDir.isEmpty()) {
-            return;
-        }
-        const QDir dir(contextDir);
-        const QString resolved = dir.filePath(path);
-
-        if (!QFileInfo::exists(resolved)) {
-            path = dir.filePath(QFileInfo(QString(path).replace('\\', '/')).fileName());
-        } else {
-            path = resolved;
-        }
-    }
-
-    auto &cache = pixmapCache();
-    auto it = cache.constFind(path);
-    if (it != cache.constEnd()) {
-        m_basePixmap = *it;
-    } else if (m_basePixmap.load(path)) {
-        cache.insert(path, m_basePixmap);
-    } else {
-        const QFileInfo info(path);
-        const QString reason = !info.exists()
-                                   ? tr("File does not exist")
-                                   : !info.isReadable()
-                                         ? tr("File is not readable")
-                                         : tr("Unknown reason");
-
-        // Load the default appearance so the element remains renderable before the exception unwinds
-        m_basePixmap.load(m_defaultAppearances.constFirst());
-        m_pixmap = m_basePixmap;
-        qCDebug(zero) << "Problem loading pixmapPath: " << path;
-        throw PANDACEPTION("Couldn't load pixmap: %1 (%2)", path, reason);
-    }
-
-    m_resolvedPixmapPath = path;
-    // Derive the displayed pixmap from the base, swapping in a text-corrected variant when the
-    // element is rotated or flipped.
-    applyPixmapOrientation();
-
-    // The transform origin must be updated whenever the pixmap changes so that
-    // rotation and scale operations remain centred on the new image
-    setTransformOriginPoint(pixmapCenter());
-    update();
-
-    m_currentPixmapPath = pixmapPath;
+    m_appearance.setPixmap(pixmapPath);
 }
 
 const QVector<QNEOutputPort *> &GraphicElement::outputs() const
@@ -396,7 +171,7 @@ void GraphicElement::setInputs(const QVector<QNEInputPort *> &inputs)
 
 QPointF GraphicElement::pixmapCenter() const
 {
-    return QRectF(pixmap().rect()).center();
+    return m_appearance.pixmapCenter();
 }
 
 QRectF GraphicElement::boundingRect() const
@@ -423,31 +198,7 @@ void GraphicElement::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
     Q_UNUSED(widget)
     Q_UNUSED(option)
 
-    if (isSelected()) {
-        painter->save();
-        painter->setBrush(m_selectionBrush);
-        // 0.5 pen width keeps the selection outline thin regardless of zoom level
-        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
-        // Corner radius of 5 matches the visual rounding used on element bodies
-        painter->drawRoundedRect(boundingRect(), 5, 5);
-        painter->restore();
-    }
-
-    // Draw the body from vector data (crisp at any zoom) when the appearance is an SVG; fall back to
-    // the rasterised pixmap for raster (PNG/JPG) appearances. DeviceCoordinateCache re-renders this
-    // per zoom level, so the SVG stays sharp instead of scaling a fixed-size bitmap.
-    if (m_svgRenderer && m_svgRenderer->isValid()) {
-        painter->save();
-        painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing |
-                                QPainter::SmoothPixmapTransform, true);
-        // Render into the SVG's native box at the origin — the same 0,0..defaultSize the raster occupied.
-        m_svgRenderer->render(painter, QRectF(QPointF(0, 0), QSizeF(m_svgRenderer->defaultSize())));
-        painter->restore();
-    } else {
-        // Pixmap origin is always (0,0) in item coordinates; the transform origin
-        // (centre of the pixmap) is set separately via setTransformOriginPoint().
-        painter->drawPixmap(QPoint(0, 0), pixmap());
-    }
+    m_appearance.render(painter, boundingRect(), isSelected());
 }
 
 void GraphicElement::addPort(const QString &name, const bool isOutput)
@@ -498,7 +249,7 @@ void GraphicElement::setRotation(const qreal angle)
     // around the element centre so connections track the correct positions.
     if (rotatesGraphic()) {
         QGraphicsItem::setRotation(m_angle);
-        applyPixmapOrientation();
+        m_appearance.applyOrientation();
     } else {
         rotatePorts();
     }
@@ -577,80 +328,18 @@ void GraphicElement::applyFlipTransform()
     // whose baked-in SVG <text> is pre-counter-oriented so the glyphs read upright after the
     // rotation + flip while still moving to the opposite side. No-op for an upright, unflipped or
     // non-SVG pixmap.
-    applyPixmapOrientation();
+    m_appearance.applyOrientation();
     update();
-}
-
-void GraphicElement::applyPixmapOrientation()
-{
-    // Only rotatable elements transform their graphic, so only they need the baked <text> labels
-    // counter-oriented. A non-rotatable element keeps its icon upright (it moves only its ports),
-    // so its text — if any — must render as authored and never be counter-oriented.
-    const bool oriented = rotatesGraphic() && (m_flippedX || m_flippedY || (m_angle != 0.0));
-    if (oriented && m_resolvedPixmapPath.endsWith(QLatin1String(".svg"), Qt::CaseInsensitive)) {
-        const QPixmap variant = orientedSvgPixmap(m_resolvedPixmapPath, m_angle, m_flippedX, m_flippedY);
-        m_pixmap = variant.isNull() ? m_basePixmap : variant;
-    } else {
-        m_pixmap = m_basePixmap;
-    }
-    rebuildSvgRenderer();
-    update();
-}
-
-void GraphicElement::rebuildSvgRenderer()
-{
-    // paint() draws this vector renderer so SVG elements stay crisp at any zoom; raster (PNG/JPG)
-    // appearances leave it null and fall back to drawing the rasterised m_pixmap.
-    if (!m_resolvedPixmapPath.endsWith(QLatin1String(".svg"), Qt::CaseInsensitive)) {
-        m_svgRenderer.reset();
-        return;
-    }
-
-    QFile file(m_resolvedPixmapPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        m_svgRenderer.reset();
-        return;
-    }
-    QByteArray svg = file.readAll();
-
-    // Counter-orient each <text> while rotated/flipped so pin labels stay upright — the same
-    // correction orientedSvgPixmap() bakes into the rasterised variant. Gated on rotatesGraphic()
-    // because a non-rotatable element never transforms its graphic, so its text stays as authored.
-    const bool oriented = rotatesGraphic() && (m_flippedX || m_flippedY || (m_angle != 0.0));
-    if (oriented && svg.contains("<text")) {
-        svg = orientSvgTextNodes(svg, m_angle, m_flippedX, m_flippedY);
-    }
-
-    auto renderer = std::make_unique<QSvgRenderer>(svg);
-    m_svgRenderer = renderer->isValid() ? std::move(renderer) : nullptr;
 }
 
 void GraphicElement::setAppearance(const bool defaultAppearance, const QString &fileName)
 {
-    if (defaultAppearance) {
-        m_alternativeAppearances = m_defaultAppearances;
-    } else {
-        m_alternativeAppearances[0] = fileName;
-    }
-
-    m_usingDefaultAppearance = defaultAppearance;
-    setPixmap(0);
+    m_appearance.setAppearance(defaultAppearance, fileName);
 }
 
 void GraphicElement::setAppearanceAt(const int index, const QString &fileName)
 {
-    if (index < 0 || index >= m_alternativeAppearances.size()) {
-        return;
-    }
-
-    if (fileName.isEmpty()) {
-        m_alternativeAppearances[index] = m_defaultAppearances.at(index);
-    } else {
-        m_alternativeAppearances[index] = fileName;
-    }
-
-    m_usingDefaultAppearance = (m_alternativeAppearances == m_defaultAppearances);
-    setPixmap(index);
+    m_appearance.setAppearanceAt(index, fileName);
 }
 
 QList<QPair<int, QString>> GraphicElement::appearanceStates() const
@@ -850,8 +539,7 @@ void GraphicElement::updateTheme()
     const ThemeAttributes theme = ThemeManager::attributes();
 
     m_label->setBrush(theme.m_graphicElementLabelColor);
-    m_selectionBrush = theme.m_selectionBrush;
-    m_selectionPen = theme.m_selectionPen;
+    m_appearance.applyTheme(theme);
 
     for (auto *input : std::as_const(m_inputPorts)) {
         input->updateTheme();

--- a/App/Element/GraphicElement.cpp
+++ b/App/Element/GraphicElement.cpp
@@ -1073,104 +1073,17 @@ void GraphicElement::updateLogic()
 
 void GraphicElement::resetSimState()
 {
-    // Reset each output slot to the port's power-on default so that the next
-    // BeWavedDolphin sweep starts from a known, reproducible state.
-    // Subclasses with internal edge-detection variables (flip-flops) override this
-    // to also clear those fields.
-    for (int i = 0; i < m_simOutputValues.size(); ++i) {
-        const Status def = (i < m_outputPorts.size())
-                               ? m_outputPorts.at(i)->defaultValue()
-                               : Status::Inactive;
-        m_simOutputValues[i] = (def == Status::Unknown) ? Status::Inactive : def;
-    }
-    m_simOutputChanged = true;
-}
-
-qsizetype GraphicElement::simOutputSize() const
-{
-    return m_simOutputValues.size();
+    m_sim.reset(m_outputPorts);
 }
 
 void GraphicElement::connectPredecessor(const int inputIndex, GraphicElement *source, const int outputPort)
 {
-    if (inputIndex >= m_simInputConnections.size()) {
-        return;
-    }
-    m_simInputConnections[inputIndex] = {source, outputPort};
+    m_sim.connectPredecessor(inputIndex, source, outputPort);
 }
 
 void GraphicElement::initSimulationVectors(const int inputCount, const int outputCount)
 {
-    m_simInputConnections.fill({}, inputCount);
-    m_simInputValues.fill(Status::Inactive, inputCount);
-    m_simOutputValues.resize(outputCount);
-    // Initialize outputs from port default statuses when they're explicitly set
-    // (e.g., flip-flop Q'=Active), otherwise default to Inactive.
-    // Using Inactive (not Unknown) ensures gate-level feedback loops can settle.
-    for (int i = 0; i < outputCount; ++i) {
-        if (i < m_outputPorts.size()) {
-            const Status def = m_outputPorts.at(i)->defaultValue();
-            m_simOutputValues[i] = (def == Status::Unknown) ? Status::Inactive : def;
-        } else {
-            m_simOutputValues[i] = Status::Inactive;
-        }
-    }
-    m_simOutputChanged = false;
-}
-
-bool GraphicElement::simUpdateInputsImpl(const bool allowUnknown)
-{
-    for (int index = 0; index < m_simInputConnections.size(); ++index) {
-        auto *pred = m_simInputConnections.at(index).sourceElement;
-        Status val;
-        if (pred) {
-            val = pred->outputValue(m_simInputConnections.at(index).sourceOutputIndex);
-        } else {
-            if (index < m_inputPorts.size() && m_inputPorts.at(index)->connections().size() > 1) {
-                val = Status::Error;  // multi-driver bus conflict
-            } else {
-                // Unconnected input: use port's default status (replaces global GND/VCC).
-                val = (index < m_inputPorts.size()) ? m_inputPorts.at(index)->defaultValue() : Status::Unknown;
-            }
-        }
-
-        // allowUnknown: only fail for truly unconnected inputs that return Unknown.
-        // !allowUnknown: fail for any Unknown or Error value.
-        const bool shouldFail = allowUnknown ? (val == Status::Unknown && !pred)
-                                             : (val == Status::Unknown || val == Status::Error);
-        if (shouldFail) {
-            for (auto &out : m_simOutputValues) {
-                if (out != Status::Unknown) {
-                    m_simOutputChanged = true;
-                }
-                out = Status::Unknown;
-            }
-            return false;
-        }
-        m_simInputValues[index] = val;
-    }
-    return true;
-}
-
-bool GraphicElement::simUpdateInputs()
-{
-    return simUpdateInputsImpl(false);
-}
-
-bool GraphicElement::simUpdateInputsAllowUnknown()
-{
-    return simUpdateInputsImpl(true);
-}
-
-int GraphicElement::decodeSelectValue(int offset, int count) const
-{
-    int selectValue = 0;
-    for (int i = 0; i < count; i++) {
-        if (m_simInputValues.at(offset + i) == Status::Active) {
-            selectValue |= (1 << i);
-        }
-    }
-    return selectValue;
+    m_sim.initVectors(inputCount, outputCount, m_outputPorts);
 }
 
 int GraphicElement::minOutputSize() const

--- a/App/Element/GraphicElement.h
+++ b/App/Element/GraphicElement.h
@@ -17,6 +17,7 @@
 
 #include "App/Core/Enums.h"
 #include "App/Core/ItemWithId.h"
+#include "App/Element/ElementSimState.h"
 #include "App/Element/PropertyDescriptor.h"
 
 struct SerializationContext;
@@ -360,40 +361,31 @@ public:
     virtual void resetSimState();
 
     /// Returns the four-state signal value on simulation output port \a index.
-    inline Status outputValue(const int index = 0) const
-    {
-        if (index >= m_simOutputValues.size()) { return Status::Unknown; }
-        return m_simOutputValues.at(index);
-    }
+    inline Status outputValue(const int index = 0) const { return m_sim.outputValue(index); }
 
     /// Returns the number of simulation output slots.
-    qsizetype simOutputSize() const;
+    qsizetype simOutputSize() const { return m_sim.outputSize(); }
 
     /// Sets simulation output port \a index to \a value.
-    inline void setOutputValue(const int index, const Status value)
-    {
-        if (index >= m_simOutputValues.size()) { return; }
-        if (m_simOutputValues[index] != value) { m_simOutputChanged = true; }
-        m_simOutputValues[index] = value;
-    }
+    inline void setOutputValue(const int index, const Status value) { m_sim.setOutputValue(index, value); }
 
     /// Sets simulation output port 0 to \a value.
-    inline void setOutputValue(const Status value) { setOutputValue(0, value); }
+    inline void setOutputValue(const Status value) { m_sim.setOutputValue(0, value); }
 
     /// Convenience overload — converts \c bool to Active/Inactive for port \a index.
-    void setOutputValue(const int index, const bool value) { setOutputValue(index, value ? Status::Active : Status::Inactive); }
+    void setOutputValue(const int index, const bool value) { m_sim.setOutputValue(index, value ? Status::Active : Status::Inactive); }
 
     /// Convenience overload — converts \c bool to Active/Inactive for port 0.
-    void setOutputValue(const bool value) { setOutputValue(value ? Status::Active : Status::Inactive); }
+    void setOutputValue(const bool value) { m_sim.setOutputValue(0, value ? Status::Active : Status::Inactive); }
 
     /// Connects simulation input \a inputIndex to output \a outputPort of \a source element.
     void connectPredecessor(const int inputIndex, GraphicElement *source, const int outputPort);
 
     /// Returns \c true if any simulation output changed since the last query (and resets the flag).
-    bool outputChanged() const { return m_simOutputChanged; }
+    bool outputChanged() const { return m_sim.outputChanged(); }
 
     /// Clears the simulation output-changed flag.
-    void clearOutputChanged() { m_simOutputChanged = false; }
+    void clearOutputChanged() { m_sim.clearOutputChanged(); }
 
     /// Allocates simulation I/O vectors with \a inputs inputs and \a outputs outputs.
     void initSimulationVectors(const int inputCount, const int outputCount);
@@ -443,10 +435,10 @@ public:
     void setPortName(const QString &name);
 
     /// Read-only view of the cached simulation input values.
-    const QVector<Status> &simInputs() const { return m_simInputValues; }
+    const QVector<Status> &simInputs() const { return m_sim.inputs(); }
 
     /// Read-only view of the current simulation output values.
-    const QVector<Status> &simOutputs() const { return m_simOutputValues; }
+    const QVector<Status> &simOutputs() const { return m_sim.outputs(); }
 
     // --- Theme ---
 
@@ -557,7 +549,7 @@ protected:
      *
      * \return \c true if all inputs are Active or Inactive (simulation can proceed).
      */
-    bool simUpdateInputs();
+    bool simUpdateInputs() { return m_sim.updateInputs(false, m_inputPorts); }
 
     /**
      * \brief Like simUpdateInputs(), but allows Unknown/Error values through.
@@ -566,7 +558,7 @@ protected:
      * Only a truly unconnected input (null predecessor whose port default
      * is Unknown) triggers an early all-outputs-Unknown return.
      */
-    bool simUpdateInputsAllowUnknown();
+    bool simUpdateInputsAllowUnknown() { return m_sim.updateInputs(true, m_inputPorts); }
 
     /**
      * \brief Decodes \a count select-line statuses from simInputs() into a binary index.
@@ -575,7 +567,7 @@ protected:
      * \return An integer where bit i is 1 if simInputs()[offset+i] == Active.
      * \details Used by Mux and Demux to convert select-line signals into a data-port index.
      */
-    int decodeSelectValue(int offset, int count) const;
+    int decodeSelectValue(int offset, int count) const { return m_sim.decodeSelectValue(offset, count); }
 
 private:
     // --- Flip Transform ---
@@ -616,8 +608,6 @@ private:
     /// Erases \a deletedPort's serial-ID entry from \a portMap during deserialization.
     static void removePortFromMap(QNEPort *deletedPort, QMap<quint64, QNEPort *> &portMap);
 
-    /// Shared implementation for simUpdateInputs() and simUpdateInputsAllowUnknown().
-    bool simUpdateInputsImpl(const bool allowUnknown);
     /// Removes input ports beyond \a inputSize_ (used when the loaded port count exceeds current limits).
     void removeSurplusInputs(const quint64 inputSize_, SerializationContext &context);
     /// Removes output ports beyond \a outputSize_ (used when the loaded port count exceeds current limits).
@@ -678,20 +668,9 @@ private:
 
     // --- Members: Direct Simulation ---
 
-    /**
-     * \brief Describes a single simulation-graph edge: which element and output
-     * port feeds into one of this element's input slots.
-     * \details Used by simUpdateInputs() to traverse the simulation graph.
-     */
-    struct SimInputConnection {
-        GraphicElement *sourceElement = nullptr;
-        int sourceOutputIndex = 0;
-    };
-
-    QVector<SimInputConnection> m_simInputConnections;
-    QVector<Status> m_simInputValues;
-    QVector<Status> m_simOutputValues;
-    bool m_simOutputChanged = false;
+    /// Owns the simulation runtime state (I/O values + connection graph); this element
+    /// forwards its direct-simulation interface here.  See ElementSimState.
+    ElementSimState m_sim;
 
     // --- Members: Trigger & Label ---
 

--- a/App/Element/GraphicElement.h
+++ b/App/Element/GraphicElement.h
@@ -17,6 +17,7 @@
 
 #include "App/Core/Enums.h"
 #include "App/Core/ItemWithId.h"
+#include "App/Element/ElementAppearance.h"
 #include "App/Element/ElementSimState.h"
 #include "App/Element/PropertyDescriptor.h"
 
@@ -502,39 +503,22 @@ protected:
     /// Sets the minimum number of output ports to \a minOutputSize.
     void setMinOutputSize(const int minOutputSize);
 
-    /// Path to all default appearances. The default appearance is in a resource file.
-    QStringList m_defaultAppearances;
-
-    /// Path to all custom appearances. Custom appearance names are system file paths defined by the user.
-    QStringList m_alternativeAppearances;
-
     /// All input ports owned by this element (ordered by index).
     QVector<QNEInputPort *> m_inputPorts;
 
     /// All output ports owned by this element (ordered by index).
     QVector<QNEOutputPort *> m_outputPorts;
 
-    /// Current pixmap displayed for this GraphicElement.
-    QPixmap m_pixmap;
+    /// Owns the pixmap/SVG appearance, the appearance list, and selection-highlight colors;
+    /// this element forwards its rendering and appearance interface here.  See ElementAppearance.
+    ElementAppearance m_appearance{this};
 
-    /// Upright, unflipped pixmap loaded for the current appearance. m_pixmap is derived from this:
-    /// it equals m_basePixmap normally, or a text-corrected SVG variant while rotated or flipped.
-    QPixmap m_basePixmap;
-
-    /// Vector renderer for the current SVG appearance (with labels counter-oriented while rotated/
-    /// flipped), drawn by paint() so the element stays crisp at any zoom. Null for raster appearances.
-    std::unique_ptr<QSvgRenderer> m_svgRenderer;
-
-    QColor m_selectionBrush; ///< Fill color used to draw the selection highlight rectangle.
-    QColor m_selectionPen;   ///< Border color used to draw the selection highlight rectangle.
     QGraphicsSimpleTextItem *m_label = new QGraphicsSimpleTextItem(this); ///< Child text item that displays the label and optional trigger shortcut.
 
     // --- Members: Metadata ---
 
-    QString m_pixmapPath;     ///< Resource or file path of the element's default pixmap (from metadata).
     QString m_titleText;      ///< Translated title text shown in UI panels (from metadata).
     QString m_translatedName; ///< Translated element name used as tooltip and port object name.
-    bool m_usingDefaultAppearance = true; ///< True when the active appearance matches the built-in default appearances.
 
     // --- Direct Simulation Helpers ---
 
@@ -574,16 +558,6 @@ private:
 
     /// Recomputes the QGraphicsItem transform from the current flip flags.
     void applyFlipTransform();
-
-    /// Selects m_pixmap from m_basePixmap, substituting a text-corrected SVG variant while the
-    /// element is rotated or flipped so baked-in <text> labels stay upright after the item-level
-    /// rotation + flip.
-    void applyPixmapOrientation();
-
-    /// Rebuilds m_svgRenderer from the current resolved SVG path and orientation (reusing the
-    /// <text> counter-orientation), or clears it for non-SVG (raster) appearances. Called whenever
-    /// the appearance or rotation/flip state changes, via applyPixmapOrientation().
-    void rebuildSvgRenderer();
 
     /// Orients \a port for the current rotation + flip state (used by non-rotatable elements,
     /// which keep their pixmap fixed). Applies Rotate(centre, m_angle) then Flip about the
@@ -676,9 +650,6 @@ private:
 
     QKeySequence m_trigger;
     QString m_labelText;
-
-    QString m_currentPixmapPath;
-    QString m_resolvedPixmapPath; ///< Resolved file/resource path of m_basePixmap; used to build orientation variants.
 
     // --- Members: Capabilities & Display State ---
 

--- a/App/Element/GraphicElementInput.cpp
+++ b/App/Element/GraphicElementInput.cpp
@@ -25,11 +25,11 @@ void GraphicElementInput::setWaveformValue(const bool value, const int port)
 void GraphicElementInput::setAppearance(const bool defaultAppearance, const QString &fileName)
 {
     if (defaultAppearance) {
-        m_alternativeAppearances = m_defaultAppearances;
+        m_appearance.resetAlternativeToDefault();
     } else {
-        m_alternativeAppearances[static_cast<int>(m_isOn)] = fileName;
+        m_appearance.setAlternativeAppearanceAt(static_cast<int>(m_isOn), fileName);
     }
 
-    m_usingDefaultAppearance = defaultAppearance;
+    m_appearance.setUsingDefaultAppearance(defaultAppearance);
     setPixmap(static_cast<int>(m_isOn));
 }

--- a/App/Element/GraphicElementSerializer.cpp
+++ b/App/Element/GraphicElementSerializer.cpp
@@ -127,7 +127,7 @@ void GraphicElement::save(QDataStream &stream) const
 
     QList<QMap<QString, QVariant>> appearancesMap;
 
-    for (const auto &appearance : m_alternativeAppearances) {
+    for (const auto &appearance : m_appearance.alternativeAppearances()) {
         QMap<QString, QVariant> tempMap;
         tempMap.insert("skinName", appearance.startsWith(":/") ? appearance : QFileInfo(appearance).fileName());
         appearancesMap << tempMap;
@@ -329,16 +329,16 @@ void GraphicElement::loadNewFormat(QDataStream &stream, SerializationContext &co
     int index = 0;
 
     for (const auto &entry : std::as_const(appearancesMap)) {
-        if (index >= m_alternativeAppearances.size()) {
+        if (index >= m_appearance.alternativeAppearances().size()) {
             throw PANDACEPTION("Appearance index %1 out of range (size=%2) — stream may be corrupt",
                                QString::number(index),
-                               QString::number(m_alternativeAppearances.size()));
+                               QString::number(m_appearance.alternativeAppearances().size()));
         }
 
         const QString name = entry.value("skinName").toString();
 
         if (!name.startsWith(":/")) {
-            m_alternativeAppearances[index] = name;
+            m_appearance.setAlternativeAppearanceAt(index, name);
         }
 
         ++index;
@@ -346,10 +346,7 @@ void GraphicElement::loadNewFormat(QDataStream &stream, SerializationContext &co
 
     // If all alternative appearance slots still match the defaults, the user never
     // applied a custom appearance — record that so the "Reset to default" action works.
-    m_usingDefaultAppearance = std::equal(
-        m_defaultAppearances.begin(), m_defaultAppearances.end(),
-        m_alternativeAppearances.begin(), m_alternativeAppearances.end()
-        );
+    m_appearance.recomputeUsingDefault();
 
     refresh();
 
@@ -551,10 +548,7 @@ void GraphicElement::loadPixmapAppearanceNames(QDataStream &stream, Serializatio
             loadPixmapAppearanceName(stream, static_cast<int>(i), context.contextDir);
         }
 
-        m_usingDefaultAppearance = std::equal(
-            m_defaultAppearances.begin(), m_defaultAppearances.end(),
-            m_alternativeAppearances.begin(), m_alternativeAppearances.end()
-            );
+        m_appearance.recomputeUsingDefault();
 
         refresh();
     }
@@ -564,9 +558,9 @@ void GraphicElement::loadPixmapAppearanceName(QDataStream &stream, const int ind
 {
     const QString name = Serialization::readBoundedString(stream);
 
-    if (index >= m_alternativeAppearances.size()) {
+    if (index >= m_appearance.alternativeAppearances().size()) {
         throw PANDACEPTION("Appearance index %1 out of range (size=%2) for appearance name \"%3\" — stream may be corrupt",
-                           QString::number(index), QString::number(m_alternativeAppearances.size()), name);
+                           QString::number(index), QString::number(m_appearance.alternativeAppearances().size()), name);
     }
 
     // Only override the alternative appearance if it is a filesystem path; resource
@@ -574,9 +568,9 @@ void GraphicElement::loadPixmapAppearanceName(QDataStream &stream, const int ind
     // potentially missing saved path from an older project file.
     if (!name.startsWith(":/")) {
         if (!contextDir.isEmpty() && QDir::isRelativePath(name)) {
-            m_alternativeAppearances[index] = contextDir + "/" + name;
+            m_appearance.setAlternativeAppearanceAt(index, contextDir + "/" + name);
         } else {
-            m_alternativeAppearances[index] = name;
+            m_appearance.setAlternativeAppearanceAt(index, name);
         }
     }
 }

--- a/App/Element/GraphicElements/Demux.cpp
+++ b/App/Element/GraphicElements/Demux.cpp
@@ -157,7 +157,7 @@ void Demux::generatePixmap()
           << QPointF(42 - fillInset, bodyTop + fillInset);
     painter.drawPolygon(inner);
 
-    m_pixmap = tempPixmap;
+    m_appearance.setRenderPixmap(tempPixmap);
 }
 
 void Demux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -167,8 +167,8 @@ void Demux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWi
 
     if (isSelected()) {
         painter->save();
-        painter->setBrush(m_selectionBrush);
-        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
+        painter->setBrush(m_appearance.selectionBrush());
+        painter->setPen(QPen(m_appearance.selectionPen(), 0.5, Qt::SolidLine));
         painter->drawRoundedRect(portsBoundingRect().united(QRectF(0, 0, 64, 64)), 5, 5);
         painter->restore();
     }

--- a/App/Element/GraphicElements/Display14.cpp
+++ b/App/Element/GraphicElements/Display14.cpp
@@ -65,21 +65,21 @@ struct ElementInfo<Display14> {
 Display14::Display14(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display14, parent)
 {
-    a  = Display7::cachedSegmentColors(m_defaultAppearances.at(1));
-    b  = Display7::cachedSegmentColors(m_defaultAppearances.at(2));
-    c  = Display7::cachedSegmentColors(m_defaultAppearances.at(3));
-    d  = Display7::cachedSegmentColors(m_defaultAppearances.at(4));
-    e  = Display7::cachedSegmentColors(m_defaultAppearances.at(5));
-    f  = Display7::cachedSegmentColors(m_defaultAppearances.at(6));
-    g1 = Display7::cachedSegmentColors(m_defaultAppearances.at(7));
-    g2 = Display7::cachedSegmentColors(m_defaultAppearances.at(8));
-    h  = Display7::cachedSegmentColors(m_defaultAppearances.at(9));
-    j  = Display7::cachedSegmentColors(m_defaultAppearances.at(10));
-    k  = Display7::cachedSegmentColors(m_defaultAppearances.at(11));
-    l  = Display7::cachedSegmentColors(m_defaultAppearances.at(12));
-    m  = Display7::cachedSegmentColors(m_defaultAppearances.at(13));
-    n  = Display7::cachedSegmentColors(m_defaultAppearances.at(14));
-    dp = Display7::cachedSegmentColors(m_defaultAppearances.at(15));
+    a  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(1));
+    b  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(2));
+    c  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(3));
+    d  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(4));
+    e  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(5));
+    f  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(6));
+    g1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(7));
+    g2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(8));
+    h  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(9));
+    j  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(10));
+    k  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(11));
+    l  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(12));
+    m  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(13));
+    n  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(14));
+    dp = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(15));
 
     Display14::updatePortsProperties();
 }

--- a/App/Element/GraphicElements/Display16.cpp
+++ b/App/Element/GraphicElements/Display16.cpp
@@ -67,23 +67,23 @@ struct ElementInfo<Display16> {
 Display16::Display16(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display16, parent)
 {
-    a1 = Display7::cachedSegmentColors(m_defaultAppearances.at(1));
-    a2 = Display7::cachedSegmentColors(m_defaultAppearances.at(2));
-    b  = Display7::cachedSegmentColors(m_defaultAppearances.at(3));
-    c  = Display7::cachedSegmentColors(m_defaultAppearances.at(4));
-    d1 = Display7::cachedSegmentColors(m_defaultAppearances.at(5));
-    d2 = Display7::cachedSegmentColors(m_defaultAppearances.at(6));
-    e  = Display7::cachedSegmentColors(m_defaultAppearances.at(7));
-    f  = Display7::cachedSegmentColors(m_defaultAppearances.at(8));
-    g1 = Display7::cachedSegmentColors(m_defaultAppearances.at(9));
-    g2 = Display7::cachedSegmentColors(m_defaultAppearances.at(10));
-    h  = Display7::cachedSegmentColors(m_defaultAppearances.at(11));
-    j  = Display7::cachedSegmentColors(m_defaultAppearances.at(12));
-    k  = Display7::cachedSegmentColors(m_defaultAppearances.at(13));
-    l  = Display7::cachedSegmentColors(m_defaultAppearances.at(14));
-    m  = Display7::cachedSegmentColors(m_defaultAppearances.at(15));
-    n  = Display7::cachedSegmentColors(m_defaultAppearances.at(16));
-    dp = Display7::cachedSegmentColors(m_defaultAppearances.at(17));
+    a1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(1));
+    a2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(2));
+    b  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(3));
+    c  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(4));
+    d1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(5));
+    d2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(6));
+    e  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(7));
+    f  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(8));
+    g1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(9));
+    g2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(10));
+    h  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(11));
+    j  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(12));
+    k  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(13));
+    l  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(14));
+    m  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(15));
+    n  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(16));
+    dp = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(17));
 
     Display16::updatePortsProperties();
 }

--- a/App/Element/GraphicElements/Display7.cpp
+++ b/App/Element/GraphicElements/Display7.cpp
@@ -60,14 +60,14 @@ struct ElementInfo<Display7> {
 Display7::Display7(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display7, parent)
 {
-    a  = cachedSegmentColors(m_defaultAppearances.at(1));
-    b  = cachedSegmentColors(m_defaultAppearances.at(2));
-    c  = cachedSegmentColors(m_defaultAppearances.at(3));
-    d  = cachedSegmentColors(m_defaultAppearances.at(4));
-    e  = cachedSegmentColors(m_defaultAppearances.at(5));
-    f  = cachedSegmentColors(m_defaultAppearances.at(6));
-    g  = cachedSegmentColors(m_defaultAppearances.at(7));
-    dp = cachedSegmentColors(m_defaultAppearances.at(8));
+    a  = cachedSegmentColors(m_appearance.defaultAppearances().at(1));
+    b  = cachedSegmentColors(m_appearance.defaultAppearances().at(2));
+    c  = cachedSegmentColors(m_appearance.defaultAppearances().at(3));
+    d  = cachedSegmentColors(m_appearance.defaultAppearances().at(4));
+    e  = cachedSegmentColors(m_appearance.defaultAppearances().at(5));
+    f  = cachedSegmentColors(m_appearance.defaultAppearances().at(6));
+    g  = cachedSegmentColors(m_appearance.defaultAppearances().at(7));
+    dp = cachedSegmentColors(m_appearance.defaultAppearances().at(8));
 
     Display7::updatePortsProperties();
 }

--- a/App/Element/GraphicElements/InputRotary.cpp
+++ b/App/Element/GraphicElements/InputRotary.cpp
@@ -50,8 +50,8 @@ struct ElementInfo<InputRotary> {
 InputRotary::InputRotary(QGraphicsItem *parent)
     : GraphicElementInput(ElementType::InputRotary, parent)
 {
-    m_rotary = m_defaultAppearances.at(0);
-    m_arrow  = m_defaultAppearances.at(1);
+    m_rotary = m_appearance.defaultAppearances().at(0);
+    m_arrow  = m_appearance.defaultAppearances().at(1);
 
     setLocked(false);
 
@@ -316,12 +316,12 @@ void InputRotary::load(QDataStream &stream, SerializationContext &context)
 void InputRotary::setAppearance(const bool defaultAppearance, const QString &fileName)
 {
     if (defaultAppearance) {
-        m_alternativeAppearances = m_defaultAppearances;
+        m_appearance.resetAlternativeToDefault();
     } else {
-        m_alternativeAppearances[0] = fileName;
+        m_appearance.setAlternativeAppearanceAt(0, fileName);
     }
 
-    m_usingDefaultAppearance = defaultAppearance;
+    m_appearance.setUsingDefaultAppearance(defaultAppearance);
     setPixmap(0);
 }
 

--- a/App/Element/GraphicElements/Led.cpp
+++ b/App/Element/GraphicElements/Led.cpp
@@ -82,8 +82,7 @@ Led::Led(QGraphicsItem *parent)
     // base offset for the chosen color (0=White, 2=Red, 4=Green, 6=Blue, 8=Purple).
     // Even indices are the Off state; odd indices are the On state.
     // Indices 10-25 cover multi-input (2/3/4-bit) color palettes (see comment below).
-    m_defaultAppearances = ElementMetadataRegistry::metadata(ElementType::Led).defaultAppearances;
-    m_alternativeAppearances = m_defaultAppearances;
+    m_appearance.seedFromMetadata(ElementMetadataRegistry::metadata(ElementType::Led).defaultAppearances, {}, {});
     setPixmap(0);
 
     setHasColors(true);
@@ -223,14 +222,14 @@ void Led::setAppearance(const bool useDefaultAppearance, const QString &fileName
     const int index = colorIndex();
 
     if (useDefaultAppearance) {
-        m_alternativeAppearances = m_defaultAppearances;
+        m_appearance.resetAlternativeToDefault();
     } else {
         // Replace only the appearance for the currently active color/state, so other
         // color states continue to use their default images.
-        m_alternativeAppearances[index] = fileName;
+        m_appearance.setAlternativeAppearanceAt(index, fileName);
     }
 
-    m_usingDefaultAppearance = useDefaultAppearance;
+    m_appearance.setUsingDefaultAppearance(useDefaultAppearance);
     setPixmap(index);
 }
 

--- a/App/Element/GraphicElements/Mux.cpp
+++ b/App/Element/GraphicElements/Mux.cpp
@@ -125,7 +125,7 @@ void Mux::generatePixmap()
           << QPointF(42 - fillInset, bodyTop + rightInset + fillInset - 2);
     painter.drawPolygon(inner);
 
-    m_pixmap = tempPixmap;
+    m_appearance.setRenderPixmap(tempPixmap);
 }
 
 void Mux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -135,8 +135,8 @@ void Mux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
 
     if (isSelected()) {
         painter->save();
-        painter->setBrush(m_selectionBrush);
-        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
+        painter->setBrush(m_appearance.selectionBrush());
+        painter->setPen(QPen(m_appearance.selectionPen(), 0.5, Qt::SolidLine));
         painter->drawRoundedRect(portsBoundingRect().united(QRectF(0, 0, 64, 64)), 5, 5);
         painter->restore();
     }

--- a/App/Element/GraphicElements/TruthTable.cpp
+++ b/App/Element/GraphicElements/TruthTable.cpp
@@ -135,7 +135,7 @@ void TruthTable::generatePixmap()
     const QSize size = portsBoundingRect().united(QRectF(0, 0, 64, 64)).size().toSize();
     QPixmap sizingPixmap(size);
     sizingPixmap.fill(Qt::transparent);
-    m_pixmap = sizingPixmap;
+    m_appearance.setRenderPixmap(sizingPixmap);
     GraphicElement::update();
 }
 
@@ -180,8 +180,8 @@ void TruthTable::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
 
     if (isSelected()) {
         painter->save();
-        painter->setBrush(m_selectionBrush);
-        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
+        painter->setBrush(m_appearance.selectionBrush());
+        painter->setPen(QPen(m_appearance.selectionPen(), 0.5, Qt::SolidLine));
         // Expand the highlight rect to cover any ports that extend outside the 64x64 body
         painter->drawRoundedRect(portsBoundingRect().united(QRectF(0, 0, 64, 64)), 5, 5);
         painter->restore();

--- a/App/Element/IC.cpp
+++ b/App/Element/IC.cpp
@@ -570,7 +570,7 @@ void IC::generatePixmap()
     const QSize size = portsBoundingRect().united(QRectF(0, 0, 64, 64)).size().toSize();
     QPixmap sizingPixmap(size);
     sizingPixmap.fill(Qt::transparent);
-    m_pixmap = sizingPixmap;
+    m_appearance.setRenderPixmap(sizingPixmap);
     update();
 }
 
@@ -731,8 +731,8 @@ void IC::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidge
 
     if (isSelected()) {
         painter->save();
-        painter->setBrush(m_selectionBrush);
-        painter->setPen(QPen(m_selectionPen, 0.5, Qt::SolidLine));
+        painter->setBrush(m_appearance.selectionBrush());
+        painter->setPen(QPen(m_appearance.selectionPen(), 0.5, Qt::SolidLine));
         painter->drawRoundedRect(boundingRect(), 5, 5);
         painter->restore();
     }

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -52,10 +52,9 @@ Scene::Scene(QObject *parent)
     // (e.g., to detect Ctrl+drag for cloning before Qt's default drag-selection activates)
     installEventFilter(this);
 
-    // The rubber-band selection rectangle must not itself be selectable or it would
-    // appear in selectedItems() and interfere with element operations
-    m_selectionRect.setFlag(QGraphicsItem::ItemIsSelectable, false);
-    addItem(&m_selectionRect);
+    // Attach the interaction layer: adds its rubber-band selection rectangle to the
+    // scene and starts its drag throttle timer.
+    m_interaction.attachToScene();
 
     m_undoAction = new QAction(tr("&Undo"), this);
     m_undoAction->setEnabled(false);
@@ -72,9 +71,6 @@ Scene::Scene(QObject *parent)
     connect(&m_undoStack, &QUndoStack::canRedoChanged, m_redoAction, &QAction::setEnabled);
     connect(&m_undoStack, &QUndoStack::redoTextChanged, this, &Scene::updateRedoText);
     connect(m_redoAction, &QAction::triggered, &m_undoStack, &QUndoStack::redo);
-
-    // Used to throttle expensive operations during drag (e.g., ensureVisible)
-    m_timer.start();
 
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged, this, &Scene::updateTheme);
     // Emit autosave signal only after each undo-stack index change (not on every internal state update)
@@ -409,7 +405,7 @@ void Scene::resizeScene()
 {
     const auto bounds = itemsBoundingRect();
 
-    if (m_draggingElement) {
+    if (m_interaction.isDraggingElement()) {
         // While dragging, only expand the scene rect (union with current rect).
         // Never shrink during drag — shrinking shifts the viewport origin and
         // causes jarring visual jumps as the scene rect chases the items.
@@ -470,8 +466,7 @@ void Scene::updateTheme()
     const ThemeAttributes theme = ThemeManager::attributes();
     setBackgroundBrush(theme.m_sceneBgBrush);
     setDots(QPen(theme.m_sceneBgDots));
-    m_selectionRect.setBrush(QBrush(theme.m_selectionBrush));
-    m_selectionRect.setPen(QPen(theme.m_selectionPen, 1, Qt::SolidLine));
+    m_interaction.applyTheme(theme);
 
     for (auto *element : elements()) {
         element->updateTheme();
@@ -507,15 +502,6 @@ void Scene::showGates(const bool checked)
 void Scene::showWires(const bool checked)
 {
     m_visibilityManager.showWires(checked);
-}
-
-void Scene::startSelectionRect()
-{
-    m_selectionStartPoint = m_mousePos;
-    m_markingSelectionBox = true;
-    m_selectionRect.setRect(QRectF(m_selectionStartPoint, m_selectionStartPoint));
-    m_selectionRect.show();
-    m_selectionRect.update();
 }
 
 GraphicsView *Scene::view() const
@@ -558,7 +544,7 @@ void Scene::updateRedoText(const QString &text)
 
 void Scene::contextMenu(const QPoint screenPos)
 {
-    if (auto *item = itemAt(m_mousePos)) {
+    if (auto *item = itemAt(m_interaction.lastMousePos())) {
         // Right-clicking a selected item opens the property context menu for that selection
         if (selectedItems().contains(item)) {
             emit contextMenuPos(screenPos, item);
@@ -778,81 +764,9 @@ bool Scene::eventFilter(QObject *watched, QEvent *event)
 
 void Scene::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    m_mousePos = event->scenePos();
-    m_connectionManager.updateHover(m_mousePos);
-
-    auto *item = itemAt(m_mousePos);
-
-    if (item) {
-        // --- Element selection and drag preparation ---
-        if (event->button() == Qt::LeftButton) {
-            if (event->modifiers().testFlag(Qt::ControlModifier)) {
-                // Ctrl+click toggles individual item membership in the selection
-                item->setSelected(!item->isSelected());
-            }
-
-            auto selectedElements_ = selectedElements();
-
-            // Include the clicked element even if it isn't yet selected, so a
-            // single-click drag of an unselected element works immediately
-            if (auto *element = qgraphicsitem_cast<GraphicElement *>(item)) {
-                selectedElements_ << element;
-            }
-
-            m_draggingElement = ((item->type() == GraphicElement::Type) && !selectedElements_.isEmpty());
-            if (m_draggingElement) {
-                sentryBreadcrumb("ui", QStringLiteral("Drag started: %1 element(s)").arg(selectedElements_.size()));
-            }
-
-            // Snapshot positions now; MoveCommand compares these against release-time positions.
-            // QPointer in m_dragSnapshot lets entries auto-clear if the element is destroyed
-            // before release (e.g. Delete shortcut while mid-drag — see WIREDPANDA-H9).
-            m_dragSnapshot.clear();
-            m_dragSnapshot.reserve(selectedElements_.size());
-
-            for (auto *element : std::as_const(selectedElements_)) {
-                m_dragSnapshot.append({element, element->pos()});
-            }
-        }
-
-        // --- Wire connection handling ---
-        if (item->type() == QNEPort::Type) {
-            /* When the mouse is pressed over an connected input port, the line
-             * is disconnected and can be connected to another port. */
-            if (m_connectionManager.hasEditedConnection()) {
-                // An in-progress wire exists; try to complete it at this port
-                m_connectionManager.tryComplete(m_mousePos);
-                return;
-            }
-
-            auto *pressedPort = qgraphicsitem_cast<QNEPort *>(item);
-
-            if (auto *startPort = dynamic_cast<QNEOutputPort *>(pressedPort)) {
-                m_connectionManager.startFromOutput(startPort);
-                return;
-            }
-
-            if (auto *endPort = dynamic_cast<QNEInputPort *>(pressedPort)) {
-                // Empty input port: begin a new wire; occupied port: detach the existing wire
-                endPort->connections().isEmpty() ? m_connectionManager.startFromInput(endPort) : m_connectionManager.detach(endPort);
-                return;
-            }
-        }
+    if (!m_interaction.mousePress(event)) {
+        QGraphicsScene::mousePressEvent(event);
     }
-
-    // Clicking on empty space while a wire is being drawn cancels it
-        m_connectionManager.cancel();
-
-    if (!item && (event->button() == Qt::LeftButton)) {
-        startSelectionRect();
-    }
-
-    if (event->button() == Qt::RightButton) {
-        contextMenu(event->screenPos());
-        return;
-    }
-
-    QGraphicsScene::mousePressEvent(event);
 }
 
 void Scene::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
@@ -863,118 +777,31 @@ void Scene::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     // scrolling to satisfy the H-margin violates the V-margin, so the replay
     // triggers another ensureVisible() that does the opposite, oscillating
     // until a stack overflow. Dropping the re-entrant call breaks the loop.
+    // The guard lives here, not in SceneInteraction, because it must wrap the
+    // base-class call below where the re-entrancy actually originates.
     if (m_handlingMouseMove) {
         return;
     }
     m_handlingMouseMove = true;
     const auto resetFlag = qScopeGuard([this] { m_handlingMouseMove = false; });
 
-    m_mousePos = event->scenePos();
-    m_connectionManager.updateHover(m_mousePos);
-
-    // Expand scene rect while dragging so elements can be moved beyond the current boundary,
-    // and auto-scroll the viewport to follow the cursor.
-    if (m_draggingElement) {
-        resizeScene();
-
-        if (m_timer.elapsed() > 50) {
-            const auto viewList = views();
-            if (!viewList.isEmpty()) {
-                viewList.first()->ensureVisible(m_mousePos.x(), m_mousePos.y(), 1, 1, 50, 50);
-            }
-            m_timer.restart();
-        }
+    if (!m_interaction.mouseMove(event)) {
+        QGraphicsScene::mouseMoveEvent(event);
     }
-
-    // --- In-progress wire routing ---
-    if (m_connectionManager.hasEditedConnection()) {
-        m_connectionManager.updateEditedEnd(m_mousePos);
-        return;
-    }
-
-    // --- Rubber-band selection rectangle ---
-    if (m_markingSelectionBox) {
-        const QRectF rect = QRectF(m_selectionStartPoint, m_mousePos).normalized();
-        m_selectionRect.setRect(rect);
-        QPainterPath selectionBox;
-        selectionBox.addRect(rect);
-        setSelectionArea(selectionBox);
-    }
-
-    QGraphicsScene::mouseMoveEvent(event);
 }
 
 void Scene::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (m_draggingElement && (event->button() == Qt::LeftButton)) {
-        bool moved = false;
-
-        if (!m_dragSnapshot.empty()) {
-            // Filter out elements destroyed mid-drag (their QPointers are now null).
-            // Without this, dereferencing a freed element below crashes the app.
-            QList<GraphicElement *> liveElements;
-            QList<QPointF> liveOldPositions;
-            liveElements.reserve(m_dragSnapshot.size());
-            liveOldPositions.reserve(m_dragSnapshot.size());
-
-            for (const auto &[ptr, oldPos] : std::as_const(m_dragSnapshot)) {
-                if (ptr) {
-                    liveElements.append(ptr.data());
-                    liveOldPositions.append(oldPos);
-                }
-            }
-
-            // Only push a MoveCommand if at least one surviving element actually changed
-            // position; avoids polluting the undo stack with no-op moves (click without drag).
-            for (int i = 0; i < liveElements.size(); ++i) {
-                if (liveElements.at(i)->pos() != liveOldPositions.at(i)) {
-                    moved = true;
-                    break;
-                }
-            }
-
-            if (moved) {
-                receiveCommand(new MoveCommand(liveElements, liveOldPositions, this));
-            }
-        }
-
-        sentryBreadcrumb("ui", moved ? QStringLiteral("Drag ended: moved") : QStringLiteral("Drag ended: no move"));
-        m_draggingElement = false;
-        m_dragSnapshot.clear();
-
-        // Only tighten scene rect after an actual drag; a click-without-move
-        // should not trigger a rect change that could shift the viewport.
-        if (moved) {
-            resizeScene();
-        }
+    if (!m_interaction.mouseRelease(event)) {
+        QGraphicsScene::mouseReleaseEvent(event);
     }
-
-    m_selectionRect.hide();
-    m_markingSelectionBox = false;
-
-    // Complete an in-progress wire on mouse release (when no button is held)
-    // — this handles the drag-to-connect gesture (press output → drag → release on input)
-    if (m_connectionManager.hasEditedConnection() && (event->buttons() == Qt::NoButton)) {
-        m_connectionManager.tryComplete(m_mousePos);
-        return;
-    }
-
-    QGraphicsScene::mouseReleaseEvent(event);
 }
 
 void Scene::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (event->modifiers().testFlag(Qt::ControlModifier)) {
-        return;
+    if (!m_interaction.mouseDoubleClick(event)) {
+        QGraphicsScene::mouseDoubleClickEvent(event);
     }
-
-    // Double-click on a fully connected wire inserts a routing node at the click point,
-    // splitting the wire into two segments; guard ensures it's not a dangling wire
-    if (auto *connection = qgraphicsitem_cast<QNEConnection *>(itemAt(m_mousePos)); connection && connection->startPort() && connection->endPort()) {
-        receiveCommand(new SplitCommand(connection, m_mousePos, this));
-    }
-
-    QGraphicsScene::mouseDoubleClickEvent(event);
 }
 
 void Scene::addItem(QMimeData *mimeData)

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -138,62 +138,47 @@ void Scene::removeItem(QGraphicsItem *item)
 
 ItemWithId *Scene::itemById(const int id) const
 {
-    return m_elementRegistry.value(id, nullptr);
+    return m_itemRegistry.itemById(id);
 }
 
 bool Scene::contains(const int id) const
 {
-    return m_elementRegistry.contains(id);
+    return m_itemRegistry.contains(id);
 }
 
 int Scene::lastId() const
 {
-    return m_lastId;
+    return m_itemRegistry.lastId();
 }
 
 void Scene::setLastId(const int newLastId)
 {
-    m_lastId = qMax(m_lastId, newLastId);
+    m_itemRegistry.setLastId(newLastId);
 }
 
 int Scene::nextId()
 {
-    return ++m_lastId;
+    return m_itemRegistry.nextId();
 }
 
 void Scene::updateItemId(ItemWithId *item, const int newId)
 {
-    // Called before addItem() to pre-assign a specific ID (undo/redo restore path).
-    // The item is not yet in the registry; addItem() will preserve this positive ID.
-    item->setId(newId);
-    setLastId(newId);
+    m_itemRegistry.updateItemId(item, newId);
 }
 
 void Scene::forgetItemId(const int id)
 {
-    m_elementRegistry.remove(id);
+    m_itemRegistry.forgetItemId(id);
 }
 
 void Scene::registerItem(ItemWithId *item)
 {
-    if (!item) {
-        return;
-    }
-    // HC invariant: an id must map to exactly one live item — never to a stale pointer
-    // left behind by a missed unregisterItem (the WIREDPANDA-HC family upstream condition)
-    Q_ASSERT(!m_elementRegistry.contains(item->id())
-          || m_elementRegistry.value(item->id()) == item);
-    m_elementRegistry[item->id()] = item;
+    m_itemRegistry.registerItem(item);
 }
 
 void Scene::unregisterItem(ItemWithId *item)
 {
-    if (!item) {
-        return;
-    }
-    m_elementRegistry.remove(item->id());
-    // HC postcondition: after unregister, the registry must not still resolve this id
-    Q_ASSERT(!m_elementRegistry.contains(item->id()));
+    m_itemRegistry.unregisterItem(item);
 }
 
 SerializationContext Scene::deserializationContext(QMap<quint64, QNEPort *> &portMap, const QVersionNumber &version)

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -681,18 +681,9 @@ void Scene::flipVertically()
     }
 }
 
-bool Scene::isSupportedDropFormat(const QMimeData *mimeData)
-{
-    const auto &formats = mimeData->formats();
-    return formats.contains(MimeType::DragDropLegacy)
-           || formats.contains(MimeType::CloneDragLegacy)
-           || formats.contains(MimeType::DragDrop)
-           || formats.contains(MimeType::CloneDrag);
-}
-
 void Scene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
 {
-    if (isSupportedDropFormat(event->mimeData())) {
+    if (SceneDropHandler::isSupportedDropFormat(event->mimeData())) {
         event->accept();
         return;
     }
@@ -702,105 +693,12 @@ void Scene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
 
 void Scene::dragMoveEvent(QGraphicsSceneDragDropEvent *event)
 {
-    if (isSupportedDropFormat(event->mimeData())) {
+    if (SceneDropHandler::isSupportedDropFormat(event->mimeData())) {
         event->accept();
         return;
     }
 
     QGraphicsScene::dragMoveEvent(event);
-}
-
-void Scene::handleNewElementDrop(QGraphicsSceneDragDropEvent *event)
-{
-    // Both MIME types carry the same payload; the newer format has a namespaced key
-    QByteArray itemData;
-
-    if (event->mimeData()->hasFormat(MimeType::DragDropLegacy)) {
-        itemData = event->mimeData()->data(MimeType::DragDropLegacy);
-    }
-
-    if (event->mimeData()->hasFormat(MimeType::DragDrop)) {
-        itemData = event->mimeData()->data(MimeType::DragDrop);
-    }
-
-    QDataStream stream(&itemData, QIODevice::ReadOnly);
-    Serialization::readPandaHeader(stream);
-
-    QPoint offset;      stream >> offset;
-    ElementType type;   stream >> type;
-    QString icFileName; stream >> icFileName;
-
-    bool isEmbedded = false;
-    QString blobName;
-    if (!stream.atEnd()) { stream >> isEmbedded; }
-    if (!stream.atEnd()) { stream >> blobName; }
-
-    // Subtract the drag offset so the element lands under the original grab point
-    QPointF pos = event->scenePos() - offset;
-    qCDebug(zero) << type << " at position: " << pos.x() << ", " << pos.y() << ", label: " << icFileName;
-
-    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
-    qCDebug(zero) << "Valid element.";
-
-    if (isEmbedded && type == ElementType::IC) {
-        if (!m_icRegistry.initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
-            return;
-        }
-    } else {
-        // loadFromDrop can throw on malformed files; unique_ptr keeps the
-        // freshly-allocated element from leaking when it does.
-        element->loadFromDrop(icFileName, contextDir());
-    }
-
-    qCDebug(zero) << "Adding the element to the scene.";
-    auto *raw = element.release();
-    receiveCommand(new AddItemsCommand({raw}, this));
-
-    qCDebug(zero) << "Cleaning the selection.";
-    clearSelection();
-
-    qCDebug(zero) << "Setting created element as selected.";
-    raw->setSelected(true);
-
-    qCDebug(zero) << "Adjusting the position of the element.";
-    raw->setPos(pos);
-}
-
-void Scene::handleCloneDrag(QGraphicsSceneDragDropEvent *event)
-{
-    QByteArray itemData;
-
-    if (event->mimeData()->hasFormat(MimeType::CloneDragLegacy)) {
-        itemData = event->mimeData()->data(MimeType::CloneDragLegacy);
-    }
-
-    if (event->mimeData()->hasFormat(MimeType::CloneDrag)) {
-        itemData = event->mimeData()->data(MimeType::CloneDrag);
-    }
-
-    QDataStream stream(&itemData, QIODevice::ReadOnly);
-    QVersionNumber version = Serialization::readPandaHeader(stream);
-
-    // offset = mouse position at drag-start; recompute drop offset from current position
-    QPointF offset; stream >> offset;
-    QPointF ctr;    stream >> ctr;
-    offset = event->scenePos() - offset;
-
-    QMap<quint64, QNEPort *> portMap;
-    auto context = deserializationContext(portMap, version);
-    const auto itemList = Serialization::deserialize(stream, context);
-
-    receiveCommand(new AddItemsCommand(itemList, this));
-    clearSelection();
-
-    for (auto *item : itemList) {
-        if (item->type() == GraphicElement::Type) {
-            item->setPos((item->pos() + offset));
-            item->setSelected(true);
-        }
-    }
-
-    resizeScene();
 }
 
 void Scene::dropEvent(QGraphicsSceneDragDropEvent *event)
@@ -809,12 +707,12 @@ void Scene::dropEvent(QGraphicsSceneDragDropEvent *event)
 
     if (event->mimeData()->hasFormat(MimeType::DragDropLegacy)
         || event->mimeData()->hasFormat(MimeType::DragDrop)) {
-        handleNewElementDrop(event);
+        m_dropHandler.handleNewElementDrop(event);
     }
 
     if (event->mimeData()->hasFormat(MimeType::CloneDragLegacy)
         || event->mimeData()->hasFormat(MimeType::CloneDrag)) {
-        handleCloneDrag(event);
+        m_dropHandler.handleCloneDrag(event);
     }
 
     QGraphicsScene::dropEvent(event);
@@ -1081,44 +979,5 @@ void Scene::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
 
 void Scene::addItem(QMimeData *mimeData)
 {
-    QByteArray itemData = mimeData->hasFormat(MimeType::DragDrop)
-        ? mimeData->data(MimeType::DragDrop)
-        : mimeData->data(MimeType::DragDropLegacy);
-    QDataStream stream(&itemData, QIODevice::ReadOnly);
-    Serialization::readPandaHeader(stream);
-
-    QPoint offset;      stream >> offset;
-    ElementType type;   stream >> type;
-    QString icFileName; stream >> icFileName;
-
-    bool isEmbedded = false;
-    QString blobName;
-    if (!stream.atEnd()) { stream >> isEmbedded; }
-    if (!stream.atEnd()) { stream >> blobName; }
-
-    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
-    qCDebug(zero) << "Valid element.";
-
-    // RAII for mimeData too — the original deleteLater at the bottom is
-    // unreachable if loadFromDrop throws, so the QMimeData would leak alongside
-    // the half-built element.
-    auto mimeGuard = qScopeGuard([mimeData]() { mimeData->deleteLater(); });
-
-    if (isEmbedded && type == ElementType::IC) {
-        if (!m_icRegistry.initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
-            return;
-        }
-    } else {
-        element->loadFromDrop(icFileName, contextDir());
-    }
-
-    qCDebug(zero) << "Adding the element to the scene.";
-    auto *raw = element.release();
-    receiveCommand(new AddItemsCommand({raw}, this));
-
-    qCDebug(zero) << "Cleaning the selection.";
-    clearSelection();
-
-    qCDebug(zero) << "Setting created element as selected.";
-    raw->setSelected(true);
+    m_dropHandler.addFromMimeData(mimeData);
 }

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -21,6 +21,7 @@
 #include "App/Scene/ClipboardManager.h"
 #include "App/Scene/ConnectionManager.h"
 #include "App/Scene/PropertyShortcutHandler.h"
+#include "App/Scene/SceneItemRegistry.h"
 #include "App/Scene/VisibilityManager.h"
 #include "App/Simulation/Simulation.h"
 
@@ -355,8 +356,7 @@ private:
 
     // Per-scene element registry (must be declared before m_selectionRect so it is
     // initialized before the Scene constructor calls addItem(&m_selectionRect))
-    QMap<int, ItemWithId *> m_elementRegistry;
-    int m_lastId = 0;
+    SceneItemRegistry m_itemRegistry;
 
     // Rendering
     QPen m_dots;

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -7,12 +7,10 @@
 
 #pragma once
 
-#include <QElapsedTimer>
 #include <QGraphicsScene>
 #include <QHash>
 #include <QMap>
 #include <QMimeData>
-#include <QPointer>
 #include <QUndoCommand>
 #include <QVersionNumber>
 
@@ -22,6 +20,7 @@
 #include "App/Scene/ConnectionManager.h"
 #include "App/Scene/PropertyShortcutHandler.h"
 #include "App/Scene/SceneDropHandler.h"
+#include "App/Scene/SceneInteraction.h"
 #include "App/Scene/SceneItemRegistry.h"
 #include "App/Scene/VisibilityManager.h"
 #include "App/Simulation/Simulation.h"
@@ -165,7 +164,10 @@ public:
     QGraphicsItem *itemAt(QPointF pos);
 
     /// Returns the last known mouse position in scene coordinates.
-    [[nodiscard]] QPointF mousePos() const { return m_mousePos; }
+    [[nodiscard]] QPointF mousePos() const { return m_interaction.lastMousePos(); }
+
+    /// Opens the element/selection context menu at \a screenPos (driven by SceneInteraction on right-click).
+    void contextMenu(const QPoint screenPos);
 
     // --- Adding Items ---
 
@@ -321,13 +323,11 @@ private:
     QList<QGraphicsItem *> itemsAt(const QPointF pos);
     const QVector<QNEConnection *> connections();
     void checkUpdateRequest();
-    void contextMenu(const QPoint screenPos);
     void updateUndoText(const QString &text);
     void updateRedoText(const QString &text);
     void drawBackground(QPainter *painter, const QRectF &rect) override;
     void rotate(const int angle);
     void setDots(const QPen &dots);
-    void startSelectionRect();
 
     /// Registers \a item's current ID in the scene registry. Called by addItem().
     void registerItem(ItemWithId *item);
@@ -347,25 +347,15 @@ private:
     // Simulation
     Simulation m_simulation;
 
-    // Per-scene element registry (must be declared before m_selectionRect so it is
-    // initialized before the Scene constructor calls addItem(&m_selectionRect))
+    // Per-scene element registry (delegated to SceneItemRegistry)
     SceneItemRegistry m_itemRegistry;
 
     // Rendering
     QPen m_dots;
-    QGraphicsRectItem m_selectionRect;
 
-    // Mouse / interaction state
-    QElapsedTimer m_timer;
-    QPointF m_mousePos;
-    QPointF m_selectionStartPoint;
-    /// Drag-state snapshot: each entry pairs an element with its press-time
-    /// position. QPointer auto-clears if the element is destroyed mid-drag
-    /// (e.g. user presses Delete while holding the mouse), preventing a
-    /// dangling-pointer dereference in mouseReleaseEvent.
-    QList<QPair<QPointer<GraphicElement>, QPointF>> m_dragSnapshot;
-    bool m_draggingElement = false;
-    bool m_markingSelectionBox = false;
+    // Mouse-move re-entrancy guard. Stays on Scene (not SceneInteraction) because it
+    // must wrap the base QGraphicsScene::mouseMoveEvent call, where the re-entrancy
+    // (ensureVisible → replayLastMouseEvent → mouseMoveEvent) actually originates.
     bool m_handlingMouseMove = false;
 
     // Context directory (directory of the .panda file owning this scene)
@@ -391,4 +381,7 @@ private:
 
     // Drag-and-drop payload decoding (delegated to SceneDropHandler)
     SceneDropHandler m_dropHandler{this};
+
+    // Mouse-driven editing gestures + rubber-band selection (delegated to SceneInteraction)
+    SceneInteraction m_interaction{this};
 };

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -21,6 +21,7 @@
 #include "App/Scene/ClipboardManager.h"
 #include "App/Scene/ConnectionManager.h"
 #include "App/Scene/PropertyShortcutHandler.h"
+#include "App/Scene/SceneDropHandler.h"
 #include "App/Scene/SceneItemRegistry.h"
 #include "App/Scene/VisibilityManager.h"
 #include "App/Simulation/Simulation.h"
@@ -317,14 +318,6 @@ protected:
 private:
     // --- Helpers ---
 
-    /// Returns \c true if \a mimeData contains any recognised wiRedPanda drop format.
-    static bool isSupportedDropFormat(const QMimeData *mimeData);
-
-    /// Handles a new-element drop from the toolbox palette.
-    void handleNewElementDrop(QGraphicsSceneDragDropEvent *event);
-    /// Handles a clone drag (Ctrl+drag of an existing selection).
-    void handleCloneDrag(QGraphicsSceneDragDropEvent *event);
-
     QList<QGraphicsItem *> itemsAt(const QPointF pos);
     const QVector<QNEConnection *> connections();
     void checkUpdateRequest();
@@ -395,4 +388,7 @@ private:
 
     // Visibility control (delegated to VisibilityManager)
     VisibilityManager m_visibilityManager{this};
+
+    // Drag-and-drop payload decoding (delegated to SceneDropHandler)
+    SceneDropHandler m_dropHandler{this};
 };

--- a/App/Scene/SceneDropHandler.cpp
+++ b/App/Scene/SceneDropHandler.cpp
@@ -1,0 +1,172 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Scene/SceneDropHandler.h"
+
+#include <memory>
+
+#include <QGraphicsSceneDragDropEvent>
+#include <QMimeData>
+#include <QtGlobal>
+
+#include "App/Core/Common.h"
+#include "App/Core/Enums.h"
+#include "App/Core/MimeTypes.h"
+#include "App/Element/ElementFactory.h"
+#include "App/Element/GraphicElement.h"
+#include "App/Element/IC.h"
+#include "App/Element/ICRegistry.h"
+#include "App/IO/Serialization.h"
+#include "App/Scene/Commands.h"
+#include "App/Scene/Scene.h"
+
+SceneDropHandler::SceneDropHandler(Scene *scene)
+    : m_scene(scene)
+{
+}
+
+bool SceneDropHandler::isSupportedDropFormat(const QMimeData *mimeData)
+{
+    const auto &formats = mimeData->formats();
+    return formats.contains(MimeType::DragDropLegacy)
+           || formats.contains(MimeType::CloneDragLegacy)
+           || formats.contains(MimeType::DragDrop)
+           || formats.contains(MimeType::CloneDrag);
+}
+
+void SceneDropHandler::handleNewElementDrop(QGraphicsSceneDragDropEvent *event)
+{
+    // Both MIME types carry the same payload; the newer format has a namespaced key
+    QByteArray itemData;
+
+    if (event->mimeData()->hasFormat(MimeType::DragDropLegacy)) {
+        itemData = event->mimeData()->data(MimeType::DragDropLegacy);
+    }
+
+    if (event->mimeData()->hasFormat(MimeType::DragDrop)) {
+        itemData = event->mimeData()->data(MimeType::DragDrop);
+    }
+
+    QDataStream stream(&itemData, QIODevice::ReadOnly);
+    Serialization::readPandaHeader(stream);
+
+    QPoint offset;      stream >> offset;
+    ElementType type;   stream >> type;
+    QString icFileName; stream >> icFileName;
+
+    bool isEmbedded = false;
+    QString blobName;
+    if (!stream.atEnd()) { stream >> isEmbedded; }
+    if (!stream.atEnd()) { stream >> blobName; }
+
+    // Subtract the drag offset so the element lands under the original grab point
+    QPointF pos = event->scenePos() - offset;
+    qCDebug(zero) << type << " at position: " << pos.x() << ", " << pos.y() << ", label: " << icFileName;
+
+    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
+    qCDebug(zero) << "Valid element.";
+
+    if (isEmbedded && type == ElementType::IC) {
+        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
+            return;
+        }
+    } else {
+        // loadFromDrop can throw on malformed files; unique_ptr keeps the
+        // freshly-allocated element from leaking when it does.
+        element->loadFromDrop(icFileName, m_scene->contextDir());
+    }
+
+    qCDebug(zero) << "Adding the element to the scene.";
+    auto *raw = element.release();
+    m_scene->receiveCommand(new AddItemsCommand({raw}, m_scene));
+
+    qCDebug(zero) << "Cleaning the selection.";
+    m_scene->clearSelection();
+
+    qCDebug(zero) << "Setting created element as selected.";
+    raw->setSelected(true);
+
+    qCDebug(zero) << "Adjusting the position of the element.";
+    raw->setPos(pos);
+}
+
+void SceneDropHandler::handleCloneDrag(QGraphicsSceneDragDropEvent *event)
+{
+    QByteArray itemData;
+
+    if (event->mimeData()->hasFormat(MimeType::CloneDragLegacy)) {
+        itemData = event->mimeData()->data(MimeType::CloneDragLegacy);
+    }
+
+    if (event->mimeData()->hasFormat(MimeType::CloneDrag)) {
+        itemData = event->mimeData()->data(MimeType::CloneDrag);
+    }
+
+    QDataStream stream(&itemData, QIODevice::ReadOnly);
+    QVersionNumber version = Serialization::readPandaHeader(stream);
+
+    // offset = mouse position at drag-start; recompute drop offset from current position
+    QPointF offset; stream >> offset;
+    QPointF ctr;    stream >> ctr;
+    offset = event->scenePos() - offset;
+
+    QMap<quint64, QNEPort *> portMap;
+    auto context = m_scene->deserializationContext(portMap, version);
+    const auto itemList = Serialization::deserialize(stream, context);
+
+    m_scene->receiveCommand(new AddItemsCommand(itemList, m_scene));
+    m_scene->clearSelection();
+
+    for (auto *item : itemList) {
+        if (item->type() == GraphicElement::Type) {
+            item->setPos((item->pos() + offset));
+            item->setSelected(true);
+        }
+    }
+
+    m_scene->resizeScene();
+}
+
+void SceneDropHandler::addFromMimeData(QMimeData *mimeData)
+{
+    QByteArray itemData = mimeData->hasFormat(MimeType::DragDrop)
+        ? mimeData->data(MimeType::DragDrop)
+        : mimeData->data(MimeType::DragDropLegacy);
+    QDataStream stream(&itemData, QIODevice::ReadOnly);
+    Serialization::readPandaHeader(stream);
+
+    QPoint offset;      stream >> offset;
+    ElementType type;   stream >> type;
+    QString icFileName; stream >> icFileName;
+
+    bool isEmbedded = false;
+    QString blobName;
+    if (!stream.atEnd()) { stream >> isEmbedded; }
+    if (!stream.atEnd()) { stream >> blobName; }
+
+    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
+    qCDebug(zero) << "Valid element.";
+
+    // RAII for mimeData too — the original deleteLater at the bottom is
+    // unreachable if loadFromDrop throws, so the QMimeData would leak alongside
+    // the half-built element.
+    auto mimeGuard = qScopeGuard([mimeData]() { mimeData->deleteLater(); });
+
+    if (isEmbedded && type == ElementType::IC) {
+        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
+            return;
+        }
+    } else {
+        element->loadFromDrop(icFileName, m_scene->contextDir());
+    }
+
+    qCDebug(zero) << "Adding the element to the scene.";
+    auto *raw = element.release();
+    m_scene->receiveCommand(new AddItemsCommand({raw}, m_scene));
+
+    qCDebug(zero) << "Cleaning the selection.";
+    m_scene->clearSelection();
+
+    qCDebug(zero) << "Setting created element as selected.";
+    raw->setSelected(true);
+}

--- a/App/Scene/SceneDropHandler.h
+++ b/App/Scene/SceneDropHandler.h
@@ -1,0 +1,43 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief SceneDropHandler: decodes drag-and-drop payloads into scene elements.
+ */
+
+#pragma once
+
+class QGraphicsSceneDragDropEvent;
+class QMimeData;
+class Scene;
+
+/**
+ * \class SceneDropHandler
+ * \brief Decodes wiRedPanda drag-and-drop payloads (new element from the palette,
+ * and clone-drag of an existing selection) and commits them to the owning Scene.
+ *
+ * \details Extracted from Scene, following the ConnectionManager pattern: it holds a
+ * back-reference to the Scene and delegates element creation, undo commands, and
+ * scene resizing back to it. Scene keeps the QGraphicsScene drag/drop event
+ * overrides and forwards the payload handling here.
+ */
+class SceneDropHandler
+{
+public:
+    explicit SceneDropHandler(Scene *scene);
+
+    /// Returns \c true if \a mimeData carries any recognised wiRedPanda drop format.
+    static bool isSupportedDropFormat(const QMimeData *mimeData);
+
+    /// Builds a new element from a palette drag payload and adds it under the cursor.
+    void handleNewElementDrop(QGraphicsSceneDragDropEvent *event);
+
+    /// Re-instantiates a clone-dragged selection at the drop position.
+    void handleCloneDrag(QGraphicsSceneDragDropEvent *event);
+
+    /// Adds a new element from \a mimeData (palette drop path); takes ownership of \a mimeData.
+    void addFromMimeData(QMimeData *mimeData);
+
+private:
+    Scene *m_scene;
+};

--- a/App/Scene/SceneInteraction.cpp
+++ b/App/Scene/SceneInteraction.cpp
@@ -1,0 +1,241 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Scene/SceneInteraction.h"
+
+#include <utility>
+
+#include <QBrush>
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsView>
+#include <QPainterPath>
+#include <QPen>
+
+#include "App/Core/SentryHelpers.h"
+#include "App/Core/ThemeManager.h"
+#include "App/Element/GraphicElement.h"
+#include "App/Nodes/QNEConnection.h"
+#include "App/Nodes/QNEPort.h"
+#include "App/Scene/Commands.h"
+#include "App/Scene/ConnectionManager.h"
+#include "App/Scene/Scene.h"
+
+SceneInteraction::SceneInteraction(Scene *scene)
+    : m_scene(scene)
+{
+}
+
+void SceneInteraction::attachToScene()
+{
+    // The rubber-band selection rectangle must not itself be selectable or it would
+    // appear in selectedItems() and interfere with element operations
+    m_selectionRect.setFlag(QGraphicsItem::ItemIsSelectable, false);
+    m_scene->addItem(&m_selectionRect);
+
+    // Used to throttle expensive operations during drag (e.g., ensureVisible)
+    m_timer.start();
+}
+
+void SceneInteraction::applyTheme(const ThemeAttributes &theme)
+{
+    m_selectionRect.setBrush(QBrush(theme.m_selectionBrush));
+    m_selectionRect.setPen(QPen(theme.m_selectionPen, 1, Qt::SolidLine));
+}
+
+void SceneInteraction::startSelectionRect()
+{
+    m_selectionStartPoint = m_mousePos;
+    m_markingSelectionBox = true;
+    m_selectionRect.setRect(QRectF(m_selectionStartPoint, m_selectionStartPoint));
+    m_selectionRect.show();
+    m_selectionRect.update();
+}
+
+bool SceneInteraction::mousePress(QGraphicsSceneMouseEvent *event)
+{
+    m_mousePos = event->scenePos();
+    m_scene->connectionManager()->updateHover(m_mousePos);
+
+    auto *item = m_scene->itemAt(m_mousePos);
+
+    if (item) {
+        // --- Element selection and drag preparation ---
+        if (event->button() == Qt::LeftButton) {
+            if (event->modifiers().testFlag(Qt::ControlModifier)) {
+                // Ctrl+click toggles individual item membership in the selection
+                item->setSelected(!item->isSelected());
+            }
+
+            auto selectedElements_ = m_scene->selectedElements();
+
+            // Include the clicked element even if it isn't yet selected, so a
+            // single-click drag of an unselected element works immediately
+            if (auto *element = qgraphicsitem_cast<GraphicElement *>(item)) {
+                selectedElements_ << element;
+            }
+
+            m_draggingElement = ((item->type() == GraphicElement::Type) && !selectedElements_.isEmpty());
+            if (m_draggingElement) {
+                sentryBreadcrumb("ui", QStringLiteral("Drag started: %1 element(s)").arg(selectedElements_.size()));
+            }
+
+            // Snapshot positions now; MoveCommand compares these against release-time positions.
+            // QPointer in m_dragSnapshot lets entries auto-clear if the element is destroyed
+            // before release (e.g. Delete shortcut while mid-drag — see WIREDPANDA-H9).
+            m_dragSnapshot.clear();
+            m_dragSnapshot.reserve(selectedElements_.size());
+
+            for (auto *element : std::as_const(selectedElements_)) {
+                m_dragSnapshot.append({element, element->pos()});
+            }
+        }
+
+        // --- Wire connection handling ---
+        if (item->type() == QNEPort::Type) {
+            /* When the mouse is pressed over an connected input port, the line
+             * is disconnected and can be connected to another port. */
+            if (m_scene->connectionManager()->hasEditedConnection()) {
+                // An in-progress wire exists; try to complete it at this port
+                m_scene->connectionManager()->tryComplete(m_mousePos);
+                return true;
+            }
+
+            auto *pressedPort = qgraphicsitem_cast<QNEPort *>(item);
+
+            if (auto *startPort = dynamic_cast<QNEOutputPort *>(pressedPort)) {
+                m_scene->connectionManager()->startFromOutput(startPort);
+                return true;
+            }
+
+            if (auto *endPort = dynamic_cast<QNEInputPort *>(pressedPort)) {
+                // Empty input port: begin a new wire; occupied port: detach the existing wire
+                endPort->connections().isEmpty() ? m_scene->connectionManager()->startFromInput(endPort) : m_scene->connectionManager()->detach(endPort);
+                return true;
+            }
+        }
+    }
+
+    // Clicking on empty space while a wire is being drawn cancels it
+    m_scene->connectionManager()->cancel();
+
+    if (!item && (event->button() == Qt::LeftButton)) {
+        startSelectionRect();
+    }
+
+    if (event->button() == Qt::RightButton) {
+        m_scene->contextMenu(event->screenPos());
+        return true;
+    }
+
+    return false;
+}
+
+bool SceneInteraction::mouseMove(QGraphicsSceneMouseEvent *event)
+{
+    m_mousePos = event->scenePos();
+    m_scene->connectionManager()->updateHover(m_mousePos);
+
+    // Expand scene rect while dragging so elements can be moved beyond the current boundary,
+    // and auto-scroll the viewport to follow the cursor.
+    if (m_draggingElement) {
+        m_scene->resizeScene();
+
+        if (m_timer.elapsed() > 50) {
+            const auto viewList = m_scene->views();
+            if (!viewList.isEmpty()) {
+                viewList.first()->ensureVisible(m_mousePos.x(), m_mousePos.y(), 1, 1, 50, 50);
+            }
+            m_timer.restart();
+        }
+    }
+
+    // --- In-progress wire routing ---
+    if (m_scene->connectionManager()->hasEditedConnection()) {
+        m_scene->connectionManager()->updateEditedEnd(m_mousePos);
+        return true;
+    }
+
+    // --- Rubber-band selection rectangle ---
+    if (m_markingSelectionBox) {
+        const QRectF rect = QRectF(m_selectionStartPoint, m_mousePos).normalized();
+        m_selectionRect.setRect(rect);
+        QPainterPath selectionBox;
+        selectionBox.addRect(rect);
+        m_scene->setSelectionArea(selectionBox);
+    }
+
+    return false;
+}
+
+bool SceneInteraction::mouseRelease(QGraphicsSceneMouseEvent *event)
+{
+    if (m_draggingElement && (event->button() == Qt::LeftButton)) {
+        bool moved = false;
+
+        if (!m_dragSnapshot.empty()) {
+            // Filter out elements destroyed mid-drag (their QPointers are now null).
+            // Without this, dereferencing a freed element below crashes the app.
+            QList<GraphicElement *> liveElements;
+            QList<QPointF> liveOldPositions;
+            liveElements.reserve(m_dragSnapshot.size());
+            liveOldPositions.reserve(m_dragSnapshot.size());
+
+            for (const auto &[ptr, oldPos] : std::as_const(m_dragSnapshot)) {
+                if (ptr) {
+                    liveElements.append(ptr.data());
+                    liveOldPositions.append(oldPos);
+                }
+            }
+
+            // Only push a MoveCommand if at least one surviving element actually changed
+            // position; avoids polluting the undo stack with no-op moves (click without drag).
+            for (int i = 0; i < liveElements.size(); ++i) {
+                if (liveElements.at(i)->pos() != liveOldPositions.at(i)) {
+                    moved = true;
+                    break;
+                }
+            }
+
+            if (moved) {
+                m_scene->receiveCommand(new MoveCommand(liveElements, liveOldPositions, m_scene));
+            }
+        }
+
+        sentryBreadcrumb("ui", moved ? QStringLiteral("Drag ended: moved") : QStringLiteral("Drag ended: no move"));
+        m_draggingElement = false;
+        m_dragSnapshot.clear();
+
+        // Only tighten scene rect after an actual drag; a click-without-move
+        // should not trigger a rect change that could shift the viewport.
+        if (moved) {
+            m_scene->resizeScene();
+        }
+    }
+
+    m_selectionRect.hide();
+    m_markingSelectionBox = false;
+
+    // Complete an in-progress wire on mouse release (when no button is held)
+    // — this handles the drag-to-connect gesture (press output → drag → release on input)
+    if (m_scene->connectionManager()->hasEditedConnection() && (event->buttons() == Qt::NoButton)) {
+        m_scene->connectionManager()->tryComplete(m_mousePos);
+        return true;
+    }
+
+    return false;
+}
+
+bool SceneInteraction::mouseDoubleClick(QGraphicsSceneMouseEvent *event)
+{
+    if (event->modifiers().testFlag(Qt::ControlModifier)) {
+        return true;
+    }
+
+    // Double-click on a fully connected wire inserts a routing node at the click point,
+    // splitting the wire into two segments; guard ensures it's not a dangling wire
+    if (auto *connection = qgraphicsitem_cast<QNEConnection *>(m_scene->itemAt(m_mousePos)); connection && connection->startPort() && connection->endPort()) {
+        m_scene->receiveCommand(new SplitCommand(connection, m_mousePos, m_scene));
+    }
+
+    return false;
+}

--- a/App/Scene/SceneInteraction.h
+++ b/App/Scene/SceneInteraction.h
@@ -1,0 +1,79 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief SceneInteraction: owns the scene's mouse-driven editing state and gestures.
+ */
+
+#pragma once
+
+#include <QElapsedTimer>
+#include <QGraphicsRectItem>
+#include <QList>
+#include <QPair>
+#include <QPointF>
+#include <QPointer>
+
+class GraphicElement;
+class QGraphicsSceneMouseEvent;
+class Scene;
+class ThemeAttributes;
+
+/**
+ * \class SceneInteraction
+ * \brief Owns the interactive editing state of a Scene — element dragging, the
+ * rubber-band selection rectangle, and the last cursor position — and implements the
+ * press/move/release/double-click gestures.
+ *
+ * \details Extracted from Scene via ownership inversion, mirroring ConnectionManager:
+ * it holds the drag snapshot, selection-box state and the selection-rect item, and
+ * calls back to the Scene only for genuine scene operations (itemAt, selectedElements,
+ * receiveCommand, resizeScene, contextMenu, the connection manager). The gesture
+ * methods return \c true when the event is fully handled so Scene skips the base-class
+ * call. (The mouse-move re-entrancy guard stays on Scene because it must wrap Scene's
+ * own base-event call.)
+ */
+class SceneInteraction
+{
+public:
+    explicit SceneInteraction(Scene *scene);
+
+    /// Adds the selection rectangle to the scene and starts the drag throttle timer.
+    /// Called from the Scene constructor body to preserve the original init order.
+    void attachToScene();
+
+    /// \returns \c true if the press was fully handled (caller skips the base call).
+    bool mousePress(QGraphicsSceneMouseEvent *event);
+    /// \returns \c true if the move was fully handled (caller skips the base call).
+    bool mouseMove(QGraphicsSceneMouseEvent *event);
+    /// \returns \c true if the release was fully handled (caller skips the base call).
+    bool mouseRelease(QGraphicsSceneMouseEvent *event);
+    /// \returns \c true if the double-click was fully handled (caller skips the base call).
+    bool mouseDoubleClick(QGraphicsSceneMouseEvent *event);
+
+    /// Last known cursor position in scene coordinates.
+    [[nodiscard]] QPointF lastMousePos() const { return m_mousePos; }
+
+    /// \c true while an element drag is in progress (drives Scene::resizeScene's expand-only mode).
+    [[nodiscard]] bool isDraggingElement() const { return m_draggingElement; }
+
+    /// Applies the theme's selection-rectangle brush and pen.
+    void applyTheme(const ThemeAttributes &theme);
+
+private:
+    /// Begins a rubber-band selection anchored at the current cursor position.
+    void startSelectionRect();
+
+    Scene *m_scene;
+
+    QGraphicsRectItem m_selectionRect;
+    QElapsedTimer m_timer;
+    QPointF m_mousePos;
+    QPointF m_selectionStartPoint;
+
+    /// Per-drag snapshot of (element, original position); QPointer auto-clears if an
+    /// element is destroyed mid-drag (e.g. Delete shortcut while dragging).
+    QList<QPair<QPointer<GraphicElement>, QPointF>> m_dragSnapshot;
+    bool m_draggingElement = false;
+    bool m_markingSelectionBox = false;
+};

--- a/App/Scene/SceneItemRegistry.cpp
+++ b/App/Scene/SceneItemRegistry.cpp
@@ -1,0 +1,68 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Scene/SceneItemRegistry.h"
+
+#include <QtGlobal>
+
+#include "App/Core/ItemWithId.h"
+
+ItemWithId *SceneItemRegistry::itemById(const int id) const
+{
+    return m_elementRegistry.value(id, nullptr);
+}
+
+bool SceneItemRegistry::contains(const int id) const
+{
+    return m_elementRegistry.contains(id);
+}
+
+int SceneItemRegistry::lastId() const
+{
+    return m_lastId;
+}
+
+void SceneItemRegistry::setLastId(const int newLastId)
+{
+    m_lastId = qMax(m_lastId, newLastId);
+}
+
+int SceneItemRegistry::nextId()
+{
+    return ++m_lastId;
+}
+
+void SceneItemRegistry::updateItemId(ItemWithId *item, const int newId)
+{
+    // Called before addItem() to pre-assign a specific ID (undo/redo restore path).
+    // The item is not yet in the registry; addItem() will preserve this positive ID.
+    item->setId(newId);
+    setLastId(newId);
+}
+
+void SceneItemRegistry::forgetItemId(const int id)
+{
+    m_elementRegistry.remove(id);
+}
+
+void SceneItemRegistry::registerItem(ItemWithId *item)
+{
+    if (!item) {
+        return;
+    }
+    // HC invariant: an id must map to exactly one live item — never to a stale pointer
+    // left behind by a missed unregisterItem (the WIREDPANDA-HC family upstream condition)
+    Q_ASSERT(!m_elementRegistry.contains(item->id())
+          || m_elementRegistry.value(item->id()) == item);
+    m_elementRegistry[item->id()] = item;
+}
+
+void SceneItemRegistry::unregisterItem(ItemWithId *item)
+{
+    if (!item) {
+        return;
+    }
+    m_elementRegistry.remove(item->id());
+    // HC postcondition: after unregister, the registry must not still resolve this id
+    Q_ASSERT(!m_elementRegistry.contains(item->id()));
+}

--- a/App/Scene/SceneItemRegistry.h
+++ b/App/Scene/SceneItemRegistry.h
@@ -1,0 +1,56 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief SceneItemRegistry: maps stable integer IDs to the scene's identifiable items.
+ */
+
+#pragma once
+
+#include <QMap>
+
+class ItemWithId;
+
+/**
+ * \class SceneItemRegistry
+ * \brief Owns the id↔item bookkeeping for a Scene: the id-to-item map and the
+ * monotonically increasing last-assigned id.
+ *
+ * \details Extracted from Scene. Pure data structure with no back-reference to the
+ * scene; Scene forwards its itemById/nextId/register/… API here. Keeping the
+ * invariant (one id ↔ one live item) local makes the registry independently testable.
+ */
+class SceneItemRegistry
+{
+public:
+    /// Returns the item registered under \a id, or nullptr.
+    [[nodiscard]] ItemWithId *itemById(int id) const;
+
+    /// Returns \c true if an item is registered under \a id.
+    [[nodiscard]] bool contains(int id) const;
+
+    /// Returns the highest id assigned so far.
+    int lastId() const;
+
+    /// Raises the last-assigned id to \a newLastId (never lowers it).
+    void setLastId(int newLastId);
+
+    /// Returns a fresh, previously unused id.
+    int nextId();
+
+    /// Pre-assigns \a newId to \a item before it is added (undo/redo restore path).
+    void updateItemId(ItemWithId *item, int newId);
+
+    /// Removes the mapping for \a id without touching the item.
+    void forgetItemId(int id);
+
+    /// Registers \a item under its current id.
+    void registerItem(ItemWithId *item);
+
+    /// Removes \a item's mapping from the registry.
+    void unregisterItem(ItemWithId *item);
+
+private:
+    QMap<int, ItemWithId *> m_elementRegistry;
+    int m_lastId = 0;
+};

--- a/App/UI/ExportController.cpp
+++ b/App/UI/ExportController.cpp
@@ -21,17 +21,6 @@
 #include "App/UI/FileDialogProvider.h"
 #include "App/UI/MainWindowHost.h"
 
-namespace
-{
-    /// Appends \a extension to \a fileName when it is not already present.
-    void ensureFileExtension(QString &fileName, const QString &extension)
-    {
-        if (!fileName.endsWith(extension)) {
-            fileName.append(extension);
-        }
-    }
-} // namespace
-
 ExportController::ExportController(MainWindowHost &host, QObject *parent)
     : QObject(parent)
     , m_host(host)
@@ -59,7 +48,9 @@ void ExportController::exportToArduino(QString fileName)
     // the simulation timer and the code generator reading element state.
     SimulationBlocker simulationBlocker(tab->simulation());
 
-    ensureFileExtension(fileName, ".ino");
+    if (!fileName.endsWith(".ino")) {
+        fileName.append(".ino");
+    }
 
     ArduinoCodeGen arduino(QDir::home().absoluteFilePath(fileName), elements);
     arduino.generate();
@@ -87,7 +78,9 @@ void ExportController::exportToSystemVerilog(QString fileName)
 
     SimulationBlocker simulationBlocker(tab->simulation());
 
-    ensureFileExtension(fileName, ".sv");
+    if (!fileName.endsWith(".sv")) {
+        fileName.append(".sv");
+    }
 
     SystemVerilogCodeGen verilog(QDir::home().absoluteFilePath(fileName), elements);
     verilog.generate();

--- a/App/UI/ExportController.cpp
+++ b/App/UI/ExportController.cpp
@@ -1,0 +1,219 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/UI/ExportController.h"
+
+#include <QDesktopServices>
+#include <QDir>
+#include <QLoggingCategory>
+#include <QUrl>
+
+#include "App/BeWavedDolphin/BeWavedDolphin.h"
+#include "App/CodeGen/ArduinoCodeGen.h"
+#include "App/CodeGen/SystemVerilogCodeGen.h"
+#include "App/Core/Application.h"
+#include "App/Core/Common.h"
+#include "App/Core/SentryHelpers.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/Simulation/SimulationBlocker.h"
+#include "App/UI/CircuitExporter.h"
+#include "App/UI/FileDialogProvider.h"
+#include "App/UI/MainWindowHost.h"
+
+namespace
+{
+    /// Appends \a extension to \a fileName when it is not already present.
+    void ensureFileExtension(QString &fileName, const QString &extension)
+    {
+        if (!fileName.endsWith(extension)) {
+            fileName.append(extension);
+        }
+    }
+} // namespace
+
+ExportController::ExportController(MainWindowHost &host, QObject *parent)
+    : QObject(parent)
+    , m_host(host)
+{
+}
+
+void ExportController::exportToArduino(QString fileName)
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    if (fileName.isEmpty()) {
+        throw PANDACEPTION("Missing file name.");
+    }
+
+    auto elements = tab->scene()->elements();
+
+    if (elements.isEmpty()) {
+        throw PANDACEPTION("The .panda file is empty.");
+    }
+
+    // Pause the simulation while generating code to avoid data races between
+    // the simulation timer and the code generator reading element state.
+    SimulationBlocker simulationBlocker(tab->simulation());
+
+    ensureFileExtension(fileName, ".ino");
+
+    ArduinoCodeGen arduino(QDir::home().absoluteFilePath(fileName), elements);
+    arduino.generate();
+    m_host.showStatusMessage(tr("Arduino code successfully generated."), 4000);
+
+    qCDebug(zero) << "Arduino code successfully generated.";
+}
+
+void ExportController::exportToSystemVerilog(QString fileName)
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    if (fileName.isEmpty()) {
+        throw PANDACEPTION("Missing file name.");
+    }
+
+    auto elements = tab->scene()->elements();
+
+    if (elements.isEmpty()) {
+        throw PANDACEPTION("The .panda file is empty.");
+    }
+
+    SimulationBlocker simulationBlocker(tab->simulation());
+
+    ensureFileExtension(fileName, ".sv");
+
+    SystemVerilogCodeGen verilog(QDir::home().absoluteFilePath(fileName), elements);
+    verilog.generate();
+    m_host.showStatusMessage(tr("SystemVerilog code successfully generated."), 4000);
+
+    qCDebug(zero) << "SystemVerilog code successfully generated.";
+}
+
+void ExportController::exportToWaveFormFile(const QString &fileName)
+{
+    if (fileName.isEmpty()) {
+        throw PANDACEPTION("Missing file name.");
+    }
+
+    // Headless export: a stack instance is never shown/closed, so it cleans up at scope end
+    // (its WA_DeleteOnClose only fires on a close event) — and RAII-frees even if this throws.
+    BewavedDolphin bewavedDolphin(m_host.currentTab()->scene(), false, m_host.dolphinHost());
+    bewavedDolphin.createWaveform(fileName);
+    bewavedDolphin.print();
+}
+
+void ExportController::exportToWaveFormTerminal()
+{
+    BewavedDolphin bewavedDolphin(m_host.currentTab()->scene(), false, m_host.dolphinHost());
+    bewavedDolphin.createWaveform();
+    bewavedDolphin.print();
+}
+
+void ExportController::exportArduinoDialog()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("export", QStringLiteral("Export to Arduino"));
+        if (!m_host.currentTab()) {
+            return;
+        }
+
+        QString path;
+
+        if (m_host.currentFile().exists()) {
+            path = m_host.currentFile().absolutePath();
+        }
+
+        const QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Generate Arduino Code"), path, tr("Arduino file (*.ino)")).fileName;
+
+        if (!fileName.isEmpty()) {
+            exportToArduino(fileName);
+        }
+    });
+}
+
+void ExportController::exportSystemVerilogDialog()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("export", QStringLiteral("Export to SystemVerilog"));
+        if (!m_host.currentTab()) {
+            return;
+        }
+
+        QString path;
+
+        if (m_host.currentFile().exists()) {
+            path = m_host.currentFile().absolutePath();
+        }
+
+        const QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Generate SystemVerilog Code"), path, tr("SystemVerilog file (*.sv)")).fileName;
+
+        if (!fileName.isEmpty()) {
+            exportToSystemVerilog(fileName);
+        }
+    });
+}
+
+void ExportController::exportPdfDialog()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("export", QStringLiteral("Export to PDF"));
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        // De-select elements so their selection handles don't appear in the export.
+        tab->scene()->clearSelection();
+
+        const QString path    = m_host.currentFile().exists() ? m_host.currentFile().absolutePath() : QString();
+        QString pdfFile = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Export to PDF"), path, tr("PDF files (*.pdf)")).fileName;
+
+        if (pdfFile.isEmpty()) {
+            return;
+        }
+
+        if (!pdfFile.endsWith(".pdf", Qt::CaseInsensitive)) {
+            pdfFile.append(".pdf");
+        }
+
+        CircuitExporter::renderToPdf(tab->scene(), pdfFile);
+        m_host.showStatusMessage(tr("Exported file successfully."), 4000);
+        QDesktopServices::openUrl(QUrl::fromLocalFile(pdfFile));
+    });
+}
+
+void ExportController::exportImageDialog()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("export", QStringLiteral("Export to image"));
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        // De-select elements so their selection handles don't appear in the export.
+        tab->scene()->clearSelection();
+
+        const QString path    = m_host.currentFile().exists() ? m_host.currentFile().absolutePath() : QString();
+        QString pngFile = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Export to Image"), path, tr("PNG files (*.png)")).fileName;
+
+        if (pngFile.isEmpty()) {
+            return;
+        }
+
+        if (!pngFile.endsWith(".png", Qt::CaseInsensitive)) {
+            pngFile.append(".png");
+        }
+
+        CircuitExporter::renderToImage(tab->scene(), pngFile);
+        m_host.showStatusMessage(tr("Exported file successfully."), 4000);
+        QDesktopServices::openUrl(QUrl::fromLocalFile(pngFile));
+    });
+}

--- a/App/UI/ExportController.h
+++ b/App/UI/ExportController.h
@@ -1,0 +1,56 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief ExportController: orchestrates exporting the current circuit to its output formats.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+class MainWindowHost;
+
+/**
+ * \class ExportController
+ * \brief Owns the circuit-export workflow: Arduino / SystemVerilog code, PDF / PNG
+ * images, and beWavedDolphin waveform output.
+ *
+ * \details Extracted from MainWindow. The `export*` methods are the headless cores
+ * (used by the CLI batch mode and the MCP server); the dialog slots add file-picker
+ * and status-bar glue on top of them. All circuit state is reached through a
+ * MainWindowHost so the controller never depends on a concrete MainWindow.
+ */
+class ExportController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ExportController(MainWindowHost &host, QObject *parent = nullptr);
+
+    // --- Headless export cores (called by CLI batch mode and the MCP server) ---
+
+    /// Generates an Arduino sketch for the current circuit at \a fileName.
+    void exportToArduino(QString fileName);
+
+    /// Generates SystemVerilog for the current circuit at \a fileName.
+    void exportToSystemVerilog(QString fileName);
+
+    /// Writes the beWavedDolphin waveform of the current circuit to \a fileName.
+    void exportToWaveFormFile(const QString &fileName);
+
+    /// Prints the beWavedDolphin waveform of the current circuit to the terminal.
+    void exportToWaveFormTerminal();
+
+public slots:
+    // --- Interactive dialog handlers (wired to the Export menu actions) ---
+
+    void exportArduinoDialog();
+    void exportSystemVerilogDialog();
+    void exportImageDialog();
+    void exportPdfDialog();
+
+private:
+    MainWindowHost &m_host;
+};

--- a/App/UI/ICController.cpp
+++ b/App/UI/ICController.cpp
@@ -1,0 +1,387 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/UI/ICController.h"
+
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QInputDialog>
+#include <QLineEdit>
+#include <QMessageBox>
+
+#include "App/Core/Application.h"
+#include "App/Core/Common.h"
+#include "App/Core/Enums.h"
+#include "App/Core/SentryHelpers.h"
+#include "App/Element/IC.h"
+#include "App/Element/ICRegistry.h"
+#include "App/IO/Serialization.h"
+#include "App/Scene/Commands.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/Simulation/Simulation.h"
+#include "App/UI/ElementPalette.h"
+#include "App/UI/FileDialogProvider.h"
+#include "App/UI/MainWindowHost.h"
+
+ICController::ICController(MainWindowHost &host, QObject *parent)
+    : QObject(parent)
+    , m_host(host)
+{
+}
+
+IC *ICController::selectedIC() const
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return nullptr;
+    }
+
+    const auto selected = tab->scene()->selectedElements();
+    if (selected.isEmpty()) {
+        return nullptr;
+    }
+
+    if (selected.first()->elementType() != ElementType::IC) {
+        return nullptr;
+    }
+
+    return static_cast<IC *>(selected.first());
+}
+
+void ICController::addICFromFile()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ic", QStringLiteral("Add IC"));
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        // The IC list is directory-relative.  If the project hasn't been saved yet
+        // we don't have a directory to copy into, so require a save first.
+        if (!tab->fileInfo().isReadable()) {
+            throw PANDACEPTION("Save file first.");
+        }
+
+        const QString selectedFile = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Open File"), QString(), tr("Panda (*.panda)"));
+
+        if (selectedFile.isEmpty()) {
+            return;
+        }
+
+        const QStringList files = {selectedFile};
+
+        QMessageBox::information(m_host.widget(), tr("Info"), tr("Selected files (and their dependencies) will be copied to the current project folder."));
+
+        // Copy the chosen .panda file (and any ICs it depends on transitively)
+        // into the project's directory so that relative paths work when reopened.
+        for (const auto &file : files) {
+            QFileInfo destPath(m_host.currentDir().absolutePath() + "/" + QFileInfo(file).fileName());
+            Serialization::copyPandaFile(QFileInfo(file), destPath);
+        }
+
+        m_host.palette()->updateICList(m_host.icListFile());
+    });
+}
+
+void ICController::showRemoveICHint()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ic", QStringLiteral("Remove IC"));
+        QMessageBox::information(m_host.widget(), tr("Info"), tr("Drag here to remove."));
+    });
+}
+
+void ICController::removeICFile(const QString &icFileName)
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    QList<QGraphicsItem *> toDelete;
+    for (auto *element : tab->scene()->elements()) {
+        if (element->elementType() == ElementType::IC && element->label().append(".panda").toLower() == icFileName) {
+            toDelete.append(element);
+        }
+    }
+
+    if (!toDelete.isEmpty()) {
+        tab->scene()->receiveCommand(new DeleteItemsCommand(toDelete, tab->scene()));
+        tab->simulation()->restart();
+    }
+
+    QFile file(m_host.currentDir().absolutePath() + "/" + icFileName);
+
+    if (!file.remove()) {
+        throw PANDACEPTION("Error removing file: %1", file.errorString());
+    }
+
+    m_host.palette()->updateICList(m_host.icListFile());
+    // Auto-save after removal so the scene no longer references the deleted file.
+    m_host.requestSave();
+}
+
+QString ICController::resolveUniqueBlobName(const QString &initialName, Scene *scene)
+{
+    auto *reg = scene->icRegistry();
+    QString blobName = reg->uniqueBlobName(initialName.trimmed());
+
+    // If the auto-generated name differs from the initial, let the user confirm or override
+    if (blobName != initialName.trimmed()) {
+        bool ok = false;
+        blobName = QInputDialog::getText(m_host.widget(),
+            tr("Name Collision"),
+            tr("An embedded IC named \"%1\" already exists.\nSuggested name:").arg(initialName.trimmed()),
+            QLineEdit::Normal, blobName, &ok);
+        blobName = blobName.trimmed();
+        if (!ok || blobName.isEmpty()) {
+            return {};
+        }
+        // Re-check in case the user typed a name that also collides
+        if (reg->hasBlob(blobName)) {
+            blobName = reg->uniqueBlobName(blobName);
+        }
+    }
+    return blobName;
+}
+
+void ICController::embedSelectedIC()
+{
+    sentryBreadcrumb("ic", QStringLiteral("Embed IC"));
+    auto *firstIC = selectedIC();
+    if (!firstIC || firstIC->file().isEmpty()) {
+        return;
+    }
+
+    auto *scene = m_host.currentTab()->scene();
+
+    const QString contextDir = scene->contextDir();
+    if (contextDir.isEmpty()) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Please save the project first so ICs can be resolved."));
+        return;
+    }
+
+    QString blobName = resolveUniqueBlobName(QFileInfo(firstIC->file()).baseName(), scene);
+    if (blobName.isEmpty()) {
+        return;
+    }
+
+    QFile file(QDir(contextDir).absoluteFilePath(firstIC->file()));
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
+        return;
+    }
+    QByteArray fileBytes = file.readAll();
+    file.close();
+
+    scene->icRegistry()->embedICsByFile(firstIC->file(), fileBytes, blobName);
+    m_host.palette()->updateEmbeddedICList(scene);
+    m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
+}
+
+void ICController::extractSelectedIC()
+{
+    sentryBreadcrumb("ic", QStringLiteral("Extract IC"));
+    auto *firstIC = selectedIC();
+    if (!firstIC || !firstIC->isEmbedded()) {
+        return;
+    }
+
+    auto *scene = m_host.currentTab()->scene();
+    const QString blobName = firstIC->blobName();
+    const QString contextDir = scene->contextDir();
+    if (contextDir.isEmpty()) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Please save the project first."));
+        return;
+    }
+
+    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
+    QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files (*.panda)")).fileName;
+
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    if (!fileName.endsWith(".panda")) {
+        fileName.append(".panda");
+    }
+
+    scene->icRegistry()->extractToFile(blobName, fileName);
+    m_host.palette()->updateICList(m_host.icListFile());
+    m_host.palette()->updateEmbeddedICList(scene);
+    m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
+}
+
+void ICController::embedICByFile(const QString &fileName)
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    auto *scene = tab->scene();
+    const QString contextDir = scene->contextDir();
+    if (contextDir.isEmpty()) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Please save the project first so ICs can be resolved."));
+        return;
+    }
+
+    const QString absolutePath = QDir(contextDir).absoluteFilePath(fileName);
+    QFile file(absolutePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
+        return;
+    }
+    QByteArray fileBytes = file.readAll();
+    file.close();
+
+    QString blobName = resolveUniqueBlobName(QFileInfo(absolutePath).baseName(), scene);
+    if (blobName.isEmpty()) {
+        return;
+    }
+
+    auto *reg = scene->icRegistry();
+    if (reg->embedICsByFile(absolutePath, fileBytes, blobName) == 0) {
+        // No existing instances — register the blob only; don't add to scene.
+        scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
+    }
+
+    m_host.palette()->updateEmbeddedICList(scene);
+    m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
+}
+
+void ICController::extractICByBlobName(const QString &blobName)
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    auto *scene = tab->scene();
+    const QString contextDir = scene->contextDir();
+    if (contextDir.isEmpty()) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Please save the project first."));
+        return;
+    }
+
+    // Find any embedded IC with this blobName to get the blob data
+    auto *reg = scene->icRegistry();
+    if (!reg->hasBlob(blobName)) {
+        return;
+    }
+
+    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
+    QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files (*.panda)")).fileName;
+
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    if (!fileName.endsWith(".panda")) {
+        fileName.append(".panda");
+    }
+
+    reg->extractToFile(blobName, fileName);
+    m_host.palette()->updateICList(m_host.icListFile());
+    m_host.palette()->updateEmbeddedICList(scene);
+    m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
+}
+
+void ICController::makeSelfContained()
+{
+    sentryBreadcrumb("ic", QStringLiteral("Make self-contained"));
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+
+    auto *scene = tab->scene();
+    const QString contextDir = scene->contextDir();
+    if (contextDir.isEmpty()) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Please save the project first."));
+        return;
+    }
+
+    // Collect unique file paths from all file-backed ICs
+    QStringList uniqueFiles;
+    for (auto *elm : scene->elements()) {
+        if (elm->elementType() != ElementType::IC || elm->isEmbedded()) {
+            continue;
+        }
+        const QString icFile = static_cast<IC *>(elm)->file();
+        if (!icFile.isEmpty() && !uniqueFiles.contains(icFile)) {
+            uniqueFiles.append(icFile);
+        }
+    }
+
+    if (uniqueFiles.isEmpty()) {
+        m_host.showStatusMessage(tr("No file-based ICs to embed."), 4000);
+        return;
+    }
+
+    int totalEmbedded = 0;
+    auto *reg = scene->icRegistry();
+
+    for (const QString &icFile : std::as_const(uniqueFiles)) {
+        const QString fullPath = QDir(contextDir).absoluteFilePath(icFile);
+        QFile file(fullPath);
+        if (!file.open(QIODevice::ReadOnly)) {
+            QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
+            break;
+        }
+        QByteArray fileBytes = file.readAll();
+        file.close();
+
+        QString blobName = resolveUniqueBlobName(QFileInfo(icFile).baseName(), scene);
+        if (blobName.isEmpty()) {
+            break; // User cancelled
+        }
+
+        totalEmbedded += reg->embedICsByFile(fullPath, fileBytes, blobName);
+    }
+
+    m_host.palette()->updateEmbeddedICList(scene);
+    m_host.showStatusMessage(tr("Embedded %1 IC(s). Circuit is now self-contained.").arg(totalEmbedded), 4000);
+}
+
+void ICController::addEmbeddedICFromFile()
+{
+    auto *tab = m_host.currentTab();
+    if (!tab) {
+        return;
+    }
+    QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Select IC file to embed"), m_host.currentDir().absolutePath(), tr("Panda files (*.panda)"));
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read file: %1").arg(file.errorString()));
+        return;
+    }
+    QByteArray fileBytes = file.readAll();
+    file.close();
+
+    auto *scene = tab->scene();
+    QString blobName = resolveUniqueBlobName(QFileInfo(fileName).baseName(), scene);
+    if (blobName.isEmpty()) {
+        return;
+    }
+
+    scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
+    m_host.palette()->updateEmbeddedICList(scene);
+}
+
+void ICController::removeEmbeddedIC(const QString &blobName)
+{
+    auto *tab = m_host.currentTab();
+    if (tab) {
+        tab->removeEmbeddedIC(blobName);
+        m_host.palette()->updateEmbeddedICList(tab->scene());
+    }
+}

--- a/App/UI/ICController.h
+++ b/App/UI/ICController.h
@@ -1,0 +1,73 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief ICController: integrated-circuit embed / extract / import / removal operations.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+class IC;
+class MainWindowHost;
+class Scene;
+
+/**
+ * \class ICController
+ * \brief Owns the IC management workflow: importing file-based ICs into the project
+ * directory, embedding/extracting blobs, and making a circuit self-contained.
+ *
+ * \details Extracted from MainWindow. Reaches circuit state (current tab, scene,
+ * IC registry, palette, status bar) through a MainWindowHost, so it never depends on
+ * a concrete MainWindow. Widget-state helpers for the IC tool buttons remain on
+ * MainWindow because they belong to its tab lifecycle.
+ */
+class ICController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ICController(MainWindowHost &host, QObject *parent = nullptr);
+
+public slots:
+    /// Copies a chosen .panda file (and its dependencies) into the project's IC directory.
+    void addICFromFile();
+
+    /// Shows the "drag here to remove" hint for the file-based IC trash button.
+    void showRemoveICHint();
+
+    /// Deletes \a icFileName from the project directory and any instances of it in the scene.
+    void removeICFile(const QString &icFileName);
+
+    /// Embeds the currently selected file-backed IC as a blob in the circuit.
+    void embedSelectedIC();
+
+    /// Extracts the currently selected embedded IC back out to a .panda file.
+    void extractSelectedIC();
+
+    /// Embeds the file-based IC named \a fileName (drag-and-drop target).
+    void embedICByFile(const QString &fileName);
+
+    /// Extracts the embedded IC blob \a blobName to a user-chosen .panda file.
+    void extractICByBlobName(const QString &blobName);
+
+    /// Embeds every file-based IC in the circuit so it becomes self-contained.
+    void makeSelfContained();
+
+    /// Prompts for a .panda file and registers it as an embedded IC blob.
+    void addEmbeddedICFromFile();
+
+    /// Removes the embedded IC blob \a blobName from the current circuit.
+    void removeEmbeddedIC(const QString &blobName);
+
+private:
+    /// Returns the first selected element if it is an IC, else nullptr.
+    IC *selectedIC() const;
+
+    /// Resolves a non-colliding blob name for \a initialName, prompting on collision.
+    QString resolveUniqueBlobName(const QString &initialName, Scene *scene);
+
+    MainWindowHost &m_host;
+};

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -4,6 +4,7 @@
 #include "App/UI/MainWindow.h"
 
 #include <algorithm>
+#include <utility>
 
 #ifdef Q_OS_WASM
 #include <emscripten/emscripten.h>
@@ -32,8 +33,6 @@
 #endif
 
 #include "App/BeWavedDolphin/BeWavedDolphin.h"
-#include "App/CodeGen/ArduinoCodeGen.h"
-#include "App/CodeGen/SystemVerilogCodeGen.h"
 #include "App/Core/Application.h"
 #include "App/Core/Common.h"
 #include "App/Core/SentryHelpers.h"
@@ -50,9 +49,8 @@
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
-#include "App/Simulation/SimulationBlocker.h"
-#include "App/UI/CircuitExporter.h"
 #include "App/UI/ElementPalette.h"
+#include "App/UI/ExportController.h"
 #include "App/UI/FileDialogProvider.h"
 #include "App/UI/LanguageManager.h"
 #include "App/UI/MainWindowUI.h"
@@ -86,6 +84,8 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
 
     // Shared IC-hover preview, owned by this MainWindow as a Qt child.
     m_icPreviewPopup = new ICPreviewPopup(this);
+
+    m_exportController = new ExportController(*this, this);
 
     setupLanguage();
     setupGeometry();
@@ -270,10 +270,10 @@ void MainWindow::setupConnections()
     connect(m_ui->actionDarkTheme,             &QAction::triggered,       this,                &MainWindow::on_actionDarkTheme_triggered);
     connect(m_ui->actionSystemTheme,           &QAction::triggered,       this,                &MainWindow::on_actionSystemTheme_triggered);
     connect(m_ui->actionExit,                  &QAction::triggered,       this,                &MainWindow::on_actionExit_triggered);
-    connect(m_ui->actionExportToArduino,       &QAction::triggered,       this,                &MainWindow::on_actionExportToArduino_triggered);
-    connect(m_ui->actionExportToSystemVerilog, &QAction::triggered,       this,                &MainWindow::on_actionExportToSystemVerilog_triggered);
-    connect(m_ui->actionExportToImage,         &QAction::triggered,       this,                &MainWindow::on_actionExportToImage_triggered);
-    connect(m_ui->actionExportToPdf,           &QAction::triggered,       this,                &MainWindow::on_actionExportToPdf_triggered);
+    connect(m_ui->actionExportToArduino,       &QAction::triggered,       m_exportController,  &ExportController::exportArduinoDialog);
+    connect(m_ui->actionExportToSystemVerilog, &QAction::triggered,       m_exportController,  &ExportController::exportSystemVerilogDialog);
+    connect(m_ui->actionExportToImage,         &QAction::triggered,       m_exportController,  &ExportController::exportImageDialog);
+    connect(m_ui->actionExportToPdf,           &QAction::triggered,       m_exportController,  &ExportController::exportPdfDialog);
     connect(m_ui->actionFastMode,              &QAction::triggered,       this,                &MainWindow::on_actionFastMode_triggered);
     connect(m_ui->actionFlipHorizontally,      &QAction::triggered,       this,                &MainWindow::on_actionFlipHorizontally_triggered);
     connect(m_ui->actionFlipVertically,        &QAction::triggered,       this,                &MainWindow::on_actionFlipVertically_triggered);
@@ -1019,6 +1019,21 @@ QDir MainWindow::currentDir() const
     return m_currentTab ? m_currentTab->fileInfo().absoluteDir() : QDir();
 }
 
+QWidget *MainWindow::widget()
+{
+    return this;
+}
+
+DolphinHost *MainWindow::dolphinHost()
+{
+    return this;
+}
+
+void MainWindow::showStatusMessage(const QString &message, int timeout)
+{
+    m_ui->statusBar->showMessage(message, timeout);
+}
+
 QFileInfo MainWindow::icListFile() const
 {
     // Walk up the parent workspace chain to find the root file on disk.
@@ -1308,122 +1323,22 @@ void MainWindow::on_actionGates_triggered(const bool checked)
 
 void MainWindow::exportToArduino(QString fileName)
 {
-    if (!m_currentTab) {
-        return;
-    }
-
-    if (fileName.isEmpty()) {
-        throw PANDACEPTION("Missing file name.");
-    }
-
-    auto elements = m_currentTab->scene()->elements();
-
-    if (elements.isEmpty()) {
-        throw PANDACEPTION("The .panda file is empty.");
-    }
-
-    // Pause the simulation while generating code to avoid data races between
-    // the simulation timer and the code generator reading element state.
-    SimulationBlocker simulationBlocker(m_currentTab->simulation());
-
-    ensureFileExtension(fileName, ".ino");
-
-    ArduinoCodeGen arduino(QDir::home().absoluteFilePath(fileName), elements);
-    arduino.generate();
-    m_ui->statusBar->showMessage(tr("Arduino code successfully generated."), 4000);
-
-    qCDebug(zero) << "Arduino code successfully generated.";
+    m_exportController->exportToArduino(std::move(fileName));
 }
 
 void MainWindow::exportToSystemVerilog(QString fileName)
 {
-    if (!m_currentTab) {
-        return;
-    }
-
-    if (fileName.isEmpty()) {
-        throw PANDACEPTION("Missing file name.");
-    }
-
-    auto elements = m_currentTab->scene()->elements();
-
-    if (elements.isEmpty()) {
-        throw PANDACEPTION("The .panda file is empty.");
-    }
-
-    SimulationBlocker simulationBlocker(m_currentTab->simulation());
-
-    ensureFileExtension(fileName, ".sv");
-
-    SystemVerilogCodeGen verilog(QDir::home().absoluteFilePath(fileName), elements);
-    verilog.generate();
-    m_ui->statusBar->showMessage(tr("SystemVerilog code successfully generated."), 4000);
-
-    qCDebug(zero) << "SystemVerilog code successfully generated.";
+    m_exportController->exportToSystemVerilog(std::move(fileName));
 }
 
 void MainWindow::exportToWaveFormFile(const QString &fileName)
 {
-    if (fileName.isEmpty()) {
-        throw PANDACEPTION("Missing file name.");
-    }
-
-    // Headless export: a stack instance is never shown/closed, so it cleans up at scope end
-    // (its WA_DeleteOnClose only fires on a close event) — and RAII-frees even if this throws.
-    BewavedDolphin bewavedDolphin(m_currentTab->scene(), false, this);
-    bewavedDolphin.createWaveform(fileName);
-    bewavedDolphin.print();
+    m_exportController->exportToWaveFormFile(fileName);
 }
 
 void MainWindow::exportToWaveFormTerminal()
 {
-    BewavedDolphin bewavedDolphin(m_currentTab->scene(), false, this);
-    bewavedDolphin.createWaveform();
-    bewavedDolphin.print();
-}
-
-void MainWindow::on_actionExportToArduino_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("export", QStringLiteral("Export to Arduino"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        QString path;
-
-        if (currentFile().exists()) {
-            path = currentFile().absolutePath();
-        }
-
-        const QString fileName = FileDialogs::provider()->getSaveFileName(this, tr("Generate Arduino Code"), path, tr("Arduino file (*.ino)")).fileName;
-
-        if (!fileName.isEmpty()) {
-            exportToArduino(fileName);
-        }
-    });
-}
-
-void MainWindow::on_actionExportToSystemVerilog_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("export", QStringLiteral("Export to SystemVerilog"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        QString path;
-
-        if (currentFile().exists()) {
-            path = currentFile().absolutePath();
-        }
-
-        const QString fileName = FileDialogs::provider()->getSaveFileName(this, tr("Generate SystemVerilog Code"), path, tr("SystemVerilog file (*.sv)")).fileName;
-
-        if (!fileName.isEmpty()) {
-            exportToSystemVerilog(fileName);
-        }
-    });
+    m_exportController->exportToWaveFormTerminal();
 }
 
 void MainWindow::on_actionZoomIn_triggered() const
@@ -1515,62 +1430,6 @@ void MainWindow::createRecentFileActions()
     }
 
     updateRecentFileActions();
-}
-
-void MainWindow::on_actionExportToPdf_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("export", QStringLiteral("Export to PDF"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        // De-select elements so their selection handles don't appear in the export.
-        m_currentTab->scene()->clearSelection();
-
-        const QString path    = currentFile().exists() ? currentFile().absolutePath() : QString();
-        QString pdfFile = FileDialogs::provider()->getSaveFileName(this, tr("Export to PDF"), path, tr("PDF files (*.pdf)")).fileName;
-
-        if (pdfFile.isEmpty()) {
-            return;
-        }
-
-        if (!pdfFile.endsWith(".pdf", Qt::CaseInsensitive)) {
-            pdfFile.append(".pdf");
-        }
-
-        CircuitExporter::renderToPdf(m_currentTab->scene(), pdfFile);
-        m_ui->statusBar->showMessage(tr("Exported file successfully."), 4000);
-        QDesktopServices::openUrl(QUrl::fromLocalFile(pdfFile));
-    });
-}
-
-void MainWindow::on_actionExportToImage_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("export", QStringLiteral("Export to image"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        // De-select elements so their selection handles don't appear in the export.
-        m_currentTab->scene()->clearSelection();
-
-        const QString path    = currentFile().exists() ? currentFile().absolutePath() : QString();
-        QString pngFile = FileDialogs::provider()->getSaveFileName(this, tr("Export to Image"), path, tr("PNG files (*.png)")).fileName;
-
-        if (pngFile.isEmpty()) {
-            return;
-        }
-
-        if (!pngFile.endsWith(".png", Qt::CaseInsensitive)) {
-            pngFile.append(".png");
-        }
-
-        CircuitExporter::renderToImage(m_currentTab->scene(), pngFile);
-        m_ui->statusBar->showMessage(tr("Exported file successfully."), 4000);
-        QDesktopServices::openUrl(QUrl::fromLocalFile(pngFile));
-    });
 }
 
 void MainWindow::retranslateUi()

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -53,6 +53,7 @@
 #include "App/UI/ICController.h"
 #include "App/UI/LanguageManager.h"
 #include "App/UI/MainWindowUI.h"
+#include "App/UI/SceneUiBinder.h"
 #include "App/UI/UpdateController.h"
 #include "App/Versions.h"
 
@@ -86,6 +87,7 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
 
     m_exportController = new ExportController(*this, this);
     m_icController = new ICController(*this, this);
+    m_binder = new SceneUiBinder(m_ui.get(), m_palette, this, this);
 
     setupLanguage();
     setupGeometry();
@@ -243,17 +245,9 @@ void MainWindow::setupExamplesMenu()
 
 void MainWindow::setupShortcuts()
 {
-    // [ / ] cycle a selected element's primary property (e.g. input size).
-    // { / } cycle a secondary property; < / > morph through element variants.
-    // Scene connections are made in connectTab() so they follow the active tab.
+    // The scene-property shortcuts ( [ ] { } < > ) are owned by SceneUiBinder, which
+    // re-targets them to the active tab's scene on each switch.
     auto *searchShortcut = new QShortcut(QKeySequence("Ctrl+F"), this);
-    m_prevMainPropShortcut  = new QShortcut(QKeySequence("["), this);
-    m_nextMainPropShortcut  = new QShortcut(QKeySequence("]"), this);
-    m_prevSecndPropShortcut = new QShortcut(QKeySequence("{"), this);
-    m_nextSecndPropShortcut = new QShortcut(QKeySequence("}"), this);
-    m_changePrevElmShortcut = new QShortcut(QKeySequence("<"), this);
-    m_changeNextElmShortcut = new QShortcut(QKeySequence(">"), this);
-
     connect(searchShortcut, &QShortcut::activated, m_ui->lineEditSearch, qOverload<>(&QWidget::setFocus));
 }
 
@@ -403,44 +397,6 @@ void MainWindow::createNewTab()
     m_ui->tab->setCurrentIndex(m_ui->tab->count() - 1);
 
     qCDebug(zero) << "Finished #tabs: " << m_ui->tab->count() << ", current tab: " << m_tabIndex;
-}
-
-void MainWindow::removeUndoRedoMenu()
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    // The undo/redo actions are always inserted at positions 0 and 1 of menuEdit.
-    // Any fewer entries means they were never added, so nothing to remove.
-    const auto actions = m_ui->menuEdit->actions();
-    if (actions.size() < 2) {
-        return;
-    }
-    m_ui->menuEdit->removeAction(actions.at(0));
-    m_ui->menuEdit->removeAction(actions.at(1));
-}
-
-void MainWindow::addUndoRedoMenu()
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-    if (!scene) {
-        return;
-    }
-
-    const auto actions = m_ui->menuEdit->actions();
-    if (actions.size() < 2) {
-        return;
-    }
-
-    // Insert before position 0 then before the new position 1 so undo appears
-    // first, redo second — above the separator that already exists in menuEdit.
-    m_ui->menuEdit->insertAction(actions.at(0), scene->undoAction());
-    m_ui->menuEdit->insertAction(m_ui->menuEdit->actions().at(1), scene->redoAction());
 }
 
 void MainWindow::setFastMode(const bool fastMode)
@@ -1129,71 +1085,29 @@ bool MainWindow::closeTab(const int tabIndex)
 
 void MainWindow::disconnectTab()
 {
-    // Called before switching away from a tab.  Tear down all connections that
-    // route scene signals into shared UI elements, and stop the simulation so it
-    // doesn't keep running in the background consuming CPU.
+    // Called before switching away from a tab. SceneUiBinder tears down the chrome
+    // wiring; the IC-open navigation connection is owned here (it drives tab/file
+    // opening, not chrome).
     if (!m_currentTab) {
         return;
     }
 
-    m_ui->elementEditor->setScene(nullptr);
-
-    qCDebug(zero) << "Stopping simulation.";
-    m_currentTab->simulation()->stop();
-
-    qCDebug(zero) << "Disconnecting zoom and simulation signals from UI.";
-    disconnect(m_currentTab->view(),       &GraphicsView::zoomChanged,        this, &MainWindow::zoomChanged);
-    disconnect(m_currentTab->simulation(), &Simulation::simulationWarning,    this, nullptr);
-
-    qCDebug(zero) << "Disconnecting scene shortcuts from previous tab.";
-    disconnect(m_prevMainPropShortcut,  nullptr, m_currentTab->scene(), nullptr);
-    disconnect(m_nextMainPropShortcut,  nullptr, m_currentTab->scene(), nullptr);
-    disconnect(m_prevSecndPropShortcut, nullptr, m_currentTab->scene(), nullptr);
-    disconnect(m_nextSecndPropShortcut, nullptr, m_currentTab->scene(), nullptr);
-    disconnect(m_changePrevElmShortcut, nullptr, m_currentTab->scene(), nullptr);
-    disconnect(m_changeNextElmShortcut, nullptr, m_currentTab->scene(), nullptr);
     disconnect(m_currentTab->scene(), &Scene::icOpenRequested, this, nullptr);
-    disconnect(m_currentTab->scene(), &Scene::openTruthTableRequested, this, nullptr);
-    disconnect(m_currentTab->scene()->undoStack(), &QUndoStack::indexChanged, this, nullptr);
-
-    qCDebug(zero) << "Removing undo and redo actions from UI menu.";
-    removeUndoRedoMenu();
+    m_binder->unbind();
 }
 
 void MainWindow::connectTab()
 {
-    qCDebug(zero) << "Connecting undo and redo functions to UI menu.";
-    addUndoRedoMenu();
+    m_binder->bind(m_currentTab);
 
+    // Tab-navigation wiring (not chrome): the file-based IC list, IC tool-button
+    // state, and the scene's open-IC-in-tab / open-file requests.
     m_palette->updateICList(icListFile());
-    m_palette->updateEmbeddedICList(m_currentTab->scene());
 
     // Hide management buttons for inline IC tabs (they use currentFile/currentDir which are empty)
     setICButtonsVisible(!m_currentTab->isInlineIC());
     refreshICButtonsEnabled();
 
-    qCDebug(zero) << "Connecting current tab to element editor menu in UI.";
-    m_ui->elementEditor->setScene(m_currentTab->scene());
-
-    connect(m_currentTab->view(),       &GraphicsView::zoomChanged, this,                  &MainWindow::zoomChanged);
-    connect(m_currentTab->simulation(), &Simulation::simulationWarning, this, [this](const QString &msg) {
-        m_ui->statusBar->showMessage(msg, 8000);
-    });
-    connect(m_currentTab->scene()->undoStack(), &QUndoStack::indexChanged, this, [this] {
-        if (m_currentTab) {
-            m_palette->updateEmbeddedICList(m_currentTab->scene());
-        }
-    });
-
-    connect(m_prevMainPropShortcut,  &QShortcut::activated, m_currentTab->scene(), &Scene::prevMainPropShortcut);
-    connect(m_nextMainPropShortcut,  &QShortcut::activated, m_currentTab->scene(), &Scene::nextMainPropShortcut);
-    connect(m_prevSecndPropShortcut, &QShortcut::activated, m_currentTab->scene(), &Scene::prevSecndPropShortcut);
-    connect(m_nextSecndPropShortcut, &QShortcut::activated, m_currentTab->scene(), &Scene::nextSecndPropShortcut);
-    connect(m_changePrevElmShortcut, &QShortcut::activated, m_currentTab->scene(), &Scene::prevElm);
-    connect(m_changeNextElmShortcut, &QShortcut::activated, m_currentTab->scene(), &Scene::nextElm);
-    connect(m_currentTab->scene(), &Scene::openTruthTableRequested, this, [this] {
-        m_ui->elementEditor->truthTable();
-    });
     connect(m_currentTab->scene(), &Scene::icOpenRequested, this, [this](int elementId, const QString &blobName, const QString &filePath) {
         if (!blobName.isEmpty()) {
             if (m_currentTab) {
@@ -1203,25 +1117,6 @@ void MainWindow::connectTab()
             loadPandaFile(filePath);
         }
     });
-
-    if (m_ui->actionPlay->isChecked()) {
-        qCDebug(zero) << "Restarting simulation.";
-        m_currentTab->simulation()->start();
-        // Clear selection so the element editor doesn't show stale data from the
-        // previously active tab.
-        m_currentTab->scene()->clearSelection();
-    }
-
-    m_currentTab->view()->setFastMode(m_ui->actionFastMode->isChecked());
-    // Synchronise zoom button state to the newly visible tab's zoom level.
-    m_ui->actionZoomIn->setEnabled(m_currentTab->view()->canZoomIn());
-    m_ui->actionZoomOut->setEnabled(m_currentTab->view()->canZoomOut());
-
-    // Synchronise the mute button state to the newly visible tab's mute intent.
-    const bool muted = m_currentTab->simulation()->isUserMuted();
-    m_ui->actionMute->setChecked(muted);
-    m_ui->actionMute->setText(muted ? tr("Unmute") : tr("Mute"));
-
 }
 
 WorkSpace *MainWindow::currentTab() const
@@ -1340,16 +1235,6 @@ void MainWindow::on_actionResetZoom_triggered() const
 
         m_currentTab->view()->resetZoom();
     });
-}
-
-void MainWindow::zoomChanged()
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    m_ui->actionZoomIn->setEnabled(m_currentTab->view()->canZoomIn());
-    m_ui->actionZoomOut->setEnabled(m_currentTab->view()->canZoomOut());
 }
 
 void MainWindow::updateRecentFileActions()

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -11,32 +11,21 @@
 #endif
 
 #include <QActionGroup>
-#include <QCheckBox>
 #include <QCloseEvent>
 #include <QDebug>
 #include <QDesktopServices>
-#include <QDialog>
-#include <QDialogButtonBox>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QInputDialog>
-#include <QLabel>
 #include <QLocale>
 #include <QLoggingCategory>
 #include <QMessageBox>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QNetworkRequest>
 #include <QPixmapCache>
-#include <QProgressDialog>
 #include <QPushButton>
 #include <QSaveFile>
 #include <QShortcut>
-#include <QSslError>
-#include <QStandardPaths>
 #include <QTemporaryFile>
-#include <QVBoxLayout>
 
 #ifdef Q_OS_MAC
 #include <QSvgRenderer>
@@ -50,7 +39,6 @@
 #include "App/Core/SentryHelpers.h"
 #include "App/Core/Settings.h"
 #include "App/Core/ThemeManager.h"
-#include "App/Core/UpdateChecker.h"
 #include "App/Element/ElementFactory.h"
 #include "App/Element/ElementLabel.h"
 #include "App/Element/IC.h"
@@ -68,6 +56,7 @@
 #include "App/UI/FileDialogProvider.h"
 #include "App/UI/LanguageManager.h"
 #include "App/UI/MainWindowUI.h"
+#include "App/UI/UpdateController.h"
 #include "App/Versions.h"
 
 #ifdef Q_OS_MAC
@@ -512,114 +501,8 @@ void MainWindow::show()
     qCDebug(zero) << "Checking for autosave file recovery.";
     loadAutosaveFiles();
 
-    if (Application::interactiveMode) {
-        auto *updateChecker = new UpdateChecker(this);
-        connect(updateChecker, &UpdateChecker::updateAvailable, this, &MainWindow::showUpdateDialog);
-        updateChecker->checkForUpdates();
-    }
-}
-
-void MainWindow::showUpdateDialog(const QString &latestVersion, const QUrl &downloadUrl, const QUrl &releaseUrl)
-{
-    QDialog dialog(this);
-    dialog.setWindowTitle(tr("Update Available"));
-    dialog.setWindowModality(Qt::WindowModal);
-
-    auto *layout = new QVBoxLayout(&dialog);
-
-    const bool hasDirectDownload = downloadUrl.isValid() && !downloadUrl.isEmpty();
-    auto *label = new QLabel(
-        (hasDirectDownload
-             ? tr("<b>wiRedPanda %1 is available.</b><br><br>"
-                  "You are currently running version %2.<br>"
-                  "Click <b>Download</b> to save the new version to your computer.")
-             : tr("<b>wiRedPanda %1 is available.</b><br><br>"
-                  "You are currently running version %2.<br>"
-                  "Visit the release page to download the new version."))
-            .arg(latestVersion, APP_VERSION),
-        &dialog);
-    label->setTextFormat(Qt::RichText);
-    label->setWordWrap(true);
-    layout->addWidget(label);
-
-    auto *skipCheckBox = new QCheckBox(tr("Don't notify me about this version again"), &dialog);
-    layout->addWidget(skipCheckBox);
-
-    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, &dialog);
-    auto *downloadButton = buttonBox->addButton(tr("Download"), QDialogButtonBox::AcceptRole);
-    connect(downloadButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.accept(); });
-    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-    layout->addWidget(buttonBox);
-
-    const bool accepted = dialog.exec() == QDialog::Accepted;
-
-    if (skipCheckBox->isChecked()) {
-        Settings::setUpdateCheckSkippedVersion(latestVersion);
-    }
-
-    if (accepted) {
-        if (hasDirectDownload) {
-            downloadUpdate(latestVersion, downloadUrl);
-        } else {
-            QDesktopServices::openUrl(releaseUrl);
-            Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
-        }
-    } else {
-        /// User closed dialog without taking action — still record the check
-        Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
-    }
-}
-
-void MainWindow::downloadUpdate(const QString &latestVersion, const QUrl &url)
-{
-    const QString fileName = url.fileName();
-    const QString savePath = QDir(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)).filePath(fileName);
-
-    auto *progress = new QProgressDialog(tr("Downloading wiRedPanda %1…").arg(latestVersion), tr("Cancel"), 0, 100, this);
-    progress->setWindowTitle(tr("Downloading Update"));
-    progress->setWindowModality(Qt::WindowModal);
-    progress->setMinimumDuration(0);
-    progress->setValue(0);
-
-    auto *network = new QNetworkAccessManager(this);
-    QNetworkRequest request(url);
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-    QNetworkReply *reply = network->get(request);
-
-    connect(reply, &QNetworkReply::downloadProgress, progress, [progress](qint64 received, qint64 total) {
-        if (total > 0) {
-            progress->setValue(static_cast<int>(received * 100 / total));
-        }
-    });
-
-    connect(progress, &QProgressDialog::canceled, reply, &QNetworkReply::abort);
-
-    connect(reply, &QNetworkReply::finished, this, [this, reply, progress, savePath] {
-        progress->close();
-        progress->deleteLater();
-
-        if (reply->error() != QNetworkReply::NoError) {
-            if (reply->error() != QNetworkReply::OperationCanceledError) {
-                QMessageBox::warning(this, tr("Download Failed"), tr("Could not download the update:\n%1").arg(reply->errorString()));
-            }
-            reply->deleteLater();
-            return;
-        }
-
-        QFile file(savePath);
-        if (!file.open(QIODevice::WriteOnly)) {
-            QMessageBox::warning(this, tr("Download Failed"), tr("Could not save the file:\n%1").arg(savePath));
-            reply->deleteLater();
-            return;
-        }
-        file.write(reply->readAll());
-        file.close();
-        reply->deleteLater();
-
-        Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
-        QMessageBox::information(this, tr("Download Complete"),
-            tr("wiRedPanda has been downloaded to:\n%1").arg(savePath));
-    });
+    auto *updateController = new UpdateController(this);
+    updateController->checkForUpdates();
 }
 
 void MainWindow::aboutThisVersion()

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -23,9 +23,7 @@
 #include <QMessageBox>
 #include <QPixmapCache>
 #include <QPushButton>
-#include <QSaveFile>
 #include <QShortcut>
-#include <QTemporaryFile>
 
 #ifdef Q_OS_MAC
 #include <QSvgRenderer>
@@ -43,18 +41,17 @@
 #include "App/Element/ICPreviewPopup.h"
 #include "App/Element/ICRegistry.h"
 #include "App/IO/RecentFiles.h"
-#include "App/IO/Serialization.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "App/UI/ElementPalette.h"
 #include "App/UI/ExportController.h"
-#include "App/UI/FileDialogProvider.h"
 #include "App/UI/ICController.h"
 #include "App/UI/LanguageManager.h"
 #include "App/UI/MainWindowUI.h"
 #include "App/UI/SceneUiBinder.h"
 #include "App/UI/UpdateController.h"
+#include "App/UI/WorkspaceManager.h"
 #include "App/Versions.h"
 
 #ifdef Q_OS_MAC
@@ -88,6 +85,13 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
     m_exportController = new ExportController(*this, this);
     m_icController = new ICController(*this, this);
     m_binder = new SceneUiBinder(m_ui.get(), m_palette, this, this);
+    m_workspaceManager = new WorkspaceManager(m_ui->tab, *this, this);
+
+    // The manager owns the tab model and announces active-tab changes; the shell
+    // rebinds the chrome. The binder forwards scene-driven navigation back to the manager.
+    connect(m_workspaceManager, &WorkspaceManager::currentTabChanged, this, &MainWindow::onCurrentTabChanged);
+    connect(m_binder, &SceneUiBinder::openICRequested, m_workspaceManager, &WorkspaceManager::openICInTab);
+    connect(m_binder, &SceneUiBinder::loadFileRequested, m_workspaceManager, &WorkspaceManager::loadPandaFile);
 
     setupLanguage();
     setupGeometry();
@@ -191,7 +195,7 @@ void MainWindow::setupTheme()
 void MainWindow::setupRecentFiles()
 {
     m_recentFiles = new RecentFiles(this);
-    connect(this,          &MainWindow::addRecentFile,         m_recentFiles, &RecentFiles::addRecentFile);
+    connect(m_workspaceManager, &WorkspaceManager::recentFileAdded, m_recentFiles, &RecentFiles::addRecentFile);
     connect(m_recentFiles, &RecentFiles::recentFilesUpdated,   this,          &MainWindow::updateRecentFileActions);
     createRecentFileActions();
 }
@@ -253,8 +257,8 @@ void MainWindow::setupShortcuts()
 
 void MainWindow::setupConnections()
 {
-    connect(m_ui->tab, &QTabWidget::currentChanged,    this, &MainWindow::tabChanged);
-    connect(m_ui->tab, &QTabWidget::tabCloseRequested, this, &MainWindow::closeTab);
+    connect(m_ui->tab, &QTabWidget::currentChanged,    m_workspaceManager, &WorkspaceManager::onCurrentIndexChanged);
+    connect(m_ui->tab, &QTabWidget::tabCloseRequested, m_workspaceManager, &WorkspaceManager::closeTab);
 
     connect(m_ui->actionAbout,                 &QAction::triggered,       this,                &MainWindow::on_actionAbout_triggered);
     connect(m_ui->actionAboutQt,               &QAction::triggered,       this,                &MainWindow::on_actionAboutQt_triggered);
@@ -276,16 +280,16 @@ void MainWindow::setupConnections()
     connect(m_ui->actionLabelsUnderIcons,      &QAction::triggered,       this,                &MainWindow::on_actionLabelsUnderIcons_triggered);
     connect(m_ui->actionLightTheme,            &QAction::triggered,       this,                &MainWindow::on_actionLightTheme_triggered);
     connect(m_ui->actionMute,                  &QAction::triggered,       this,                &MainWindow::on_actionMute_triggered);
-    connect(m_ui->actionNew,                   &QAction::triggered,       this,                &MainWindow::on_actionNew_triggered);
-    connect(m_ui->actionOpen,                  &QAction::triggered,       this,                &MainWindow::on_actionOpen_triggered);
+    connect(m_ui->actionNew,                   &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::newTab);
+    connect(m_ui->actionOpen,                  &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::openFile);
     connect(m_ui->actionPlay,                  &QAction::toggled,         this,                &MainWindow::on_actionPlay_toggled);
-    connect(m_ui->actionReloadFile,            &QAction::triggered,       this,                &MainWindow::on_actionReloadFile_triggered);
+    connect(m_ui->actionReloadFile,            &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::reloadFile);
     connect(m_ui->actionRename,                &QAction::triggered,       m_ui->elementEditor, &ElementEditor::renameAction);
 
     // ElementEditor IC sub-circuit actions
     connect(m_ui->elementEditor, &ElementEditor::editSubcircuitRequested, this, [this](const QString &blobName, int icElementId) {
-        if (m_currentTab) {
-            openICInTab(blobName, icElementId, m_currentTab->scene()->icRegistry()->blob(blobName));
+        if (currentTab()) {
+            openICInTab(blobName, icElementId, currentTab()->scene()->icRegistry()->blob(blobName));
         }
     });
     connect(m_ui->elementEditor, &ElementEditor::embedSubcircuitRequested, m_icController, &ICController::embedSelectedIC);
@@ -294,8 +298,8 @@ void MainWindow::setupConnections()
     connect(m_ui->actionRestart,               &QAction::triggered,       this,                &MainWindow::on_actionRestart_triggered);
     connect(m_ui->actionRotateLeft,            &QAction::triggered,       this,                &MainWindow::on_actionRotateLeft_triggered);
     connect(m_ui->actionRotateRight,           &QAction::triggered,       this,                &MainWindow::on_actionRotateRight_triggered);
-    connect(m_ui->actionSave,                  &QAction::triggered,       this,                &MainWindow::on_actionSave_triggered);
-    connect(m_ui->actionSaveAs,               &QAction::triggered,       this,                &MainWindow::on_actionSaveAs_triggered);
+    connect(m_ui->actionSave,                  &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::saveFile);
+    connect(m_ui->actionSaveAs,               &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::saveFileAs);
     connect(m_ui->actionSelectAll,             &QAction::triggered,       this,                &MainWindow::on_actionSelectAll_triggered);
     connect(m_ui->actionShortcutsAndTips,      &QAction::triggered,       this,                &MainWindow::on_actionShortcuts_and_Tips_triggered);
     connect(m_ui->actionWaveform,              &QAction::triggered,       this,                &MainWindow::on_actionWaveform_triggered);
@@ -303,7 +307,7 @@ void MainWindow::setupConnections()
     connect(m_ui->actionZoomIn,                &QAction::triggered,       this,                &MainWindow::on_actionZoomIn_triggered);
     connect(m_ui->actionZoomOut,               &QAction::triggered,       this,                &MainWindow::on_actionZoomOut_triggered);
     connect(m_palette,                         &ElementPalette::addElementRequested, this, [this](QMimeData *mimeData) {
-        if (m_currentTab) m_currentTab->scene()->addItem(mimeData);
+        if (currentTab()) currentTab()->scene()->addItem(mimeData);
     });
     connect(m_ui->pushButtonAddIC,             &QPushButton::clicked,     m_icController,      &ICController::addICFromFile);
     connect(m_ui->pushButtonRemoveIC,          &QPushButton::clicked,     m_icController,      &ICController::showRemoveICHint);
@@ -332,79 +336,29 @@ void MainWindow::setupConnections()
 void MainWindow::connectSceneAction(QAction *action, void (Scene::*method)())
 {
     connect(action, &QAction::triggered, this, [this, method] {
-        if (m_currentTab) {
-            (m_currentTab->scene()->*method)();
+        if (currentTab()) {
+            (currentTab()->scene()->*method)();
         }
     });
 }
 
 MainWindow::~MainWindow()
 {
-    disconnectTab();
-}
-
-void MainWindow::loadAutosaveFiles()
-{
-    QStringList autosaves(Settings::autosaveFiles());
-
-    qCDebug(zero) << "All autosave files: " << autosaves;
-
-    for (auto it = autosaves.begin(); it != autosaves.end();) {
-        QFile file(*it);
-
-        if (!file.exists()) {
-            qCDebug(zero) << "Removing from config the autosave file that does not exist.";
-            it = autosaves.erase(it);
-            continue;
-        }
-
-        try {
-            loadPandaFile(*it);
-        } catch (const std::exception &e) {
-            if (Application::interactiveMode) {
-                QMessageBox::critical(nullptr, tr("Error!"), e.what());
-            }
-            qCDebug(zero) << "Removing autosave file that is corrupted.";
-            it = autosaves.erase(it);
-            continue;
-        }
-
-        // Mark the newly loaded tab so it knows it came from an autosave,
-        // causing it to prompt for a real save path on the next Ctrl+S.
-        m_currentTab->setAutosaveFile();
-
-        ++it;
-    }
-
-    Settings::setAutosaveFiles(autosaves);
+    // Tear down the active tab's chrome wiring before child objects are destroyed.
+    m_binder->unbind();
 }
 
 void MainWindow::createNewTab()
 {
-    qCDebug(zero) << "Creating new workspace.";
-    auto *workspace = new WorkSpace(this);
-
-    connect(workspace, &WorkSpace::fileChanged, this, &MainWindow::setCurrentFile);
-
-    workspace->view()->setFastMode(m_ui->actionFastMode->isChecked());
-    workspace->scene()->updateTheme();
-
-    qCDebug(zero) << "Adding tab. #tabs: " << m_ui->tab->count() << ", current tab: " << m_tabIndex;
-    m_ui->tab->addTab(workspace, tr("New Project"));
-    sentryBreadcrumb("ui", QStringLiteral("Tab opened"));
-
-    qCDebug(zero) << "Selecting the newly created tab.";
-    m_ui->tab->setCurrentIndex(m_ui->tab->count() - 1);
-
-    qCDebug(zero) << "Finished #tabs: " << m_ui->tab->count() << ", current tab: " << m_tabIndex;
+    m_workspaceManager->createNewTab();
 }
 
 void MainWindow::setFastMode(const bool fastMode)
 {
     m_ui->actionFastMode->setChecked(fastMode);
 
-    if (m_currentTab) {
-        m_currentTab->view()->setFastMode(fastMode);
+    if (currentTab()) {
+        currentTab()->view()->setFastMode(fastMode);
     }
 }
 
@@ -417,13 +371,7 @@ void MainWindow::on_actionExit_triggered()
 
 void MainWindow::save(const QString &fileName)
 {
-    if (!m_currentTab) {
-        return;
-    }
-
-    m_currentTab->save(fileName);
-    m_palette->updateICList(icListFile());
-    m_ui->statusBar->showMessage(tr("File saved successfully."), 4000);
+    m_workspaceManager->save(fileName);
 }
 
 void MainWindow::show()
@@ -431,7 +379,7 @@ void MainWindow::show()
     QMainWindow::show();
 
     qCDebug(zero) << "Checking for autosave file recovery.";
-    loadAutosaveFiles();
+    m_workspaceManager->loadAutosaveFiles();
 
     auto *updateController = new UpdateController(this);
     updateController->checkForUpdates();
@@ -461,52 +409,12 @@ void MainWindow::aboutThisVersion()
     msgBox.exec();
 }
 
-int MainWindow::closeTabAnyway()
-{
-    QMessageBox msgBox;
-    msgBox.setParent(this);
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox.setText(tr("File not saved. Close tab anyway?"));
-    msgBox.setWindowModality(Qt::WindowModal);
-    msgBox.setDefaultButton(QMessageBox::No);
-    return msgBox.exec();
-}
-
-int MainWindow::confirmSave(const bool multiple)
-{
-    QMessageBox msgBox;
-    msgBox.setParent(this);
-
-    // When closing all tabs at once, offer "Yes to All" / "No to All" to avoid
-    // repeated per-file prompts.
-    if (multiple) {
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel);
-    } else {
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-    }
-
-    const QString fileName = currentFile().fileName().isEmpty() ? tr("New Project") : currentFile().fileName();
-
-    msgBox.setText(fileName + tr(" has been modified.\nDo you want to save your changes?"));
-    msgBox.setWindowModality(Qt::WindowModal);
-    msgBox.setDefaultButton(QMessageBox::Yes);
-    return msgBox.exec();
-}
-
-void MainWindow::on_actionNew_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ui", QStringLiteral("New project"));
-        createNewTab();
-    });
-}
-
 void MainWindow::on_actionWires_triggered(const bool checked)
 {
     Application::guardedSlot(this, [this, checked] {
         sentryBreadcrumb("ui", QStringLiteral("Wires: %1").arg(checked));
-        if (m_currentTab) {
-            m_currentTab->scene()->showWires(checked);
+        if (currentTab()) {
+            currentTab()->scene()->showWires(checked);
         }
     });
 }
@@ -514,8 +422,8 @@ void MainWindow::on_actionWires_triggered(const bool checked)
 void MainWindow::on_actionRotateRight_triggered()
 {
     Application::guardedSlot(this, [this] {
-        if (m_currentTab) {
-            m_currentTab->scene()->rotateRight();
+        if (currentTab()) {
+            currentTab()->scene()->rotateRight();
         }
     });
 }
@@ -523,229 +431,20 @@ void MainWindow::on_actionRotateRight_triggered()
 void MainWindow::on_actionRotateLeft_triggered()
 {
     Application::guardedSlot(this, [this] {
-        if (m_currentTab) {
-            m_currentTab->scene()->rotateLeft();
+        if (currentTab()) {
+            currentTab()->scene()->rotateLeft();
         }
     });
 }
 
 void MainWindow::loadPandaFile(const QString &fileName)
 {
-    const QFileInfo newFileInfo(fileName);
-
-    for (int i = 0; i < m_ui->tab->count(); ++i) {
-        if (auto *workspace = qobject_cast<WorkSpace *>(m_ui->tab->widget(i))) {
-            if (workspace->fileInfo() == newFileInfo) {
-                m_ui->tab->setCurrentIndex(i);
-                return;
-            }
-        }
-    }
-
-    createNewTab();
-    qCDebug(zero) << "Loading in editor.";
-    try {
-        m_currentTab->load(fileName);
-    } catch (...) {
-        // Drop the half-populated tab so we don't leak an empty workspace
-        // into the tab bar. Clear the undo stack first so closeTab doesn't
-        // prompt the user to save the partial load.
-        m_currentTab->scene()->undoStack()->clear();
-        closeTab(m_tabIndex);
-        throw;
-    }
-    // Tighten the scene rect to the loaded items immediately so subsequent
-    // interactions (selection, drag release) don't cause a viewport jump.
-    m_currentTab->scene()->resizeScene();
-    m_palette->updateICList(icListFile());
-    m_palette->updateEmbeddedICList(m_currentTab->scene());
-    m_ui->statusBar->showMessage(tr("File loaded successfully."), 4000);
+    m_workspaceManager->loadPandaFile(fileName);
 }
 
 void MainWindow::openICInTab(const QString &blobName, int icElementId, const QByteArray &blob)
 {
-    if (!m_currentTab) {
-        return;
-    }
-
-    // Check if this blob is already being edited in a tab
-    for (int i = 0; i < m_ui->tab->count(); ++i) {
-        auto *ws = qobject_cast<WorkSpace *>(m_ui->tab->widget(i));
-        if (ws && ws->isInlineIC() && ws->inlineBlobName() == blobName
-            && ws->parentWorkspace() == m_currentTab) {
-            m_ui->tab->setCurrentIndex(i);
-            return;
-        }
-    }
-
-    auto *parentWorkspace = m_currentTab;
-
-    createNewTab();
-
-    m_currentTab->loadFromBlob(blob, parentWorkspace, icElementId, parentWorkspace->scene()->contextDir());
-    // Tighten the scene rect to the loaded items immediately so subsequent
-    // interactions (selection, drag release) don't cause a viewport jump.
-    m_currentTab->scene()->resizeScene();
-
-    // Hide management buttons for inline tabs (they use currentFile/currentDir which are empty)
-    setICButtonsVisible(false);
-
-    // Set tab title
-    int tabIndex = m_ui->tab->indexOf(m_currentTab);
-    m_ui->tab->setTabText(tabIndex, "[" + blobName + "]");
-
-    m_palette->updateICList(icListFile());
-    m_palette->updateEmbeddedICList(m_currentTab->scene());
-
-    // Connect child tab's save signal to parent
-    connect(m_currentTab, &WorkSpace::icBlobSaved, parentWorkspace, &WorkSpace::onChildICBlobSaved);
-}
-
-void MainWindow::on_actionOpen_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("file", QStringLiteral("Open file dialog"));
-    #ifdef Q_OS_WASM
-        auto fileContentReady = [this](const QString &fileName, const QByteArray &fileContent) {
-            if (!fileName.isEmpty()) {
-                // Write file content to a temporary file
-                QFile file(fileName);
-                file.open(QIODevice::WriteOnly);
-                file.write(fileContent);
-                file.close();
-                loadPandaFile(fileName);
-            }
-        };
-        QFileDialog::getOpenFileContent("Panda files (*.panda)", fileContentReady);
-    #else
-        const QString path = currentFile().exists() ? "" : "./Examples";
-        const QString fileName = FileDialogs::provider()->getOpenFileName(this, tr("Open File"), path, tr("Panda files (*.panda)"));
-
-        if (fileName.isEmpty()) {
-            return;
-        }
-
-        loadPandaFile(fileName);
-    #endif
-    });
-}
-
-void MainWindow::on_actionSave_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("file", QStringLiteral("Save"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        // Inline IC tabs serialize to a blob and emit to parent — no file dialog needed.
-        if (m_currentTab->isInlineIC()) {
-            save(QString());
-            return;
-        }
-
-    #ifdef Q_OS_WASM
-        on_actionSaveAs_triggered();
-    #else
-        // TODO: if current file is autosave ask for filename
-
-        // If the project has never been saved, fall through to a Save-As dialog.
-        QString fileName = currentFile().absoluteFilePath();
-
-        if (fileName.isEmpty()) {
-            fileName = FileDialogs::provider()->getSaveFileName(this, tr("Save File as ..."), QString(), tr("Panda files (*.panda)")).fileName;
-
-            if (fileName.isEmpty()) {
-                return;
-            }
-
-            ensureFileExtension(fileName, ".panda");
-        }
-
-        const int conflictTab = findTabWithFile(fileName);
-        if (conflictTab != -1) {
-            QMessageBox msgBox(QMessageBox::Warning,
-                               tr("File Conflict"),
-                               tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
-                               QMessageBox::Ok,
-                               this);
-            QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
-            msgBox.exec();
-            if (msgBox.clickedButton() == switchBtn) {
-                m_ui->tab->setCurrentIndex(conflictTab);
-            }
-            return;
-        }
-
-        save(fileName);
-    #endif
-    });
-}
-
-void MainWindow::on_actionSaveAs_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("file", QStringLiteral("Save as"));
-        if (!m_currentTab) {
-            return;
-        }
-
-    #ifdef Q_OS_WASM
-        // Save to a temporary file in the virtual FS, then offer it as a browser download.
-        const QString tmpPath = "/tmp/wiredpanda_save.panda";
-        save(tmpPath);
-
-        QFile file(tmpPath);
-        if (file.open(QIODevice::ReadOnly)) {
-            const QByteArray content = file.readAll();
-            file.close();
-
-            QString suggestedName = currentFile().fileName();
-            if (suggestedName.isEmpty()) {
-                suggestedName = "circuit.panda";
-            }
-            QFileDialog::saveFileContent(content, suggestedName);
-        }
-    #else
-        QString fileName = FileDialogs::provider()->getSaveFileName(this, tr("Save File as ..."), currentFile().absoluteFilePath(), tr("Panda files (*.panda)")).fileName;
-
-        if (fileName.isEmpty()) {
-            return;
-        }
-
-        ensureFileExtension(fileName, ".panda");
-
-        const int conflictTab = findTabWithFile(fileName);
-        if (conflictTab != -1) {
-            QMessageBox msgBox(QMessageBox::Warning,
-                               tr("File Conflict"),
-                               tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
-                               QMessageBox::Ok,
-                               this);
-            QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
-            msgBox.exec();
-            if (msgBox.clickedButton() == switchBtn) {
-                m_ui->tab->setCurrentIndex(conflictTab);
-            }
-            return;
-        }
-
-        save(fileName);
-    #endif
-    });
-}
-
-int MainWindow::findTabWithFile(const QString &fileName) const
-{
-    const QFileInfo newFileInfo(fileName);
-    for (int i = 0; i < m_ui->tab->count(); ++i) {
-        if (auto *workspace = qobject_cast<WorkSpace *>(m_ui->tab->widget(i))) {
-            if (workspace != m_currentTab && workspace->fileInfo() == newFileInfo) {
-                return i;
-            }
-        }
-    }
-    return -1;
+    m_workspaceManager->openICInTab(blobName, icElementId, blob);
 }
 
 void MainWindow::on_actionAbout_triggered()
@@ -815,17 +514,6 @@ void MainWindow::on_actionReportTranslationError_triggered()
     });
 }
 
-bool MainWindow::closeFiles()
-{
-    // Close from last to first so that tab indices stay stable during iteration.
-    while (m_ui->tab->count() != 0) {
-        if (!closeTab(m_ui->tab->count() - 1)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     bool closeWindow = false;
@@ -833,7 +521,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     // If nothing is modified, ask once before exiting so the user can't
     // accidentally quit with a keyboard shortcut.  If there are unsaved changes,
     // delegate to closeFiles() which prompts per-tab.
-    if (!hasModifiedFiles()) {
+    if (!m_workspaceManager->hasModifiedFiles()) {
         auto reply =
             QMessageBox::question(
                 this,
@@ -845,7 +533,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
         if (reply == QMessageBox::Yes) {
             closeWindow = true;
         }
-    } else if (closeFiles()) {
+    } else if (m_workspaceManager->closeFiles()) {
         closeWindow = true;
     }
 
@@ -866,13 +554,6 @@ void MainWindow::updateSettings()
     Settings::setSplitterState(m_ui->splitter->saveState());
 }
 
-void MainWindow::ensureFileExtension(QString &fileName, const QString &extension)
-{
-    if (!fileName.endsWith(extension)) {
-        fileName.append(extension);
-    }
-}
-
 void MainWindow::setICButtonsVisible(bool visible)
 {
     m_ui->pushButtonAddIC->setVisible(visible);
@@ -885,52 +566,18 @@ void MainWindow::refreshICButtonsEnabled()
     // Add IC needs a real project directory to copy the chosen .panda into;
     // gating click-ability on a saved file avoids the "Save file first."
     // throw → modal-error UX dead end.
-    const bool hasFile = m_currentTab && m_currentTab->fileInfo().isReadable();
+    const bool hasFile = currentTab() && currentTab()->fileInfo().isReadable();
     m_ui->pushButtonAddIC->setEnabled(hasFile);
-}
-
-bool MainWindow::hasModifiedFiles()
-{
-    const QStringList autosaves = Settings::autosaveFiles();
-
-    const auto workspaces = m_ui->tab->findChildren<WorkSpace *>();
-
-    for (auto *workspace : workspaces) {
-        auto *scene = workspace->scene();
-        if (!scene) {
-            continue;
-        }
-
-        auto *undoStack = scene->undoStack();
-        if (!undoStack) {
-            continue;
-        }
-
-        // An un-clean undo stack means uncommitted edits since the last save.
-        if (!undoStack->isClean()) {
-            return true;
-        }
-
-        // An autosave file that is still in the list has not been explicitly
-        // saved by the user yet and should be treated as modified.
-        const QString fileName = workspace->fileInfo().fileName();
-
-        if (!fileName.isEmpty() && autosaves.contains(fileName)) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 QFileInfo MainWindow::currentFile() const
 {
-    return m_currentTab ? m_currentTab->fileInfo() : QFileInfo();
+    return m_workspaceManager->currentFile();
 }
 
 QDir MainWindow::currentDir() const
 {
-    return m_currentTab ? m_currentTab->fileInfo().absoluteDir() : QDir();
+    return m_workspaceManager->currentDir();
 }
 
 QWidget *MainWindow::widget()
@@ -950,7 +597,7 @@ ElementPalette *MainWindow::palette() const
 
 void MainWindow::requestSave()
 {
-    on_actionSave_triggered();
+    m_workspaceManager->saveFile();
 }
 
 void MainWindow::showStatusMessage(const QString &message, int timeout)
@@ -960,168 +607,24 @@ void MainWindow::showStatusMessage(const QString &message, int timeout)
 
 QFileInfo MainWindow::icListFile() const
 {
-    // Walk up the parent workspace chain to find the root file on disk.
-    // Inline IC workspaces have no file of their own.
-    auto *ws = m_currentTab;
-    while (ws && ws->isInlineIC() && ws->parentWorkspace()) {
-        ws = ws->parentWorkspace();
-    }
-    if (ws) {
-        return ws->fileInfo();
-    }
-    return currentFile();
-}
-
-void MainWindow::setCurrentFile(const QFileInfo &fileInfo)
-{
-    // Find the tab belonging to the workspace that emitted the signal.
-    // The sender may differ from m_currentTab (e.g. a parent workspace emitting
-    // fileChanged while an inline IC child tab is active).
-    auto *senderWs = qobject_cast<WorkSpace *>(sender());
-    if (!senderWs) {
-        senderWs = m_currentTab;
-    }
-    if (!senderWs) {
-        return;
-    }
-
-    const int tabIndex = m_ui->tab->indexOf(senderWs);
-    if (tabIndex < 0) {
-        return;
-    }
-
-    // Inline IC tabs use "[blobName]" as title — never the parent filename.
-    QString text;
-    if (senderWs->isInlineIC()) {
-        text = "[" + senderWs->inlineBlobName() + "]";
-    } else {
-        text = fileInfo.exists() ? fileInfo.fileName() : tr("New Project");
-    }
-
-    // Append an asterisk to the tab title to indicate unsaved changes,
-    // following the common editor convention.
-    auto *scene = senderWs->scene();
-    if (scene) {
-        auto *undoStack = scene->undoStack();
-        if (undoStack && !undoStack->isClean()) {
-            text += "*";
-        }
-    }
-
-    m_ui->tab->setTabText(tabIndex, text);
-
-    // Only update tooltip and recent files for file-backed tabs.
-    if (!senderWs->isInlineIC()) {
-        m_ui->tab->setTabToolTip(tabIndex, fileInfo.absoluteFilePath());
-        qCDebug(zero) << "Adding file to recent files.";
-        emit addRecentFile(fileInfo.absoluteFilePath());
-    }
-
-    if (senderWs == m_currentTab) {
-        refreshICButtonsEnabled();
-    }
+    return m_workspaceManager->icListFile();
 }
 
 void MainWindow::on_actionSelectAll_triggered()
 {
     Application::guardedSlot(this, [this] {
         sentryBreadcrumb("ui", QStringLiteral("Select all"));
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->scene()->selectAll();
-    });
-}
-
-bool MainWindow::closeTab(const int tabIndex)
-{
-    qCDebug(zero) << "Closing tab " << tabIndex + 1 << ", #tabs: " << m_ui->tab->count();
-    // Activate the tab being closed so m_currentTab reflects the right workspace
-    // before we inspect its undo stack.
-    m_ui->tab->setCurrentIndex(tabIndex);
-
-    qCDebug(zero) << "Checking if needs to save file.";
-
-    bool needsSave = false;
-    if (m_currentTab) {
-        auto *scene = m_currentTab->scene();
-        if (scene) {
-            auto *undoStack = scene->undoStack();
-            needsSave = undoStack && !undoStack->isClean();
-        }
-    }
-
-    if (needsSave) {
-        const int selectedButton = confirmSave(false);
-
-        if (selectedButton == QMessageBox::Cancel) {
-            return false;
-        }
-
-        if (selectedButton == QMessageBox::Yes) {
-            try {
-                save();
-            } catch (const std::exception &e) {
-                QMessageBox::critical(this, tr("Error"), e.what());
-
-                // If saving failed ask whether to discard and close anyway.
-                if (closeTabAnyway() == QMessageBox::No) {
-                    return false;
-                }
-            }
-        }
-    }
-
-    qCDebug(zero) << "Deleting tab.";
-    m_currentTab->deleteLater();
-    sentryBreadcrumb("ui", QStringLiteral("Tab closed"));
-    m_ui->tab->removeTab(tabIndex);
-
-    qCDebug(zero) << "Closed tab " << tabIndex << ", #tabs: " << m_ui->tab->count() << ", current tab: " << m_tabIndex;
-
-    return true;
-}
-
-void MainWindow::disconnectTab()
-{
-    // Called before switching away from a tab. SceneUiBinder tears down the chrome
-    // wiring; the IC-open navigation connection is owned here (it drives tab/file
-    // opening, not chrome).
-    if (!m_currentTab) {
-        return;
-    }
-
-    disconnect(m_currentTab->scene(), &Scene::icOpenRequested, this, nullptr);
-    m_binder->unbind();
-}
-
-void MainWindow::connectTab()
-{
-    m_binder->bind(m_currentTab);
-
-    // Tab-navigation wiring (not chrome): the file-based IC list, IC tool-button
-    // state, and the scene's open-IC-in-tab / open-file requests.
-    m_palette->updateICList(icListFile());
-
-    // Hide management buttons for inline IC tabs (they use currentFile/currentDir which are empty)
-    setICButtonsVisible(!m_currentTab->isInlineIC());
-    refreshICButtonsEnabled();
-
-    connect(m_currentTab->scene(), &Scene::icOpenRequested, this, [this](int elementId, const QString &blobName, const QString &filePath) {
-        if (!blobName.isEmpty()) {
-            if (m_currentTab) {
-                openICInTab(blobName, elementId, m_currentTab->scene()->icRegistry()->blob(blobName));
-            }
-        } else if (!filePath.isEmpty()) {
-            loadPandaFile(filePath);
-        }
+        currentTab()->scene()->selectAll();
     });
 }
 
 WorkSpace *MainWindow::currentTab() const
 {
-    return m_currentTab;
+    return m_workspaceManager->currentTab();
 }
 
 ICPreviewPopup *MainWindow::icPreviewPopup() const
@@ -1129,49 +632,35 @@ ICPreviewPopup *MainWindow::icPreviewPopup() const
     return m_icPreviewPopup;
 }
 
-void MainWindow::tabChanged(const int newTabIndex)
+void MainWindow::onCurrentTabChanged(WorkSpace *newTab)
 {
-    sentryBreadcrumb("ui", QStringLiteral("Tab changed to index %1").arg(newTabIndex));
-    disconnectTab(); // disconnect previously selected tab
-    m_tabIndex = newTabIndex;
-    // Hide the editor panel during the transition; connectTab() will restore it
+    // Reaction to WorkspaceManager::currentTabChanged: rebind the shared chrome to the
+    // new scene and refresh the tab-navigation view state (file-based IC list, buttons).
+    m_binder->unbind(); // tear down the previously bound tab's chrome wiring
+    // Hide the editor panel during the transition; SceneUiBinder::bind restores it
     // once the new scene's selection is known.
     m_ui->elementEditor->hide();
 
-    if (newTabIndex == -1) {
+    if (!newTab) {
         // All tabs were closed; reset state.
-        m_currentTab = nullptr;
         m_palette->updateICList(QFileInfo());
         m_palette->updateEmbeddedICList(nullptr);
         return;
     }
 
-    m_currentTab = qobject_cast<WorkSpace *>(m_ui->tab->currentWidget());
-    qCDebug(zero) << "Selecting tab: " << newTabIndex;
-    connectTab();
-    qCDebug(zero) << "New tab selected. Dolphin fileName: " << m_currentTab->dolphinFileName();
-}
+    m_binder->bind(newTab);
+    m_palette->updateICList(icListFile());
 
-void MainWindow::on_actionReloadFile_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("file", QStringLiteral("Reload file"));
-        if (!currentFile().exists() || !m_currentTab) {
-            return;
-        }
-
-        const QString file = currentFile().absoluteFilePath();
-
-        closeTab(m_tabIndex);
-        loadPandaFile(file);
-    });
+    // Hide management buttons for inline IC tabs (they use currentFile/currentDir which are empty)
+    setICButtonsVisible(!newTab->isInlineIC());
+    refreshICButtonsEnabled();
 }
 
 void MainWindow::on_actionGates_triggered(const bool checked)
 {
     Application::guardedSlot(this, [this, checked] {
         sentryBreadcrumb("ui", QStringLiteral("Gates: %1").arg(checked));
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
@@ -1179,8 +668,8 @@ void MainWindow::on_actionGates_triggered(const bool checked)
         // make no sense and should be hidden too.  Re-enable the wire toggle only when
         // gates are shown so the user can't end up with floating wires.
         m_ui->actionWires->setEnabled(checked);
-        m_currentTab->scene()->showWires(checked ? m_ui->actionWires->isChecked() : checked);
-        m_currentTab->scene()->showGates(checked);
+        currentTab()->scene()->showWires(checked ? m_ui->actionWires->isChecked() : checked);
+        currentTab()->scene()->showGates(checked);
     });
 }
 
@@ -1207,33 +696,33 @@ void MainWindow::exportToWaveFormTerminal()
 void MainWindow::on_actionZoomIn_triggered() const
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->view()->zoomIn();
+        currentTab()->view()->zoomIn();
     });
 }
 
 void MainWindow::on_actionZoomOut_triggered() const
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->view()->zoomOut();
+        currentTab()->view()->zoomOut();
     });
 }
 
 void MainWindow::on_actionResetZoom_triggered() const
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->view()->resetZoom();
+        currentTab()->view()->resetZoom();
     });
 }
 
@@ -1360,11 +849,11 @@ void MainWindow::populateLanguageMenu()
 void MainWindow::on_actionPlay_toggled(const bool checked)
 {
     sentryBreadcrumb("simulation", QStringLiteral("Play toggled: %1").arg(checked));
-    if (!m_currentTab) {
+    if (!currentTab()) {
         return;
     }
 
-    auto *simulation = m_currentTab->simulation();
+    auto *simulation = currentTab()->simulation();
 
     // The action is checkable; its toggled(bool) signal drives start/stop directly.
     checked ? simulation->start() : simulation->stop();
@@ -1374,11 +863,11 @@ void MainWindow::on_actionRestart_triggered()
 {
     Application::guardedSlot(this, [this] {
         sentryBreadcrumb("simulation", QStringLiteral("Simulation restart"));
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->simulation()->restart();
+        currentTab()->simulation()->restart();
     });
 }
 
@@ -1412,14 +901,14 @@ void MainWindow::on_actionFastMode_triggered(const bool checked)
 void MainWindow::on_actionWaveform_triggered()
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
         sentryBreadcrumb("ui", QStringLiteral("Waveform dialog opened"));
-        qCDebug(zero) << "BD fileName: " << m_currentTab->dolphinFileName();
-        auto *bewavedDolphin = new BewavedDolphin(m_currentTab->scene(), true, this);
-        bewavedDolphin->createWaveform(m_currentTab->dolphinFileName());
+        qCDebug(zero) << "BD fileName: " << currentTab()->dolphinFileName();
+        auto *bewavedDolphin = new BewavedDolphin(currentTab()->scene(), true, this);
+        bewavedDolphin->createWaveform(currentTab()->dolphinFileName());
         bewavedDolphin->show();
     });
 }
@@ -1463,41 +952,33 @@ void MainWindow::updateTheme()
 void MainWindow::on_actionFlipHorizontally_triggered()
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->scene()->flipHorizontally();
+        currentTab()->scene()->flipHorizontally();
     });
 }
 
 void MainWindow::on_actionFlipVertically_triggered()
 {
     Application::guardedSlot(this, [this] {
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->scene()->flipVertically();
+        currentTab()->scene()->flipVertically();
     });
 }
 
 QString MainWindow::dolphinFileName()
 {
-    if (!m_currentTab) {
-        return {};
-    }
-
-    return m_currentTab->dolphinFileName();
+    return m_workspaceManager->dolphinFileName();
 }
 
 void MainWindow::setDolphinFileName(const QString &fileName)
 {
-    if (!m_currentTab) {
-        return;
-    }
-
-    m_currentTab->setDolphinFileName(fileName);
+    m_workspaceManager->setDolphinFileName(fileName);
 }
 
 void MainWindow::on_actionFullscreen_triggered()
@@ -1512,11 +993,11 @@ void MainWindow::on_actionMute_triggered(const bool checked)
 {
     Application::guardedSlot(this, [this, checked] {
         sentryBreadcrumb("ui", QStringLiteral("Mute toggled"));
-        if (!m_currentTab) {
+        if (!currentTab()) {
             return;
         }
 
-        m_currentTab->simulation()->setUserMuted(checked);
+        currentTab()->simulation()->setUserMuted(checked);
         m_ui->actionMute->setText(checked ? tr("Unmute") : tr("Mute"));
     });
 }

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -18,7 +18,6 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QInputDialog>
 #include <QLocale>
 #include <QLoggingCategory>
 #include <QMessageBox>
@@ -45,13 +44,13 @@
 #include "App/Element/ICRegistry.h"
 #include "App/IO/RecentFiles.h"
 #include "App/IO/Serialization.h"
-#include "App/Scene/Commands.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "App/UI/ElementPalette.h"
 #include "App/UI/ExportController.h"
 #include "App/UI/FileDialogProvider.h"
+#include "App/UI/ICController.h"
 #include "App/UI/LanguageManager.h"
 #include "App/UI/MainWindowUI.h"
 #include "App/UI/UpdateController.h"
@@ -86,6 +85,7 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
     m_icPreviewPopup = new ICPreviewPopup(this);
 
     m_exportController = new ExportController(*this, this);
+    m_icController = new ICController(*this, this);
 
     setupLanguage();
     setupGeometry();
@@ -294,8 +294,8 @@ void MainWindow::setupConnections()
             openICInTab(blobName, icElementId, m_currentTab->scene()->icRegistry()->blob(blobName));
         }
     });
-    connect(m_ui->elementEditor, &ElementEditor::embedSubcircuitRequested, this, &MainWindow::embedSelectedIC);
-    connect(m_ui->elementEditor, &ElementEditor::extractToFileRequested, this, &MainWindow::extractSelectedIC);
+    connect(m_ui->elementEditor, &ElementEditor::embedSubcircuitRequested, m_icController, &ICController::embedSelectedIC);
+    connect(m_ui->elementEditor, &ElementEditor::extractToFileRequested, m_icController, &ICController::extractSelectedIC);
     connect(m_ui->actionResetZoom,             &QAction::triggered,       this,                &MainWindow::on_actionResetZoom_triggered);
     connect(m_ui->actionRestart,               &QAction::triggered,       this,                &MainWindow::on_actionRestart_triggered);
     connect(m_ui->actionRotateLeft,            &QAction::triggered,       this,                &MainWindow::on_actionRotateLeft_triggered);
@@ -311,44 +311,20 @@ void MainWindow::setupConnections()
     connect(m_palette,                         &ElementPalette::addElementRequested, this, [this](QMimeData *mimeData) {
         if (m_currentTab) m_currentTab->scene()->addItem(mimeData);
     });
-    connect(m_ui->pushButtonAddIC,             &QPushButton::clicked,     this,                &MainWindow::on_pushButtonAddIC_clicked);
-    connect(m_ui->pushButtonRemoveIC,          &QPushButton::clicked,     this,                &MainWindow::on_pushButtonRemoveIC_clicked);
-    connect(m_ui->pushButtonRemoveIC,          &TrashButton::removeICFile,this,                &MainWindow::removeICFile);
-    connect(m_ui->pushButtonMakeSelfContained, &QPushButton::clicked,     this,                &MainWindow::makeSelfContained);
-    connect(m_ui->actionMakeSelfContained,     &QAction::triggered,       this,                &MainWindow::makeSelfContained);
+    connect(m_ui->pushButtonAddIC,             &QPushButton::clicked,     m_icController,      &ICController::addICFromFile);
+    connect(m_ui->pushButtonRemoveIC,          &QPushButton::clicked,     m_icController,      &ICController::showRemoveICHint);
+    connect(m_ui->pushButtonRemoveIC,          &TrashButton::removeICFile,m_icController,      &ICController::removeICFile);
+    connect(m_ui->pushButtonMakeSelfContained, &QPushButton::clicked,     m_icController,      &ICController::makeSelfContained);
+    connect(m_ui->actionMakeSelfContained,     &QAction::triggered,       m_icController,      &ICController::makeSelfContained);
 
     // ICDropZone cross-section drag-and-drop
-    connect(m_ui->dropZoneFileBased, &ICDropZone::extractByBlobNameRequested, this, &MainWindow::extractICByBlobName);
-    connect(m_ui->dropZoneEmbedded, &ICDropZone::embedByFileRequested, this, &MainWindow::embedICByFile);
+    connect(m_ui->dropZoneFileBased, &ICDropZone::extractByBlobNameRequested, m_icController, &ICController::extractICByBlobName);
+    connect(m_ui->dropZoneEmbedded, &ICDropZone::embedByFileRequested, m_icController, &ICController::embedICByFile);
 
     // Embedded IC section buttons
-    connect(m_ui->pushButtonAddEmbeddedIC, &QPushButton::clicked, this, [this] {
-        if (!m_currentTab) return;
-        QString fileName = FileDialogs::provider()->getOpenFileName(this, tr("Select IC file to embed"), currentDir().absolutePath(), tr("Panda files (*.panda)"));
-        if (fileName.isEmpty()) return;
-
-        QFile file(fileName);
-        if (!file.open(QIODevice::ReadOnly)) {
-            QMessageBox::warning(this, tr("Error"), tr("Could not read file: %1").arg(file.errorString()));
-            return;
-        }
-        QByteArray fileBytes = file.readAll();
-        file.close();
-
-        auto *scene = m_currentTab->scene();
-        QString blobName = resolveUniqueBlobName(QFileInfo(fileName).baseName(), scene);
-        if (blobName.isEmpty()) return;
-
-        scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
-        m_palette->updateEmbeddedICList(scene);
-    });
-    connect(m_ui->pushButtonRemoveEmbeddedIC, &QPushButton::clicked, this, &MainWindow::on_pushButtonRemoveIC_clicked);
-    connect(m_ui->pushButtonRemoveEmbeddedIC, &TrashButton::removeEmbeddedIC, this, [this](const QString &blobName) {
-        if (m_currentTab) {
-            m_currentTab->removeEmbeddedIC(blobName);
-            m_palette->updateEmbeddedICList(m_currentTab->scene());
-        }
-    });
+    connect(m_ui->pushButtonAddEmbeddedIC, &QPushButton::clicked, m_icController, &ICController::addEmbeddedICFromFile);
+    connect(m_ui->pushButtonRemoveEmbeddedIC, &QPushButton::clicked, m_icController, &ICController::showRemoveICHint);
+    connect(m_ui->pushButtonRemoveEmbeddedIC, &TrashButton::removeEmbeddedIC, m_icController, &ICController::removeEmbeddedIC);
 
     // These edit actions always delegate to the current tab's scene, so they
     // never need to be rewired on tab switch.
@@ -941,24 +917,6 @@ void MainWindow::ensureFileExtension(QString &fileName, const QString &extension
     }
 }
 
-IC *MainWindow::getSelectedIC() const
-{
-    if (!m_currentTab) {
-        return nullptr;
-    }
-
-    const auto selected = m_currentTab->scene()->selectedElements();
-    if (selected.isEmpty()) {
-        return nullptr;
-    }
-
-    if (selected.first()->elementType() != ElementType::IC) {
-        return nullptr;
-    }
-
-    return static_cast<IC *>(selected.first());
-}
-
 void MainWindow::setICButtonsVisible(bool visible)
 {
     m_ui->pushButtonAddIC->setVisible(visible);
@@ -1027,6 +985,16 @@ QWidget *MainWindow::widget()
 DolphinHost *MainWindow::dolphinHost()
 {
     return this;
+}
+
+ElementPalette *MainWindow::palette() const
+{
+    return m_palette;
+}
+
+void MainWindow::requestSave()
+{
+    on_actionSave_triggered();
 }
 
 void MainWindow::showStatusMessage(const QString &message, int timeout)
@@ -1701,292 +1669,4 @@ bool MainWindow::event(QEvent *event)
     };
 
     return QMainWindow::event(event);
-}
-
-void MainWindow::on_pushButtonAddIC_clicked()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ic", QStringLiteral("Add IC"));
-        if (!m_currentTab) {
-            return;
-        }
-
-        // The IC list is directory-relative.  If the project hasn't been saved yet
-        // we don't have a directory to copy into, so require a save first.
-        if (!m_currentTab->fileInfo().isReadable()) {
-            throw PANDACEPTION("Save file first.");
-        }
-
-        const QString selectedFile = FileDialogs::provider()->getOpenFileName(this, tr("Open File"), QString(), tr("Panda (*.panda)"));
-
-        if (selectedFile.isEmpty()) {
-            return;
-        }
-
-        const QStringList files = {selectedFile};
-
-        QMessageBox::information(this, tr("Info"), tr("Selected files (and their dependencies) will be copied to the current project folder."));
-
-        // Copy the chosen .panda file (and any ICs it depends on transitively)
-        // into the project's directory so that relative paths work when reopened.
-        for (const auto &file : files) {
-            QFileInfo destPath(currentDir().absolutePath() + "/" + QFileInfo(file).fileName());
-            Serialization::copyPandaFile(QFileInfo(file), destPath);
-        }
-
-        m_palette->updateICList(icListFile());
-    });
-}
-
-void MainWindow::on_pushButtonRemoveIC_clicked()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ic", QStringLiteral("Remove IC"));
-        QMessageBox::information(this, tr("Info"), tr("Drag here to remove."));
-    });
-}
-
-void MainWindow::removeICFile(const QString &icFileName)
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    QList<QGraphicsItem *> toDelete;
-    for (auto *element : m_currentTab->scene()->elements()) {
-        if (element->elementType() == ElementType::IC && element->label().append(".panda").toLower() == icFileName) {
-            toDelete.append(element);
-        }
-    }
-
-    if (!toDelete.isEmpty()) {
-        m_currentTab->scene()->receiveCommand(new DeleteItemsCommand(toDelete, m_currentTab->scene()));
-        m_currentTab->simulation()->restart();
-    }
-
-    QFile file(currentDir().absolutePath() + "/" + icFileName);
-
-    if (!file.remove()) {
-        throw PANDACEPTION("Error removing file: %1", file.errorString());
-    }
-
-    m_palette->updateICList(icListFile());
-    // Auto-save after removal so the scene no longer references the deleted file.
-    on_actionSave_triggered();
-}
-
-QString MainWindow::resolveUniqueBlobName(const QString &initialName, Scene *scene)
-{
-    auto *reg = scene->icRegistry();
-    QString blobName = reg->uniqueBlobName(initialName.trimmed());
-
-    // If the auto-generated name differs from the initial, let the user confirm or override
-    if (blobName != initialName.trimmed()) {
-        bool ok = false;
-        blobName = QInputDialog::getText(this,
-            tr("Name Collision"),
-            tr("An embedded IC named \"%1\" already exists.\nSuggested name:").arg(initialName.trimmed()),
-            QLineEdit::Normal, blobName, &ok);
-        blobName = blobName.trimmed();
-        if (!ok || blobName.isEmpty()) {
-            return {};
-        }
-        // Re-check in case the user typed a name that also collides
-        if (reg->hasBlob(blobName)) {
-            blobName = reg->uniqueBlobName(blobName);
-        }
-    }
-    return blobName;
-}
-
-void MainWindow::embedSelectedIC()
-{
-    sentryBreadcrumb("ic", QStringLiteral("Embed IC"));
-    auto *firstIC = getSelectedIC();
-    if (!firstIC || firstIC->file().isEmpty()) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-
-    const QString contextDir = scene->contextDir();
-    if (contextDir.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Please save the project first so ICs can be resolved."));
-        return;
-    }
-
-    QString blobName = resolveUniqueBlobName(QFileInfo(firstIC->file()).baseName(), scene);
-    if (blobName.isEmpty()) {
-        return;
-    }
-
-    QFile file(QDir(contextDir).absoluteFilePath(firstIC->file()));
-    if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-        return;
-    }
-    QByteArray fileBytes = file.readAll();
-    file.close();
-
-    scene->icRegistry()->embedICsByFile(firstIC->file(), fileBytes, blobName);
-    m_palette->updateEmbeddedICList(scene);
-    m_ui->statusBar->showMessage(tr("IC embedded successfully."), 4000);
-}
-
-void MainWindow::extractSelectedIC()
-{
-    sentryBreadcrumb("ic", QStringLiteral("Extract IC"));
-    auto *firstIC = getSelectedIC();
-    if (!firstIC || !firstIC->isEmbedded()) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-    const QString blobName = firstIC->blobName();
-    const QString contextDir = scene->contextDir();
-    if (contextDir.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Please save the project first."));
-        return;
-    }
-
-    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
-    QString fileName = FileDialogs::provider()->getSaveFileName(this, tr("Extract IC to file..."), suggestion, tr("Panda files (*.panda)")).fileName;
-
-    if (fileName.isEmpty()) {
-        return;
-    }
-
-    ensureFileExtension(fileName, ".panda");
-
-    scene->icRegistry()->extractToFile(blobName, fileName);
-    m_palette->updateICList(icListFile());
-    m_palette->updateEmbeddedICList(scene);
-    m_ui->statusBar->showMessage(tr("IC extracted to %1").arg(fileName), 4000);
-}
-
-void MainWindow::embedICByFile(const QString &fileName)
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-    const QString contextDir = scene->contextDir();
-    if (contextDir.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Please save the project first so ICs can be resolved."));
-        return;
-    }
-
-    const QString absolutePath = QDir(contextDir).absoluteFilePath(fileName);
-    QFile file(absolutePath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-        return;
-    }
-    QByteArray fileBytes = file.readAll();
-    file.close();
-
-    QString blobName = resolveUniqueBlobName(QFileInfo(absolutePath).baseName(), scene);
-    if (blobName.isEmpty()) {
-        return;
-    }
-
-    auto *reg = scene->icRegistry();
-    if (reg->embedICsByFile(absolutePath, fileBytes, blobName) == 0) {
-        // No existing instances — register the blob only; don't add to scene.
-        scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
-    }
-
-    m_palette->updateEmbeddedICList(scene);
-    m_ui->statusBar->showMessage(tr("IC embedded successfully."), 4000);
-}
-
-void MainWindow::extractICByBlobName(const QString &blobName)
-{
-    if (!m_currentTab) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-    const QString contextDir = scene->contextDir();
-    if (contextDir.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Please save the project first."));
-        return;
-    }
-
-    // Find any embedded IC with this blobName to get the blob data
-    auto *reg = scene->icRegistry();
-    if (!reg->hasBlob(blobName)) {
-        return;
-    }
-
-    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
-    QString fileName = FileDialogs::provider()->getSaveFileName(this, tr("Extract IC to file..."), suggestion, tr("Panda files (*.panda)")).fileName;
-
-    if (fileName.isEmpty()) {
-        return;
-    }
-
-    ensureFileExtension(fileName, ".panda");
-
-    reg->extractToFile(blobName, fileName);
-    m_palette->updateICList(icListFile());
-    m_palette->updateEmbeddedICList(scene);
-    m_ui->statusBar->showMessage(tr("IC extracted to %1").arg(fileName), 4000);
-}
-
-void MainWindow::makeSelfContained()
-{
-    sentryBreadcrumb("ic", QStringLiteral("Make self-contained"));
-    if (!m_currentTab) {
-        return;
-    }
-
-    auto *scene = m_currentTab->scene();
-    const QString contextDir = scene->contextDir();
-    if (contextDir.isEmpty()) {
-        QMessageBox::warning(this, tr("Error"), tr("Please save the project first."));
-        return;
-    }
-
-    // Collect unique file paths from all file-backed ICs
-    QStringList uniqueFiles;
-    for (auto *elm : scene->elements()) {
-        if (elm->elementType() != ElementType::IC || elm->isEmbedded()) {
-            continue;
-        }
-        const QString icFile = static_cast<IC *>(elm)->file();
-        if (!icFile.isEmpty() && !uniqueFiles.contains(icFile)) {
-            uniqueFiles.append(icFile);
-        }
-    }
-
-    if (uniqueFiles.isEmpty()) {
-        m_ui->statusBar->showMessage(tr("No file-based ICs to embed."), 4000);
-        return;
-    }
-
-    int totalEmbedded = 0;
-    auto *reg = scene->icRegistry();
-
-    for (const QString &icFile : std::as_const(uniqueFiles)) {
-        const QString fullPath = QDir(contextDir).absoluteFilePath(icFile);
-        QFile file(fullPath);
-        if (!file.open(QIODevice::ReadOnly)) {
-            QMessageBox::warning(this, tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-            break;
-        }
-        QByteArray fileBytes = file.readAll();
-        file.close();
-
-        QString blobName = resolveUniqueBlobName(QFileInfo(icFile).baseName(), scene);
-        if (blobName.isEmpty()) {
-            break; // User cancelled
-        }
-
-        totalEmbedded += reg->embedICsByFile(fullPath, fileBytes, blobName);
-    }
-
-    m_palette->updateEmbeddedICList(scene);
-    m_ui->statusBar->showMessage(tr("Embedded %1 IC(s). Circuit is now self-contained.").arg(totalEmbedded), 4000);
 }

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -13,7 +13,6 @@
 #include <QMainWindow>
 #include <QPointer>
 #include <QSpacerItem>
-#include <QUrl>
 
 #include "App/BeWavedDolphin/DolphinHost.h"
 #include "App/UI/MainWindowUI.h"
@@ -235,8 +234,6 @@ private:
     void makeSelfContained();
     void embedICByFile(const QString &fileName);
     void extractICByBlobName(const QString &blobName);
-    void showUpdateDialog(const QString &latestVersion, const QUrl &downloadUrl, const QUrl &releaseUrl);
-    void downloadUpdate(const QString &latestVersion, const QUrl &url);
 
     // --- Settings & Theme ---
 

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -27,6 +27,7 @@ class LanguageManager;
 class RecentFiles;
 class SceneUiBinder;
 class WorkSpace;
+class WorkspaceManager;
 
 /**
  * \class MainWindow
@@ -66,9 +67,6 @@ public:
     /// Returns the currently visible WorkSpace tab, or nullptr.
     WorkSpace *currentTab() const override;
 
-    /// Closes all tabs, prompting to save if needed. Returns \c false if cancelled.
-    bool closeFiles();
-
     // --- File Operations ---
 
     /**
@@ -85,13 +83,6 @@ public:
 
     /// Opens an embedded IC blob for editing in a new tab.
     void openICInTab(const QString &blobName, int icElementId, const QByteArray &blob);
-
-    /**
-     * \brief Prompts the user to save unsaved changes before closing.
-     * \param multiple \c true when multiple tabs may be affected.
-     * \return QMessageBox button code: Save, Discard, or Cancel.
-     */
-    int confirmSave(const bool multiple);
 
     /// Returns the QFileInfo of the currently active .panda file.
     QFileInfo currentFile() const override;
@@ -114,11 +105,11 @@ public:
     /// \reimp MainWindowHost — saves the current tab (triggers the Save action).
     void requestSave() override;
 
-    /**
-     * \brief Updates the tracked current file to \a fileInfo.
-     * \param fileInfo New file info (used after load or save-as).
-     */
-    void setCurrentFile(const QFileInfo &fileInfo);
+    /// \reimp MainWindowHost — shows/hides the IC management tool buttons.
+    void setICButtonsVisible(bool visible) override;
+
+    /// \reimp MainWindowHost — re-evaluates the Add-IC button enabled state.
+    void refreshICButtonsEnabled() override;
 
     // --- Export ---
 
@@ -191,13 +182,6 @@ public:
     /// \reimp
     bool event(QEvent *event) override;
 
-signals:
-    /**
-     * \brief Emitted when a file is successfully loaded or saved.
-     * \param fileName Absolute path of the affected file.
-     */
-    void addRecentFile(const QString &fileName);
-
 protected:
     // --- Protected Interface ---
 
@@ -209,32 +193,17 @@ private:
 
     // --- Tab Lifecycle ---
 
-    bool closeTab(const int tabIndex);
-    int closeTabAnyway();
-    void tabChanged(const int newTabIndex);
-    void disconnectTab();
-    void connectTab();
+    /// Reacts to WorkspaceManager::currentTabChanged: rebinds the chrome to the new scene.
+    void onCurrentTabChanged(WorkSpace *newTab);
 
-    /// Returns the file info to use for populating the file-based IC palette.
-    /// For inline IC tabs this returns the parent workspace's file info.
+    /// \reimp MainWindowHost — file info used to populate the file-based IC palette.
     QFileInfo icListFile() const override;
 
-    /// Connects \a action to \a method on the current tab's scene (guarded by m_currentTab check).
+    /// Connects \a action to \a method on the current tab's scene (guarded by a current-tab check).
     void connectSceneAction(QAction *action, void (Scene::*method)());
 
     // --- File Helpers ---
 
-    /// Appends \a extension (e.g. ".panda") to \a fileName if not already present.
-    static void ensureFileExtension(QString &fileName, const QString &extension);
-
-    /// Shows or hides the IC management buttons (Add, Remove, MakeSelfContained).
-    void setICButtonsVisible(bool visible);
-
-    /// Updates the enabled state of Add IC based on current tab's saved-file status.
-    void refreshICButtonsEnabled();
-
-    bool hasModifiedFiles();
-    void loadAutosaveFiles();
     void createRecentFileActions();
     void updateRecentFileActions();
     void openRecentFile();
@@ -260,17 +229,12 @@ private:
     void on_actionGates_triggered(const bool checked);
     void on_actionLabelsUnderIcons_triggered(const bool checked);
     void on_actionMute_triggered(const bool checked);
-    void on_actionNew_triggered();
-    void on_actionOpen_triggered();
     void on_actionPlay_toggled(const bool checked);
-    void on_actionReloadFile_triggered();
     void on_actionReportTranslationError_triggered();
     void on_actionResetZoom_triggered() const;
     void on_actionRestart_triggered();
     void on_actionRotateLeft_triggered();
     void on_actionRotateRight_triggered();
-    void on_actionSaveAs_triggered();
-    void on_actionSave_triggered();
     void on_actionSelectAll_triggered();
     void on_actionShortcuts_and_Tips_triggered();
     void on_actionWaveform_triggered();
@@ -310,13 +274,9 @@ private:
     ExportController *m_exportController  = nullptr;
     ICController     *m_icController      = nullptr;
     SceneUiBinder    *m_binder            = nullptr;
+    WorkspaceManager *m_workspaceManager  = nullptr;
 
     /// Shared IC-hover preview, parented to this MainWindow.
     /// QPointer so accesses during teardown are safe regardless of child-destruction order.
     QPointer<ICPreviewPopup> m_icPreviewPopup;
-
-    WorkSpace *m_currentTab = nullptr;
-    int m_tabIndex = -1;
-
-    [[nodiscard]] int findTabWithFile(const QString &fileName) const;
 };

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -24,8 +24,8 @@ class ExportController;
 class ICController;
 class ICPreviewPopup;
 class LanguageManager;
-class QShortcut;
 class RecentFiles;
+class SceneUiBinder;
 class WorkSpace;
 
 /**
@@ -212,8 +212,6 @@ private:
     bool closeTab(const int tabIndex);
     int closeTabAnyway();
     void tabChanged(const int newTabIndex);
-    void addUndoRedoMenu();
-    void removeUndoRedoMenu();
     void disconnectTab();
     void connectTab();
 
@@ -245,7 +243,6 @@ private:
 
     void updateSettings();
     void updateTheme();
-    void zoomChanged();
     void aboutThisVersion();
 
     // --- Action Handlers ---
@@ -298,7 +295,7 @@ private:
     void setupRecentFiles();
     /// Populates the Examples menu from the Examples/ directory.
     void setupExamplesMenu();
-    /// Registers all QShortcut objects (requires m_currentTab to be valid).
+    /// Registers the global search shortcut (scene-property shortcuts live in SceneUiBinder).
     void setupShortcuts();
     /// Connects all QAction and widget signals to their slots.
     void setupConnections();
@@ -312,6 +309,7 @@ private:
     RecentFiles      *m_recentFiles      = nullptr;
     ExportController *m_exportController  = nullptr;
     ICController     *m_icController      = nullptr;
+    SceneUiBinder    *m_binder            = nullptr;
 
     /// Shared IC-hover preview, parented to this MainWindow.
     /// QPointer so accesses during teardown are safe regardless of child-destruction order.
@@ -321,12 +319,4 @@ private:
     int m_tabIndex = -1;
 
     [[nodiscard]] int findTabWithFile(const QString &fileName) const;
-
-    // Scene-level shortcuts created once in setupShortcuts(), reconnected on tab switch.
-    QShortcut *m_prevMainPropShortcut  = nullptr;
-    QShortcut *m_nextMainPropShortcut  = nullptr;
-    QShortcut *m_prevSecndPropShortcut = nullptr;
-    QShortcut *m_nextSecndPropShortcut = nullptr;
-    QShortcut *m_changePrevElmShortcut = nullptr;
-    QShortcut *m_changeNextElmShortcut = nullptr;
 };

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -15,10 +15,12 @@
 #include <QSpacerItem>
 
 #include "App/BeWavedDolphin/DolphinHost.h"
+#include "App/UI/MainWindowHost.h"
 #include "App/UI/MainWindowUI.h"
 
 class ElementLabel;
 class ElementPalette;
+class ExportController;
 class IC;
 class ICPreviewPopup;
 class LanguageManager;
@@ -34,7 +36,7 @@ class WorkSpace;
  * WorkSpace), connects undo/redo stacks, handles file open/save/export, manages translations,
  * and integrates the element palette, element editor, and IC list panel.
  */
-class MainWindow : public QMainWindow, public DolphinHost
+class MainWindow : public QMainWindow, public DolphinHost, public MainWindowHost
 {
     Q_OBJECT
 
@@ -62,7 +64,7 @@ public:
     void createNewTab();
 
     /// Returns the currently visible WorkSpace tab, or nullptr.
-    WorkSpace *currentTab() const;
+    WorkSpace *currentTab() const override;
 
     /// Closes all tabs, prompting to save if needed. Returns \c false if cancelled.
     bool closeFiles();
@@ -96,6 +98,15 @@ public:
 
     /// Returns the directory of the currently active .panda file.
     QDir currentDir() const override;
+
+    /// \reimp MainWindowHost — parent widget for controller-spawned dialogs.
+    QWidget *widget() override;
+
+    /// \reimp MainWindowHost — this window's DolphinHost facet.
+    DolphinHost *dolphinHost() override;
+
+    /// \reimp MainWindowHost — shows \a message in the status bar for \a timeout ms.
+    void showStatusMessage(const QString &message, int timeout) override;
 
     /**
      * \brief Updates the tracked current file to \a fileInfo.
@@ -250,10 +261,6 @@ private:
     void on_actionAboutQt_triggered();
     void on_actionAbout_triggered();
     void on_actionExit_triggered();
-    void on_actionExportToArduino_triggered();
-    void on_actionExportToSystemVerilog_triggered();
-    void on_actionExportToImage_triggered();
-    void on_actionExportToPdf_triggered();
     void on_actionFastMode_triggered(const bool checked);
     void on_actionFlipHorizontally_triggered();
     void on_actionFlipVertically_triggered();
@@ -307,9 +314,10 @@ private:
 
     std::unique_ptr<MainWindowUi> m_ui;
 
-    ElementPalette  *m_palette         = nullptr;
-    LanguageManager *m_languageManager = nullptr;
-    RecentFiles     *m_recentFiles     = nullptr;
+    ElementPalette   *m_palette          = nullptr;
+    LanguageManager  *m_languageManager  = nullptr;
+    RecentFiles      *m_recentFiles      = nullptr;
+    ExportController *m_exportController  = nullptr;
 
     /// Shared IC-hover preview, parented to this MainWindow.
     /// QPointer so accesses during teardown are safe regardless of child-destruction order.

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -21,7 +21,7 @@
 class ElementLabel;
 class ElementPalette;
 class ExportController;
-class IC;
+class ICController;
 class ICPreviewPopup;
 class LanguageManager;
 class QShortcut;
@@ -105,8 +105,14 @@ public:
     /// \reimp MainWindowHost — this window's DolphinHost facet.
     DolphinHost *dolphinHost() override;
 
+    /// \reimp MainWindowHost — the element palette panel.
+    ElementPalette *palette() const override;
+
     /// \reimp MainWindowHost — shows \a message in the status bar for \a timeout ms.
     void showStatusMessage(const QString &message, int timeout) override;
+
+    /// \reimp MainWindowHost — saves the current tab (triggers the Save action).
+    void requestSave() override;
 
     /**
      * \brief Updates the tracked current file to \a fileInfo.
@@ -213,7 +219,7 @@ private:
 
     /// Returns the file info to use for populating the file-based IC palette.
     /// For inline IC tabs this returns the parent workspace's file info.
-    QFileInfo icListFile() const;
+    QFileInfo icListFile() const override;
 
     /// Connects \a action to \a method on the current tab's scene (guarded by m_currentTab check).
     void connectSceneAction(QAction *action, void (Scene::*method)());
@@ -222,10 +228,6 @@ private:
 
     /// Appends \a extension (e.g. ".panda") to \a fileName if not already present.
     static void ensureFileExtension(QString &fileName, const QString &extension);
-
-    /// Returns the first selected IC element, or nullptr if none is selected or
-    /// if there is no current tab or the first selected element is not an IC.
-    IC *getSelectedIC() const;
 
     /// Shows or hides the IC management buttons (Add, Remove, MakeSelfContained).
     void setICButtonsVisible(bool visible);
@@ -238,13 +240,6 @@ private:
     void createRecentFileActions();
     void updateRecentFileActions();
     void openRecentFile();
-    void removeICFile(const QString &icFileName);
-    QString resolveUniqueBlobName(const QString &initialName, Scene *scene);
-    void embedSelectedIC();
-    void extractSelectedIC();
-    void makeSelfContained();
-    void embedICByFile(const QString &fileName);
-    void extractICByBlobName(const QString &blobName);
 
     // --- Settings & Theme ---
 
@@ -285,8 +280,6 @@ private:
     void on_actionWires_triggered(const bool checked);
     void on_actionZoomIn_triggered() const;
     void on_actionZoomOut_triggered() const;
-    void on_pushButtonAddIC_clicked();
-    void on_pushButtonRemoveIC_clicked();
 
 #ifdef Q_OS_WASM
     /// Emscripten beforeunload callback — saves window geometry before the browser tab closes.
@@ -318,6 +311,7 @@ private:
     LanguageManager  *m_languageManager  = nullptr;
     RecentFiles      *m_recentFiles      = nullptr;
     ExportController *m_exportController  = nullptr;
+    ICController     *m_icController      = nullptr;
 
     /// Shared IC-hover preview, parented to this MainWindow.
     /// QPointer so accesses during teardown are safe regardless of child-destruction order.

--- a/App/UI/MainWindowHost.h
+++ b/App/UI/MainWindowHost.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <QDir>
 #include <QFileInfo>
 
 class DolphinHost;
+class ElementPalette;
 class QString;
 class QWidget;
 class WorkSpace;
@@ -34,6 +36,15 @@ public:
     /// QFileInfo of the currently active .panda file.
     virtual QFileInfo currentFile() const = 0;
 
+    /// Directory of the currently active .panda file.
+    virtual QDir currentDir() const = 0;
+
+    /// File info used to populate the file-based IC palette (parent workspace for inline IC tabs).
+    virtual QFileInfo icListFile() const = 0;
+
+    /// The element palette panel (file-based and embedded IC lists live here).
+    virtual ElementPalette *palette() const = 0;
+
     /// Widget used to parent modal dialogs spawned by a controller.
     virtual QWidget *widget() = 0;
 
@@ -42,4 +53,7 @@ public:
 
     /// Shows \a message in the host's status bar for \a timeout milliseconds.
     virtual void showStatusMessage(const QString &message, int timeout) = 0;
+
+    /// Saves the current tab (equivalent to triggering the Save action).
+    virtual void requestSave() = 0;
 };

--- a/App/UI/MainWindowHost.h
+++ b/App/UI/MainWindowHost.h
@@ -56,4 +56,10 @@ public:
 
     /// Saves the current tab (equivalent to triggering the Save action).
     virtual void requestSave() = 0;
+
+    /// Shows or hides the IC management tool buttons (Add / Remove / Make-self-contained).
+    virtual void setICButtonsVisible(bool visible) = 0;
+
+    /// Re-evaluates the enabled state of the Add-IC button against the current tab.
+    virtual void refreshICButtonsEnabled() = 0;
 };

--- a/App/UI/MainWindowHost.h
+++ b/App/UI/MainWindowHost.h
@@ -1,0 +1,45 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief MainWindowHost: the application context that MainWindow's extracted controllers depend on.
+ */
+
+#pragma once
+
+#include <QFileInfo>
+
+class DolphinHost;
+class QString;
+class QWidget;
+class WorkSpace;
+
+/**
+ * \class MainWindowHost
+ * \brief Interface MainWindow provides to its extracted controllers (export, IC, …).
+ *
+ * \details Mirrors the DolphinHost pattern: collaborators receive this narrow
+ * context instead of a concrete MainWindow, so each cluster can be exercised with a
+ * stub host. Exposes the current tab, the current circuit file, a parent widget for
+ * dialogs, and a status-bar message sink.
+ */
+class MainWindowHost
+{
+public:
+    virtual ~MainWindowHost() = default;
+
+    /// Currently visible WorkSpace tab, or nullptr when none is open.
+    virtual WorkSpace *currentTab() const = 0;
+
+    /// QFileInfo of the currently active .panda file.
+    virtual QFileInfo currentFile() const = 0;
+
+    /// Widget used to parent modal dialogs spawned by a controller.
+    virtual QWidget *widget() = 0;
+
+    /// The host's DolphinHost facet, used to drive headless beWavedDolphin exports.
+    virtual DolphinHost *dolphinHost() = 0;
+
+    /// Shows \a message in the host's status bar for \a timeout milliseconds.
+    virtual void showStatusMessage(const QString &message, int timeout) = 0;
+};

--- a/App/UI/SceneUiBinder.cpp
+++ b/App/UI/SceneUiBinder.cpp
@@ -1,0 +1,171 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/UI/SceneUiBinder.h"
+
+#include <QAction>
+#include <QKeySequence>
+#include <QMenu>
+#include <QShortcut>
+#include <QStatusBar>
+#include <QUndoStack>
+
+#include "App/Core/Common.h"
+#include "App/Scene/GraphicsView.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/Simulation/Simulation.h"
+#include "App/UI/ElementEditor.h"
+#include "App/UI/ElementPalette.h"
+#include "App/UI/MainWindowUI.h"
+
+SceneUiBinder::SceneUiBinder(MainWindowUi *ui, ElementPalette *palette, QWidget *shortcutParent, QObject *parent)
+    : QObject(parent)
+    , m_ui(ui)
+    , m_palette(palette)
+{
+    // [ / ] cycle a selected element's primary property (e.g. input size).
+    // { / } cycle a secondary property; < / > morph through element variants.
+    // They are connected to the active scene in bind() so they follow the current tab.
+    m_prevMainPropShortcut  = new QShortcut(QKeySequence("["), shortcutParent);
+    m_nextMainPropShortcut  = new QShortcut(QKeySequence("]"), shortcutParent);
+    m_prevSecndPropShortcut = new QShortcut(QKeySequence("{"), shortcutParent);
+    m_nextSecndPropShortcut = new QShortcut(QKeySequence("}"), shortcutParent);
+    m_changePrevElmShortcut = new QShortcut(QKeySequence("<"), shortcutParent);
+    m_changeNextElmShortcut = new QShortcut(QKeySequence(">"), shortcutParent);
+}
+
+void SceneUiBinder::addUndoRedoMenu()
+{
+    if (!m_bound) {
+        return;
+    }
+
+    auto *scene = m_bound->scene();
+    if (!scene) {
+        return;
+    }
+
+    const auto actions = m_ui->menuEdit->actions();
+    if (actions.size() < 2) {
+        return;
+    }
+
+    // Insert before position 0 then before the new position 1 so undo appears
+    // first, redo second — above the separator that already exists in menuEdit.
+    m_ui->menuEdit->insertAction(actions.at(0), scene->undoAction());
+    m_ui->menuEdit->insertAction(m_ui->menuEdit->actions().at(1), scene->redoAction());
+}
+
+void SceneUiBinder::removeUndoRedoMenu()
+{
+    if (!m_bound) {
+        return;
+    }
+
+    // The undo/redo actions are always inserted at positions 0 and 1 of menuEdit.
+    // Any fewer entries means they were never added, so nothing to remove.
+    const auto actions = m_ui->menuEdit->actions();
+    if (actions.size() < 2) {
+        return;
+    }
+    m_ui->menuEdit->removeAction(actions.at(0));
+    m_ui->menuEdit->removeAction(actions.at(1));
+}
+
+void SceneUiBinder::syncZoomActions()
+{
+    if (!m_bound) {
+        return;
+    }
+
+    m_ui->actionZoomIn->setEnabled(m_bound->view()->canZoomIn());
+    m_ui->actionZoomOut->setEnabled(m_bound->view()->canZoomOut());
+}
+
+void SceneUiBinder::bind(WorkSpace *tab)
+{
+    m_bound = tab;
+    auto *scene = tab->scene();
+
+    qCDebug(zero) << "Connecting undo and redo functions to UI menu.";
+    addUndoRedoMenu();
+
+    m_palette->updateEmbeddedICList(scene);
+
+    qCDebug(zero) << "Connecting current tab to element editor menu in UI.";
+    m_ui->elementEditor->setScene(scene);
+
+    connect(tab->view(),       &GraphicsView::zoomChanged,     this, &SceneUiBinder::syncZoomActions);
+    connect(tab->simulation(), &Simulation::simulationWarning, this, [this](const QString &msg) {
+        m_ui->statusBar->showMessage(msg, 8000);
+    });
+    connect(scene->undoStack(), &QUndoStack::indexChanged, this, [this] {
+        if (m_bound) {
+            m_palette->updateEmbeddedICList(m_bound->scene());
+        }
+    });
+
+    connect(m_prevMainPropShortcut,  &QShortcut::activated, scene, &Scene::prevMainPropShortcut);
+    connect(m_nextMainPropShortcut,  &QShortcut::activated, scene, &Scene::nextMainPropShortcut);
+    connect(m_prevSecndPropShortcut, &QShortcut::activated, scene, &Scene::prevSecndPropShortcut);
+    connect(m_nextSecndPropShortcut, &QShortcut::activated, scene, &Scene::nextSecndPropShortcut);
+    connect(m_changePrevElmShortcut, &QShortcut::activated, scene, &Scene::prevElm);
+    connect(m_changeNextElmShortcut, &QShortcut::activated, scene, &Scene::nextElm);
+    connect(scene, &Scene::openTruthTableRequested, this, [this] {
+        m_ui->elementEditor->truthTable();
+    });
+
+    if (m_ui->actionPlay->isChecked()) {
+        qCDebug(zero) << "Restarting simulation.";
+        tab->simulation()->start();
+        // Clear selection so the element editor doesn't show stale data from the
+        // previously active tab.
+        scene->clearSelection();
+    }
+
+    tab->view()->setFastMode(m_ui->actionFastMode->isChecked());
+    // Synchronise zoom button state to the newly visible tab's zoom level.
+    m_ui->actionZoomIn->setEnabled(tab->view()->canZoomIn());
+    m_ui->actionZoomOut->setEnabled(tab->view()->canZoomOut());
+
+    // Synchronise the mute button state to the newly visible tab's mute intent.
+    const bool muted = tab->simulation()->isUserMuted();
+    m_ui->actionMute->setChecked(muted);
+    m_ui->actionMute->setText(muted ? tr("Unmute") : tr("Mute"));
+}
+
+void SceneUiBinder::unbind()
+{
+    // Tear down all connections that route scene signals into shared UI elements, and
+    // stop the simulation so it doesn't keep running in the background consuming CPU.
+    if (!m_bound) {
+        return;
+    }
+
+    auto *scene = m_bound->scene();
+
+    m_ui->elementEditor->setScene(nullptr);
+
+    qCDebug(zero) << "Stopping simulation.";
+    m_bound->simulation()->stop();
+
+    qCDebug(zero) << "Disconnecting zoom and simulation signals from UI.";
+    disconnect(m_bound->view(),       &GraphicsView::zoomChanged,     this, &SceneUiBinder::syncZoomActions);
+    disconnect(m_bound->simulation(), &Simulation::simulationWarning, this, nullptr);
+
+    qCDebug(zero) << "Disconnecting scene shortcuts from previous tab.";
+    disconnect(m_prevMainPropShortcut,  nullptr, scene, nullptr);
+    disconnect(m_nextMainPropShortcut,  nullptr, scene, nullptr);
+    disconnect(m_prevSecndPropShortcut, nullptr, scene, nullptr);
+    disconnect(m_nextSecndPropShortcut, nullptr, scene, nullptr);
+    disconnect(m_changePrevElmShortcut, nullptr, scene, nullptr);
+    disconnect(m_changeNextElmShortcut, nullptr, scene, nullptr);
+    disconnect(scene, &Scene::openTruthTableRequested, this, nullptr);
+    disconnect(scene->undoStack(), &QUndoStack::indexChanged, this, nullptr);
+
+    qCDebug(zero) << "Removing undo and redo actions from UI menu.";
+    removeUndoRedoMenu();
+
+    m_bound = nullptr;
+}

--- a/App/UI/SceneUiBinder.cpp
+++ b/App/UI/SceneUiBinder.cpp
@@ -11,6 +11,7 @@
 #include <QUndoStack>
 
 #include "App/Core/Common.h"
+#include "App/Element/ICRegistry.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
@@ -115,6 +116,15 @@ void SceneUiBinder::bind(WorkSpace *tab)
     connect(scene, &Scene::openTruthTableRequested, this, [this] {
         m_ui->elementEditor->truthTable();
     });
+    connect(scene, &Scene::icOpenRequested, this, [this](int elementId, const QString &blobName, const QString &filePath) {
+        if (!blobName.isEmpty()) {
+            if (m_bound) {
+                emit openICRequested(blobName, elementId, m_bound->scene()->icRegistry()->blob(blobName));
+            }
+        } else if (!filePath.isEmpty()) {
+            emit loadFileRequested(filePath);
+        }
+    });
 
     if (m_ui->actionPlay->isChecked()) {
         qCDebug(zero) << "Restarting simulation.";
@@ -162,6 +172,7 @@ void SceneUiBinder::unbind()
     disconnect(m_changePrevElmShortcut, nullptr, scene, nullptr);
     disconnect(m_changeNextElmShortcut, nullptr, scene, nullptr);
     disconnect(scene, &Scene::openTruthTableRequested, this, nullptr);
+    disconnect(scene, &Scene::icOpenRequested, this, nullptr);
     disconnect(scene->undoStack(), &QUndoStack::indexChanged, this, nullptr);
 
     qCDebug(zero) << "Removing undo and redo actions from UI menu.";

--- a/App/UI/SceneUiBinder.h
+++ b/App/UI/SceneUiBinder.h
@@ -1,0 +1,62 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief SceneUiBinder: wires the active tab's scene into the shared editor chrome.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class ElementPalette;
+class MainWindowUi;
+class QShortcut;
+class QWidget;
+class WorkSpace;
+
+/**
+ * \class SceneUiBinder
+ * \brief Binds and unbinds the active WorkSpace's scene to the single-instance editor
+ * chrome (element editor, Edit-menu undo/redo, scene-property shortcuts, and the
+ * zoom/mute/play action state).
+ *
+ * \details Extracted from MainWindow. The chrome widgets are shared singletons that
+ * must be re-pointed at the current scene on every tab switch; that wiring is this
+ * class's sole responsibility. It owns the six scene-property QShortcuts (which only
+ * ever target the active scene). Tab navigation triggered by scene signals
+ * (icOpenRequested) and the file-based IC list stay with the tab owner.
+ */
+class SceneUiBinder : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// \param ui Shared UI (element editor, menus, actions, status bar).
+    /// \param palette Element palette (embedded-IC list reflects the active scene).
+    /// \param shortcutParent Widget that parents the scene-property shortcuts (the window).
+    SceneUiBinder(MainWindowUi *ui, ElementPalette *palette, QWidget *shortcutParent, QObject *parent = nullptr);
+
+    /// Connects \a tab's scene/view/simulation to the chrome and syncs action state.
+    void bind(WorkSpace *tab);
+
+    /// Tears down the connections established by bind() for the currently bound tab.
+    void unbind();
+
+private:
+    void addUndoRedoMenu();
+    void removeUndoRedoMenu();
+    void syncZoomActions();
+
+    MainWindowUi *m_ui;
+    ElementPalette *m_palette;
+    WorkSpace *m_bound = nullptr;
+
+    // Scene-property navigation shortcuts ( [ ] { } < > ), re-targeted to the active scene.
+    QShortcut *m_prevMainPropShortcut;
+    QShortcut *m_nextMainPropShortcut;
+    QShortcut *m_prevSecndPropShortcut;
+    QShortcut *m_nextSecndPropShortcut;
+    QShortcut *m_changePrevElmShortcut;
+    QShortcut *m_changeNextElmShortcut;
+};

--- a/App/UI/SceneUiBinder.h
+++ b/App/UI/SceneUiBinder.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QObject>
+#include <QString>
 
 class ElementPalette;
 class MainWindowUi;
@@ -42,6 +44,12 @@ public:
 
     /// Tears down the connections established by bind() for the currently bound tab.
     void unbind();
+
+signals:
+    /// The bound scene asked to open an embedded IC in a tab (forwarded to the tab owner).
+    void openICRequested(const QString &blobName, int icElementId, const QByteArray &blob);
+    /// The bound scene asked to open a file-based IC by path (forwarded to the tab owner).
+    void loadFileRequested(const QString &filePath);
 
 private:
     void addUndoRedoMenu();

--- a/App/UI/UpdateController.cpp
+++ b/App/UI/UpdateController.cpp
@@ -1,0 +1,146 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/UI/UpdateController.h"
+
+#include <QCheckBox>
+#include <QDate>
+#include <QDesktopServices>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QLabel>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProgressDialog>
+#include <QPushButton>
+#include <QStandardPaths>
+#include <QVBoxLayout>
+
+#include "App/Core/Application.h"
+#include "App/Core/Settings.h"
+#include "App/Core/UpdateChecker.h"
+#include "App/Versions.h"
+
+UpdateController::UpdateController(QWidget *parent)
+    : QObject(parent)
+    , m_parent(parent)
+{
+}
+
+void UpdateController::checkForUpdates()
+{
+    if (!Application::interactiveMode) {
+        return;
+    }
+
+    auto *updateChecker = new UpdateChecker(this);
+    connect(updateChecker, &UpdateChecker::updateAvailable, this, &UpdateController::showUpdateDialog);
+    updateChecker->checkForUpdates();
+}
+
+void UpdateController::showUpdateDialog(const QString &latestVersion, const QUrl &downloadUrl, const QUrl &releaseUrl)
+{
+    QDialog dialog(m_parent);
+    dialog.setWindowTitle(tr("Update Available"));
+    dialog.setWindowModality(Qt::WindowModal);
+
+    auto *layout = new QVBoxLayout(&dialog);
+
+    const bool hasDirectDownload = downloadUrl.isValid() && !downloadUrl.isEmpty();
+    auto *label = new QLabel(
+        (hasDirectDownload
+             ? tr("<b>wiRedPanda %1 is available.</b><br><br>"
+                  "You are currently running version %2.<br>"
+                  "Click <b>Download</b> to save the new version to your computer.")
+             : tr("<b>wiRedPanda %1 is available.</b><br><br>"
+                  "You are currently running version %2.<br>"
+                  "Visit the release page to download the new version."))
+            .arg(latestVersion, APP_VERSION),
+        &dialog);
+    label->setTextFormat(Qt::RichText);
+    label->setWordWrap(true);
+    layout->addWidget(label);
+
+    auto *skipCheckBox = new QCheckBox(tr("Don't notify me about this version again"), &dialog);
+    layout->addWidget(skipCheckBox);
+
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, &dialog);
+    auto *downloadButton = buttonBox->addButton(tr("Download"), QDialogButtonBox::AcceptRole);
+    connect(downloadButton, &QPushButton::clicked, &dialog, [&dialog] { dialog.accept(); });
+    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    layout->addWidget(buttonBox);
+
+    const bool accepted = dialog.exec() == QDialog::Accepted;
+
+    if (skipCheckBox->isChecked()) {
+        Settings::setUpdateCheckSkippedVersion(latestVersion);
+    }
+
+    if (accepted) {
+        if (hasDirectDownload) {
+            downloadUpdate(latestVersion, downloadUrl);
+        } else {
+            QDesktopServices::openUrl(releaseUrl);
+            Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
+        }
+    } else {
+        /// User closed dialog without taking action — still record the check
+        Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
+    }
+}
+
+void UpdateController::downloadUpdate(const QString &latestVersion, const QUrl &url)
+{
+    const QString fileName = url.fileName();
+    const QString savePath = QDir(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)).filePath(fileName);
+
+    auto *progress = new QProgressDialog(tr("Downloading wiRedPanda %1…").arg(latestVersion), tr("Cancel"), 0, 100, m_parent);
+    progress->setWindowTitle(tr("Downloading Update"));
+    progress->setWindowModality(Qt::WindowModal);
+    progress->setMinimumDuration(0);
+    progress->setValue(0);
+
+    auto *network = new QNetworkAccessManager(this);
+    QNetworkRequest request(url);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    QNetworkReply *reply = network->get(request);
+
+    connect(reply, &QNetworkReply::downloadProgress, progress, [progress](qint64 received, qint64 total) {
+        if (total > 0) {
+            progress->setValue(static_cast<int>(received * 100 / total));
+        }
+    });
+
+    connect(progress, &QProgressDialog::canceled, reply, &QNetworkReply::abort);
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply, progress, savePath] {
+        progress->close();
+        progress->deleteLater();
+
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->error() != QNetworkReply::OperationCanceledError) {
+                QMessageBox::warning(m_parent, tr("Download Failed"), tr("Could not download the update:\n%1").arg(reply->errorString()));
+            }
+            reply->deleteLater();
+            return;
+        }
+
+        QFile file(savePath);
+        if (!file.open(QIODevice::WriteOnly)) {
+            QMessageBox::warning(m_parent, tr("Download Failed"), tr("Could not save the file:\n%1").arg(savePath));
+            reply->deleteLater();
+            return;
+        }
+        file.write(reply->readAll());
+        file.close();
+        reply->deleteLater();
+
+        Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
+        QMessageBox::information(m_parent, tr("Download Complete"),
+            tr("wiRedPanda has been downloaded to:\n%1").arg(savePath));
+    });
+}

--- a/App/UI/UpdateController.h
+++ b/App/UI/UpdateController.h
@@ -1,0 +1,44 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief UpdateController: drives the application's check-for-updates workflow.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QUrl>
+
+class QWidget;
+
+/**
+ * \class UpdateController
+ * \brief Owns the update-check lifecycle: querying for a newer release and
+ * presenting the resulting notification / download dialogs.
+ *
+ * \details Extracted from MainWindow. Couples only to a parent QWidget (for
+ * dialog parenting) and Settings; it has no dependency on tabs, scenes, or
+ * circuit state. Call checkForUpdates() once after the window is shown.
+ */
+class UpdateController : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// \param parent Widget used to parent the modal update dialogs (and as QObject parent).
+    explicit UpdateController(QWidget *parent);
+
+    /// Starts an asynchronous version check; shows the update dialog if one is available.
+    void checkForUpdates();
+
+private:
+    /// Presents the "update available" dialog and dispatches download / release-page actions.
+    void showUpdateDialog(const QString &latestVersion, const QUrl &downloadUrl, const QUrl &releaseUrl);
+
+    /// Downloads \a url to the user's Downloads directory with a progress dialog.
+    void downloadUpdate(const QString &latestVersion, const QUrl &url);
+
+    QWidget *m_parent = nullptr;
+};

--- a/App/UI/WorkspaceManager.cpp
+++ b/App/UI/WorkspaceManager.cpp
@@ -1,0 +1,564 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/UI/WorkspaceManager.h"
+
+#include <QFile>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTabWidget>
+#include <QUndoStack>
+
+#include "App/Core/Application.h"
+#include "App/Core/Common.h"
+#include "App/Core/SentryHelpers.h"
+#include "App/Core/Settings.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/UI/ElementPalette.h"
+#include "App/UI/FileDialogProvider.h"
+#include "App/UI/MainWindowHost.h"
+
+WorkspaceManager::WorkspaceManager(QTabWidget *tab, MainWindowHost &host, QObject *parent)
+    : QObject(parent)
+    , m_tab(tab)
+    , m_host(host)
+{
+}
+
+QFileInfo WorkspaceManager::currentFile() const
+{
+    return m_currentTab ? m_currentTab->fileInfo() : QFileInfo();
+}
+
+QDir WorkspaceManager::currentDir() const
+{
+    return m_currentTab ? m_currentTab->fileInfo().absoluteDir() : QDir();
+}
+
+QFileInfo WorkspaceManager::icListFile() const
+{
+    // Walk up the parent workspace chain to find the root file on disk.
+    // Inline IC workspaces have no file of their own.
+    auto *ws = m_currentTab;
+    while (ws && ws->isInlineIC() && ws->parentWorkspace()) {
+        ws = ws->parentWorkspace();
+    }
+    if (ws) {
+        return ws->fileInfo();
+    }
+    return currentFile();
+}
+
+QString WorkspaceManager::dolphinFileName() const
+{
+    if (!m_currentTab) {
+        return {};
+    }
+    return m_currentTab->dolphinFileName();
+}
+
+void WorkspaceManager::setDolphinFileName(const QString &fileName)
+{
+    if (!m_currentTab) {
+        return;
+    }
+    m_currentTab->setDolphinFileName(fileName);
+}
+
+void WorkspaceManager::createNewTab()
+{
+    qCDebug(zero) << "Creating new workspace.";
+    auto *workspace = new WorkSpace(m_host.widget());
+
+    connect(workspace, &WorkSpace::fileChanged, this, &WorkspaceManager::setCurrentFile);
+
+    workspace->scene()->updateTheme();
+
+    qCDebug(zero) << "Adding tab. #tabs: " << m_tab->count() << ", current tab: " << m_tabIndex;
+    m_tab->addTab(workspace, tr("New Project"));
+    sentryBreadcrumb("ui", QStringLiteral("Tab opened"));
+
+    qCDebug(zero) << "Selecting the newly created tab.";
+    // The view's fast-mode state is applied when SceneUiBinder binds this tab below.
+    m_tab->setCurrentIndex(m_tab->count() - 1);
+}
+
+void WorkspaceManager::save(const QString &fileName)
+{
+    if (!m_currentTab) {
+        return;
+    }
+
+    m_currentTab->save(fileName);
+    m_host.palette()->updateICList(icListFile());
+    m_host.showStatusMessage(tr("File saved successfully."), 4000);
+}
+
+int WorkspaceManager::closeTabAnyway()
+{
+    QMessageBox msgBox;
+    msgBox.setParent(m_host.widget());
+    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    msgBox.setText(tr("File not saved. Close tab anyway?"));
+    msgBox.setWindowModality(Qt::WindowModal);
+    msgBox.setDefaultButton(QMessageBox::No);
+    return msgBox.exec();
+}
+
+int WorkspaceManager::confirmSave(const bool multiple)
+{
+    QMessageBox msgBox;
+    msgBox.setParent(m_host.widget());
+
+    // When closing all tabs at once, offer "Yes to All" / "No to All" to avoid
+    // repeated per-file prompts.
+    if (multiple) {
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel);
+    } else {
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+    }
+
+    const QString fileName = currentFile().fileName().isEmpty() ? tr("New Project") : currentFile().fileName();
+
+    msgBox.setText(fileName + tr(" has been modified.\nDo you want to save your changes?"));
+    msgBox.setWindowModality(Qt::WindowModal);
+    msgBox.setDefaultButton(QMessageBox::Yes);
+    return msgBox.exec();
+}
+
+void WorkspaceManager::newTab()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ui", QStringLiteral("New project"));
+        createNewTab();
+    });
+}
+
+void WorkspaceManager::loadPandaFile(const QString &fileName)
+{
+    const QFileInfo newFileInfo(fileName);
+
+    for (int i = 0; i < m_tab->count(); ++i) {
+        if (auto *workspace = qobject_cast<WorkSpace *>(m_tab->widget(i))) {
+            if (workspace->fileInfo() == newFileInfo) {
+                m_tab->setCurrentIndex(i);
+                return;
+            }
+        }
+    }
+
+    createNewTab();
+    qCDebug(zero) << "Loading in editor.";
+    try {
+        m_currentTab->load(fileName);
+    } catch (...) {
+        // Drop the half-populated tab so we don't leak an empty workspace
+        // into the tab bar. Clear the undo stack first so closeTab doesn't
+        // prompt the user to save the partial load.
+        m_currentTab->scene()->undoStack()->clear();
+        closeTab(m_tabIndex);
+        throw;
+    }
+    // Tighten the scene rect to the loaded items immediately so subsequent
+    // interactions (selection, drag release) don't cause a viewport jump.
+    m_currentTab->scene()->resizeScene();
+    m_host.palette()->updateICList(icListFile());
+    m_host.palette()->updateEmbeddedICList(m_currentTab->scene());
+    m_host.showStatusMessage(tr("File loaded successfully."), 4000);
+}
+
+void WorkspaceManager::openICInTab(const QString &blobName, int icElementId, const QByteArray &blob)
+{
+    if (!m_currentTab) {
+        return;
+    }
+
+    // Check if this blob is already being edited in a tab
+    for (int i = 0; i < m_tab->count(); ++i) {
+        auto *ws = qobject_cast<WorkSpace *>(m_tab->widget(i));
+        if (ws && ws->isInlineIC() && ws->inlineBlobName() == blobName
+            && ws->parentWorkspace() == m_currentTab) {
+            m_tab->setCurrentIndex(i);
+            return;
+        }
+    }
+
+    auto *parentWorkspace = m_currentTab;
+
+    createNewTab();
+
+    m_currentTab->loadFromBlob(blob, parentWorkspace, icElementId, parentWorkspace->scene()->contextDir());
+    // Tighten the scene rect to the loaded items immediately so subsequent
+    // interactions (selection, drag release) don't cause a viewport jump.
+    m_currentTab->scene()->resizeScene();
+
+    // Hide management buttons for inline tabs (they use currentFile/currentDir which are empty)
+    m_host.setICButtonsVisible(false);
+
+    // Set tab title
+    int tabIndex = m_tab->indexOf(m_currentTab);
+    m_tab->setTabText(tabIndex, "[" + blobName + "]");
+
+    m_host.palette()->updateICList(icListFile());
+    m_host.palette()->updateEmbeddedICList(m_currentTab->scene());
+
+    // Connect child tab's save signal to parent
+    connect(m_currentTab, &WorkSpace::icBlobSaved, parentWorkspace, &WorkSpace::onChildICBlobSaved);
+}
+
+void WorkspaceManager::openFile()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("file", QStringLiteral("Open file dialog"));
+    #ifdef Q_OS_WASM
+        auto fileContentReady = [this](const QString &fileName, const QByteArray &fileContent) {
+            if (!fileName.isEmpty()) {
+                // Write file content to a temporary file
+                QFile file(fileName);
+                file.open(QIODevice::WriteOnly);
+                file.write(fileContent);
+                file.close();
+                loadPandaFile(fileName);
+            }
+        };
+        QFileDialog::getOpenFileContent("Panda files (*.panda)", fileContentReady);
+    #else
+        const QString path = currentFile().exists() ? "" : "./Examples";
+        const QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Open File"), path, tr("Panda files (*.panda)"));
+
+        if (fileName.isEmpty()) {
+            return;
+        }
+
+        loadPandaFile(fileName);
+    #endif
+    });
+}
+
+void WorkspaceManager::saveFile()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("file", QStringLiteral("Save"));
+        if (!m_currentTab) {
+            return;
+        }
+
+        // Inline IC tabs serialize to a blob and emit to parent — no file dialog needed.
+        if (m_currentTab->isInlineIC()) {
+            save(QString());
+            return;
+        }
+
+    #ifdef Q_OS_WASM
+        saveFileAs();
+    #else
+        // TODO: if current file is autosave ask for filename
+
+        // If the project has never been saved, fall through to a Save-As dialog.
+        QString fileName = currentFile().absoluteFilePath();
+
+        if (fileName.isEmpty()) {
+            fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Save File as ..."), QString(), tr("Panda files (*.panda)")).fileName;
+
+            if (fileName.isEmpty()) {
+                return;
+            }
+
+            if (!fileName.endsWith(".panda")) {
+                fileName.append(".panda");
+            }
+        }
+
+        const int conflictTab = findTabWithFile(fileName);
+        if (conflictTab != -1) {
+            QMessageBox msgBox(QMessageBox::Warning,
+                               tr("File Conflict"),
+                               tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
+                               QMessageBox::Ok,
+                               m_host.widget());
+            QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
+            msgBox.exec();
+            if (msgBox.clickedButton() == switchBtn) {
+                m_tab->setCurrentIndex(conflictTab);
+            }
+            return;
+        }
+
+        save(fileName);
+    #endif
+    });
+}
+
+void WorkspaceManager::saveFileAs()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("file", QStringLiteral("Save as"));
+        if (!m_currentTab) {
+            return;
+        }
+
+    #ifdef Q_OS_WASM
+        // Save to a temporary file in the virtual FS, then offer it as a browser download.
+        const QString tmpPath = "/tmp/wiredpanda_save.panda";
+        save(tmpPath);
+
+        QFile file(tmpPath);
+        if (file.open(QIODevice::ReadOnly)) {
+            const QByteArray content = file.readAll();
+            file.close();
+
+            QString suggestedName = currentFile().fileName();
+            if (suggestedName.isEmpty()) {
+                suggestedName = "circuit.panda";
+            }
+            QFileDialog::saveFileContent(content, suggestedName);
+        }
+    #else
+        QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Save File as ..."), currentFile().absoluteFilePath(), tr("Panda files (*.panda)")).fileName;
+
+        if (fileName.isEmpty()) {
+            return;
+        }
+
+        if (!fileName.endsWith(".panda")) {
+            fileName.append(".panda");
+        }
+
+        const int conflictTab = findTabWithFile(fileName);
+        if (conflictTab != -1) {
+            QMessageBox msgBox(QMessageBox::Warning,
+                               tr("File Conflict"),
+                               tr("The file \"%1\" is already open in another tab.").arg(QFileInfo(fileName).fileName()),
+                               QMessageBox::Ok,
+                               m_host.widget());
+            QPushButton *switchBtn = msgBox.addButton(tr("Switch to Tab"), QMessageBox::ActionRole);
+            msgBox.exec();
+            if (msgBox.clickedButton() == switchBtn) {
+                m_tab->setCurrentIndex(conflictTab);
+            }
+            return;
+        }
+
+        save(fileName);
+    #endif
+    });
+}
+
+void WorkspaceManager::reloadFile()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("file", QStringLiteral("Reload file"));
+        if (!currentFile().exists() || !m_currentTab) {
+            return;
+        }
+
+        const QString file = currentFile().absoluteFilePath();
+
+        closeTab(m_tabIndex);
+        loadPandaFile(file);
+    });
+}
+
+int WorkspaceManager::findTabWithFile(const QString &fileName) const
+{
+    const QFileInfo newFileInfo(fileName);
+    for (int i = 0; i < m_tab->count(); ++i) {
+        if (auto *workspace = qobject_cast<WorkSpace *>(m_tab->widget(i))) {
+            if (workspace != m_currentTab && workspace->fileInfo() == newFileInfo) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+bool WorkspaceManager::closeFiles()
+{
+    // Close from last to first so that tab indices stay stable during iteration.
+    while (m_tab->count() != 0) {
+        if (!closeTab(m_tab->count() - 1)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool WorkspaceManager::hasModifiedFiles()
+{
+    const QStringList autosaves = Settings::autosaveFiles();
+
+    const auto workspaces = m_tab->findChildren<WorkSpace *>();
+
+    for (auto *workspace : workspaces) {
+        auto *scene = workspace->scene();
+        if (!scene) {
+            continue;
+        }
+
+        auto *undoStack = scene->undoStack();
+        if (!undoStack) {
+            continue;
+        }
+
+        // An un-clean undo stack means uncommitted edits since the last save.
+        if (!undoStack->isClean()) {
+            return true;
+        }
+
+        // An autosave file that is still in the list has not been explicitly
+        // saved by the user yet and should be treated as modified.
+        const QString fileName = workspace->fileInfo().fileName();
+
+        if (!fileName.isEmpty() && autosaves.contains(fileName)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void WorkspaceManager::loadAutosaveFiles()
+{
+    QStringList autosaves(Settings::autosaveFiles());
+
+    qCDebug(zero) << "All autosave files: " << autosaves;
+
+    for (auto it = autosaves.begin(); it != autosaves.end();) {
+        QFile file(*it);
+
+        if (!file.exists()) {
+            qCDebug(zero) << "Removing from config the autosave file that does not exist.";
+            it = autosaves.erase(it);
+            continue;
+        }
+
+        try {
+            loadPandaFile(*it);
+        } catch (const std::exception &e) {
+            if (Application::interactiveMode) {
+                QMessageBox::critical(nullptr, tr("Error!"), e.what());
+            }
+            qCDebug(zero) << "Removing autosave file that is corrupted.";
+            it = autosaves.erase(it);
+            continue;
+        }
+
+        // Mark the newly loaded tab so it knows it came from an autosave,
+        // causing it to prompt for a real save path on the next Ctrl+S.
+        m_currentTab->setAutosaveFile();
+
+        ++it;
+    }
+
+    Settings::setAutosaveFiles(autosaves);
+}
+
+void WorkspaceManager::setCurrentFile(const QFileInfo &fileInfo)
+{
+    // Find the tab belonging to the workspace that emitted the signal.
+    // The sender may differ from m_currentTab (e.g. a parent workspace emitting
+    // fileChanged while an inline IC child tab is active).
+    auto *senderWs = qobject_cast<WorkSpace *>(sender());
+    if (!senderWs) {
+        senderWs = m_currentTab;
+    }
+    if (!senderWs) {
+        return;
+    }
+
+    const int tabIndex = m_tab->indexOf(senderWs);
+    if (tabIndex < 0) {
+        return;
+    }
+
+    // Inline IC tabs use "[blobName]" as title — never the parent filename.
+    QString text;
+    if (senderWs->isInlineIC()) {
+        text = "[" + senderWs->inlineBlobName() + "]";
+    } else {
+        text = fileInfo.exists() ? fileInfo.fileName() : tr("New Project");
+    }
+
+    // Append an asterisk to the tab title to indicate unsaved changes,
+    // following the common editor convention.
+    auto *scene = senderWs->scene();
+    if (scene) {
+        auto *undoStack = scene->undoStack();
+        if (undoStack && !undoStack->isClean()) {
+            text += "*";
+        }
+    }
+
+    m_tab->setTabText(tabIndex, text);
+
+    // Only update tooltip and recent files for file-backed tabs.
+    if (!senderWs->isInlineIC()) {
+        m_tab->setTabToolTip(tabIndex, fileInfo.absoluteFilePath());
+        qCDebug(zero) << "Adding file to recent files.";
+        emit recentFileAdded(fileInfo.absoluteFilePath());
+    }
+
+    if (senderWs == m_currentTab) {
+        m_host.refreshICButtonsEnabled();
+    }
+}
+
+bool WorkspaceManager::closeTab(const int tabIndex)
+{
+    qCDebug(zero) << "Closing tab " << tabIndex + 1 << ", #tabs: " << m_tab->count();
+    // Activate the tab being closed so m_currentTab reflects the right workspace
+    // before we inspect its undo stack.
+    m_tab->setCurrentIndex(tabIndex);
+
+    qCDebug(zero) << "Checking if needs to save file.";
+
+    bool needsSave = false;
+    if (m_currentTab) {
+        auto *scene = m_currentTab->scene();
+        if (scene) {
+            auto *undoStack = scene->undoStack();
+            needsSave = undoStack && !undoStack->isClean();
+        }
+    }
+
+    if (needsSave) {
+        const int selectedButton = confirmSave(false);
+
+        if (selectedButton == QMessageBox::Cancel) {
+            return false;
+        }
+
+        if (selectedButton == QMessageBox::Yes) {
+            try {
+                save();
+            } catch (const std::exception &e) {
+                QMessageBox::critical(m_host.widget(), tr("Error"), e.what());
+
+                // If saving failed ask whether to discard and close anyway.
+                if (closeTabAnyway() == QMessageBox::No) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    qCDebug(zero) << "Deleting tab.";
+    m_currentTab->deleteLater();
+    sentryBreadcrumb("ui", QStringLiteral("Tab closed"));
+    m_tab->removeTab(tabIndex);
+
+    qCDebug(zero) << "Closed tab " << tabIndex << ", #tabs: " << m_tab->count() << ", current tab: " << m_tabIndex;
+
+    return true;
+}
+
+void WorkspaceManager::onCurrentIndexChanged(int newIndex)
+{
+    sentryBreadcrumb("ui", QStringLiteral("Tab changed to index %1").arg(newIndex));
+    m_tabIndex = newIndex;
+    m_currentTab = (newIndex == -1) ? nullptr : qobject_cast<WorkSpace *>(m_tab->currentWidget());
+    qCDebug(zero) << "Selecting tab: " << newIndex;
+    emit currentTabChanged(m_currentTab);
+}

--- a/App/UI/WorkspaceManager.h
+++ b/App/UI/WorkspaceManager.h
@@ -1,0 +1,93 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief WorkspaceManager: owns the circuit tabs and their file lifecycle.
+ */
+
+#pragma once
+
+#include <QDir>
+#include <QFileInfo>
+#include <QObject>
+#include <QString>
+
+class MainWindowHost;
+class QByteArray;
+class QTabWidget;
+class WorkSpace;
+
+/**
+ * \class WorkspaceManager
+ * \brief Owns the document/tab model: the current tab, tab creation/closing/switching,
+ * and the file open/save/reload/autosave workflow.
+ *
+ * \details Extracted from MainWindow via ownership inversion. It holds the current
+ * WorkSpace and drives the QTabWidget's contents (it does not own the widget — the UI
+ * does). UI feedback (status messages, palette refresh, IC tool-button state, dialog
+ * parenting) is reached through MainWindowHost; chrome rebinding is the shell's job,
+ * triggered by the currentTabChanged() signal. The public operations are kept callable
+ * from MainWindow delegators so the CLI batch mode, the MCP server, and tests are
+ * unaffected.
+ */
+class WorkspaceManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// \param tab The tab widget whose contents this manager owns (non-owning).
+    /// \param host Application context for status/palette/dialog-parent/IC-button feedback.
+    WorkspaceManager(QTabWidget *tab, MainWindowHost &host, QObject *parent = nullptr);
+
+    // --- Accessors (MainWindow's DolphinHost/MainWindowHost delegate here) ---
+
+    [[nodiscard]] WorkSpace *currentTab() const { return m_currentTab; }
+    [[nodiscard]] QFileInfo currentFile() const;
+    [[nodiscard]] QDir currentDir() const;
+    [[nodiscard]] QFileInfo icListFile() const;
+    [[nodiscard]] QString dolphinFileName() const;
+    void setDolphinFileName(const QString &fileName);
+
+    // --- Headless operations (called by CLI batch mode, the MCP server, and tests) ---
+
+    void createNewTab();
+    void loadPandaFile(const QString &fileName);
+    void openICInTab(const QString &blobName, int icElementId, const QByteArray &blob);
+    void save(const QString &fileName = {});
+    void loadAutosaveFiles();
+
+    [[nodiscard]] bool hasModifiedFiles();
+    bool closeFiles();
+    int confirmSave(bool multiple);
+
+public slots:
+    /// Reacts to QTabWidget::currentChanged: updates the current tab and emits currentTabChanged.
+    void onCurrentIndexChanged(int newIndex);
+    /// Closes the tab at \a tabIndex (prompting to save if needed). Returns false if cancelled.
+    bool closeTab(int tabIndex);
+
+    // Interactive file-menu handlers (each guards its own body).
+    void newTab();
+    void openFile();
+    void saveFile();
+    void saveFileAs();
+    void reloadFile();
+
+    /// Updates the tab title / tooltip / recent files for the workspace that emitted fileChanged.
+    void setCurrentFile(const QFileInfo &fileInfo);
+
+signals:
+    /// Emitted when the active tab changes (or becomes null); the shell rebinds the chrome.
+    void currentTabChanged(WorkSpace *tab);
+    /// Emitted when a file-backed tab is (re)named, to feed the recent-files list.
+    void recentFileAdded(const QString &filePath);
+
+private:
+    int closeTabAnyway();
+    [[nodiscard]] int findTabWithFile(const QString &fileName) const;
+
+    QTabWidget *m_tab;
+    MainWindowHost &m_host;
+    WorkSpace *m_currentTab = nullptr;
+    int m_tabIndex = -1;
+};

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -100,6 +100,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/WorkspaceManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPProcessor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPValidator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Handlers/BaseHandler.cpp
@@ -226,6 +227,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/WorkspaceManager.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Versions.h
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/JsonRpcError.h
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPProcessor.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -71,6 +71,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneDropHandler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneInteraction.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.cpp
@@ -194,6 +195,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneDropHandler.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneInteraction.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -83,6 +83,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementEditorUI.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementPalette.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementTabNavigator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/ExportController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/FileDialogProvider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICDropZone.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LabeledSlider.cpp
@@ -202,6 +203,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementEditorUI.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementPalette.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementTabNavigator.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/ExportController.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/FileDialogProvider.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICDropZone.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LabeledSlider.h
@@ -209,6 +211,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LengthDialog.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LengthDialogUI.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindow.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowHost.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowUI.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -19,6 +19,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Settings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ThemeManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/UpdateChecker.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementAppearance.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementFactory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementLabel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementMetadata.cpp
@@ -141,6 +142,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/StatusOps.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ThemeManager.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/UpdateChecker.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementAppearance.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementFactory.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementInfo.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementLabel.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -70,6 +70,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/GraphicsView.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/Simulation.cpp
@@ -191,6 +192,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/GraphicsView.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/Simulation.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -93,6 +93,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowUI.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPProcessor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPValidator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Handlers/BaseHandler.cpp
@@ -211,6 +212,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowUI.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Versions.h
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/JsonRpcError.h
     ${CMAKE_CURRENT_LIST_DIR}/MCP/Server/Core/MCPProcessor.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -70,6 +70,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/GraphicsView.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneDropHandler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.cpp
@@ -192,6 +193,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/GraphicsView.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/PropertyShortcutHandler.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Scene.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneDropHandler.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/SceneItemRegistry.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/VisibilityManager.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/Workspace.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -85,6 +85,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementTabNavigator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ExportController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/FileDialogProvider.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICDropZone.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LabeledSlider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LanguageManager.cpp
@@ -205,6 +206,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ElementTabNavigator.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ExportController.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/FileDialogProvider.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICController.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ICDropZone.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LabeledSlider.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LanguageManager.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -96,6 +96,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/LengthDialogUI.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindow.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowUI.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/SceneUiBinder.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.cpp
@@ -221,6 +222,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindow.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowHost.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/MainWindowUI.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/UI/SceneUiBinder.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/SelectionCapabilities.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/TrashButton.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/UpdateController.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -22,6 +22,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementFactory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementLabel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementMetadata.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementSimState.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElement.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElementInput.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElements/And.cpp
@@ -144,6 +145,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementInfo.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementLabel.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementMetadata.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Element/ElementSimState.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElement.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElementInput.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/GraphicElements/And.h


### PR DESCRIPTION
## Summary

Decomposes the two remaining headline god-classes (`MainWindow`, `Scene`) and partially decomposes the god *base* class `GraphicElement`, following the `BewavedDolphin` precedent. Every extraction is **structure-only and behavior-preserving** — the full test suite (176/176) stays green after each commit. The approach throughout is **ownership inversion**: a collaborator *owns the state of its responsibility* so the residual back-calls are narrow and legitimate (the `ConnectionManager` contract), rather than interface-proxying.

## What changed

**`MainWindow` 2250 → ~1040 lines** — extracted behind the `MainWindowHost`/`DolphinHost` interface:
- `UpdateController`, `ExportController`, `ICController`
- `SceneUiBinder` — owns the active-scene ↔ shared-chrome wiring (scene shortcuts, undo/redo menu, element editor, zoom/mute/play sync)
- `WorkspaceManager` — owns the tab model + open/save/reload/autosave; announces `currentTabChanged`, the shell rebinds chrome

**`Scene` 1139 → 810 lines:**
- `SceneItemRegistry` (id↔item map), `SceneDropHandler` (drag-drop decoding)
- `SceneInteraction` — owns the seven mouse/selection-state members + the gestures

**`GraphicElement` 1243 → 844 lines** (cpp), two owned-collaborator value members:
- `ElementSimState` — simulation runtime state (I/O four-state vectors, connection-graph edges, propagation). Reads ports only via parameters, so it carries no Qt graphics dependency. Inline forwarders keep all 32 subclasses + `Simulation`/`WaveformSimulator` unchanged.
- `ElementAppearance` — pixmap/SVG state, appearance lists, SVG `<text>` counter-orientation + caches, the paint body, selection colors. Orientation (rotation/flip) stays on the element as its coordinating identity; the appearance reads it back through a narrow owner reference.

## Deliberately left on the bases (with reason)

- `MainWindow`/`Scene` keep thin public delegators so the CLI/MCP/test entry points are unchanged.
- `GraphicElement` keeps **ports + orientation** (the orientation model drives both pixmap and port positioning — an irreducible coordinator) and the **property model** (mostly virtual/metadata, not ownable base state). The serializer stays a file-split TU; promoting it to a class was rejected (it owns no state — a `friend` with full private reach is not a real boundary).

## Testing

`cmake --build --preset debug` + `ctest --preset debug` — **176/176 passing** after every commit. Verified areas: element `updateLogic`/`resetSimState`, pixmap/appearance/rotation/flip rendering, `.panda`/`.ino`/`.sv` round-trips, scene + undo, waveform export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
