### PR TITLE
build: promote warnings to errors and fix all platform-specific issues

### DIFF
--- a/App/BeWavedDolphin/DolphinClipboard.cpp
+++ b/App/BeWavedDolphin/DolphinClipboard.cpp
@@ -52,7 +52,8 @@ void copy(const SignalModel &model, const QItemSelection &ranges, QDataStream &s
     const int anchorRow = firstRow(model, ranges);
     const int anchorCol = firstColumn(model, ranges);
     const auto itemList = ranges.indexes();
-    stream << static_cast<qint64>(itemList.size());
+    const qint64 sz = itemList.size();
+    stream << sz;
 
     for (const auto &item : itemList) {
         const int value = model.value(item.row(), item.column());

--- a/App/CodeGen/ArduinoCodeGen.h
+++ b/App/CodeGen/ArduinoCodeGen.h
@@ -63,7 +63,7 @@ struct ArduinoBoardConfig
     QStringList availablePins; ///< Ordered list of usable pin labels.
     QString description;   ///< Human-readable board description.
     /// Returns the total number of available pins.
-    int maxPins() const { return static_cast<int>(availablePins.size()); }
+    qsizetype maxPins() const { return availablePins.size(); }
 };
 
 /**

--- a/App/Element/ElementAppearance.cpp
+++ b/App/Element/ElementAppearance.cpp
@@ -58,7 +58,7 @@ QByteArray orientSvgTextNodes(const QByteArray &svgBytes, const qreal angle, con
     // Inkscape already ids these, but be defensive for hand-written assets.
     {
         QString out;
-        int last = 0;
+        qsizetype last = 0;
         int generated = 0;
         auto matches = textTag.globalMatch(svg);
         while (matches.hasNext()) {
@@ -89,7 +89,7 @@ QByteArray orientSvgTextNodes(const QByteArray &svgBytes, const qreal angle, con
     // glyph must carry is Rotate(-angle) ∘ Flip (rotate outer, scale inner). The rotate term is
     // omitted at angle 0 and the scale term when unflipped, so the flip-only output is unchanged.
     QString out;
-    int last = 0;
+    qsizetype last = 0;
     auto matches = textTag.globalMatch(svg);
     while (matches.hasNext()) {
         const auto match = matches.next();

--- a/App/Element/ICRegistry.cpp
+++ b/App/Element/ICRegistry.cpp
@@ -392,7 +392,7 @@ void ICRegistry::makeBlobSelfContained(const QString &name, QSet<QString> &visit
     }
 
     // Re-serialize the blob with updated metadata
-    const QByteArray elements = blobData.mid(readStream.device()->pos());
+    const QByteArray elements = readStream.device()->readAll();
 
     Serialization::serializeBlobRegistry(embeddedICs, metadata);
 
@@ -423,7 +423,7 @@ void ICRegistry::renameBlobReference(QByteArray &blobData, const QString &oldNam
     embeddedICs[newName] = embeddedICs.take(oldName);
 
     // Re-serialize the blob with updated metadata
-    const QByteArray elements = blobData.mid(readStream.device()->pos());
+    const QByteArray elements = readStream.device()->readAll();
     auto metadata = preamble.metadata;
     Serialization::serializeBlobRegistry(embeddedICs, metadata);
 

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -11,6 +11,7 @@
 #include <QGraphicsSceneDragDropEvent>
 #include <QKeyEvent>
 #include <QMenu>
+#include <QPolygon>
 #include <QScrollBar>
 
 #include "App/Core/Common.h"
@@ -201,9 +202,8 @@ void Scene::drawBackground(QPainter *painter, const QRectF &rect)
 
     painter->setPen(m_dots);
 
-    QVector<QPoint> points;
-    points.reserve(static_cast<qsizetype>((right - left) / gridSize + 1)
-                 * ((bottom - top) / gridSize + 1));
+    QPolygon points;
+    points.reserve(((right - left) / gridSize + 1) * ((bottom - top) / gridSize + 1));
 
     for (int x = left; x <= right; x += gridSize) {
         for (int y = top; y <= bottom; y += gridSize) {
@@ -211,7 +211,7 @@ void Scene::drawBackground(QPainter *painter, const QRectF &rect)
         }
     }
 
-    painter->drawPoints(points.data(), static_cast<int>(points.size()));
+    painter->drawPoints(points);
 }
 
 void Scene::setDots(const QPen &dots)

--- a/App/UI/ElementPalette.cpp
+++ b/App/UI/ElementPalette.cpp
@@ -68,7 +68,7 @@ void ElementPalette::updateICList(const QFileInfo &currentFile)
         QStringList files = directory.entryList({"*.panda", "*.PANDA"}, QDir::Files);
         // Exclude the project file itself and hidden/autosave files.
         files.removeAll(currentFile.fileName());
-        for (int i = static_cast<int>(files.size()) - 1; i >= 0; --i) {
+        for (qsizetype i = files.size() - 1; i >= 0; --i) {
             if (files.at(i).at(0) == '.') {
                 files.removeAt(i);
             }

--- a/App/UI/ElementTabNavigator.cpp
+++ b/App/UI/ElementTabNavigator.cpp
@@ -55,12 +55,12 @@ bool ElementTabNavigator::eventFilter(QObject *obj, QEvent *event)
         return a->pos().rx() < b->pos().rx();
     });
 
-    const int elmPos = static_cast<int>(elements.indexOf(elm));
-    const int step   = moveFwd ? 1 : -1;
-    const int total  = static_cast<int>(elements.size());
+    const qsizetype elmPos = elements.indexOf(elm);
+    const qsizetype step   = moveFwd ? 1 : -1;
+    const qsizetype total  = elements.size();
 
     auto *widget = qobject_cast<QWidget *>(obj);
-    int pos = (total + elmPos + step) % total;
+    qsizetype pos = (total + elmPos + step) % total;
 
     // Advance until we find an element whose editor widget is actually enabled
     // (some elements don't expose the currently focused field, so we skip them).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,10 @@ else()
 endif()
 
 if(MSVC)
-    add_compile_options(/W4 /external:W0 /permissive-)
+    add_compile_options(/W4 /WX /external:W0 /permissive-)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(
-        -Wall -Wextra -Wpedantic
+        -Wall -Wextra -Wpedantic -Werror
         -Wconversion -Wsign-conversion
         -Wshadow
         -Wnon-virtual-dtor
@@ -91,9 +91,11 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
             -Wduplicated-cond
             -Wduplicated-branches
             -Wlogical-op
-            -Wuseless-cast
             -Wsuggest-override
         )
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            add_compile_options(-Wuseless-cast)
+        endif()
     endif()
 endif()
 

--- a/MCP/Server/Handlers/BaseHandler.cpp
+++ b/MCP/Server/Handlers/BaseHandler.cpp
@@ -165,11 +165,11 @@ bool BaseHandler::validatePortRange(GraphicElement *element, int portIndex, bool
     }
 
     // Use the safe QVector size() instead of calling outputPort()/inputPort()
-    int maxPorts = 0;
+    qsizetype maxPorts = 0;
     if (isOutput) {
-        maxPorts = static_cast<int>(element->outputs().size());
+        maxPorts = element->outputs().size();
     } else {
-        maxPorts = static_cast<int>(element->inputs().size());
+        maxPorts = element->inputs().size();
     }
 
     if (portIndex >= maxPorts) {

--- a/Tests/Common/TestUtils.h
+++ b/Tests/Common/TestUtils.h
@@ -8,6 +8,12 @@
 #include <QApplication>
 #include <QTest>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+#  define QVERIFY_THROWS(exType, ...) QVERIFY_THROWS_EXCEPTION(exType, __VA_ARGS__)
+#else
+#  define QVERIFY_THROWS(exType, ...) QVERIFY_EXCEPTION_THROWN(__VA_ARGS__, exType)
+#endif
+
 #include "App/Core/Common.h"
 #include "App/Element/GraphicElement.h"
 #include "App/Scene/Scene.h"

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -4378,7 +4378,7 @@ void TestICInline::testSceneAddItemMimeDataThrowCleansUp()
     mimeData->setData("application/x-wiredpanda-dragdrop", itemData);
     QPointer<QMimeData> mimeWatcher(mimeData);
 
-    QVERIFY_EXCEPTION_THROWN(ws.scene()->addItem(mimeData), std::exception);
+    QVERIFY_THROWS(std::exception, ws.scene()->addItem(mimeData));
 
     QCOMPARE(static_cast<int>(ws.scene()->elements().size()), elementsBefore);
 

--- a/Tests/Unit/Serialization/TestDolphinSerializer.cpp
+++ b/Tests/Unit/Serialization/TestDolphinSerializer.cpp
@@ -180,7 +180,7 @@ void TestDolphinSerializer::testLoadBinaryRejectsNegativeRows()
         stream << static_cast<qint64>(5);
     }
     QDataStream stream(&payload, QIODevice::ReadOnly);
-    QVERIFY_EXCEPTION_THROWN(DolphinSerializer::loadBinary(stream, 8), std::exception);
+    QVERIFY_THROWS(std::exception, DolphinSerializer::loadBinary(stream, 8));
 }
 
 void TestDolphinSerializer::testLoadCSVRejectsNegativeRows()
@@ -195,5 +195,5 @@ void TestDolphinSerializer::testLoadCSVRejectsNegativeRows()
     }
     QFile in(path);
     QVERIFY(in.open(QIODevice::ReadOnly));
-    QVERIFY_EXCEPTION_THROWN(DolphinSerializer::loadCSV(in, 8), std::exception);
+    QVERIFY_THROWS(std::exception, DolphinSerializer::loadCSV(in, 8));
 }

--- a/Tests/Unit/Serialization/TestFileUtils.cpp
+++ b/Tests/Unit/Serialization/TestFileUtils.cpp
@@ -128,7 +128,7 @@ void TestFileUtils::testCopyToDirThrowsOnFailure()
 
     // Destination directory does not exist — QFile::copy returns false.
     const QString badDest = sourceDir.path() + "/no/such/subdirectory";
-    QVERIFY_EXCEPTION_THROWN(FileUtils::copyToDir(sourceFile, badDest), std::exception);
+    QVERIFY_THROWS(std::exception, FileUtils::copyToDir(sourceFile, badDest));
 }
 
 namespace {

--- a/Tests/Unit/Ui/TestCircuitExporter.cpp
+++ b/Tests/Unit/Ui/TestCircuitExporter.cpp
@@ -26,5 +26,5 @@ void TestCircuitExporter::testRenderToImageThrowsOnInvalidPath()
     // and pre-fix that failure was silently swallowed. The throw is the regression.
     WorkSpace workspace;
     const QString path = "/nonexistent/directory/that/does/not/exist/img.png";
-    QVERIFY_EXCEPTION_THROWN(CircuitExporter::renderToImage(workspace.scene(), path), std::exception);
+    QVERIFY_THROWS(std::exception, CircuitExporter::renderToImage(workspace.scene(), path));
 }


### PR DESCRIPTION
## Summary

- Adds `-Werror` (GCC/Clang) and `/WX` (MSVC) to make every warning a hard build error
- Fixes all resulting failures across Linux 64-bit, Linux 32-bit (i386), macOS (Clang), and Windows MSVC
- Guards `-Wuseless-cast` to 64-bit only — on 32-bit `qsizetype == int` makes all `size→int` casts appear spuriously useless
- Replaces deprecated `QVERIFY_EXCEPTION_THROWN` with a Qt-version-aware `QVERIFY_THROWS` shim (Qt 6.7+ compatibility)

## Test plan

- [x] CI green on all matrix jobs: Linux 64-bit, Linux 32-bit (i386), Linux ARM, macOS 15 + 26, Windows 2025 + ARM

🤖 Generated with [Claude Code](https://claude.com/claude-code)