### PR TITLE
fix(updater): match release asset to CPU architecture

### DIFF
--- a/App/Core/UpdateChecker.cpp
+++ b/App/Core/UpdateChecker.cpp
@@ -9,12 +9,43 @@
 #include <QJsonObject>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QSysInfo>
 #include <QVersionNumber>
 
 #include "App/Core/Settings.h"
 #include "App/Versions.h"
 
 static constexpr auto k_apiUrl = "https://api.github.com/repos/gibis-unifesp/wiredpanda/releases/latest";
+
+/// Compile-time name of the platform this binary was built for, matching the
+/// platform token embedded in release asset filenames by deploy.yml.
+static QString currentPlatform()
+{
+#if defined(Q_OS_WIN)
+    return "Windows";
+#elif defined(Q_OS_MACOS)
+    return "macOS";
+#elif defined(Q_OS_LINUX)
+    return "Linux";
+#else
+    return {};
+#endif
+}
+
+bool isMatchingReleaseAsset(const QString &name, const QString &platform, const QString &arch)
+{
+    if (platform == "Linux") {
+        return name.endsWith(".AppImage") && name.contains(arch, Qt::CaseInsensitive);
+    }
+    if (platform == "Windows") {
+        return name.contains("Windows") && name.endsWith(".zip") && name.contains(arch, Qt::CaseInsensitive);
+    }
+    if (platform == "macOS") {
+        // A single universal DMG serves both architectures, so it carries no arch token.
+        return name.contains("macOS") && name.endsWith(".dmg");
+    }
+    return false;
+}
 
 UpdateChecker::UpdateChecker(QObject *parent)
     : QObject(parent)
@@ -63,20 +94,13 @@ void UpdateChecker::onReplyFinished(QNetworkReply *reply)
     }
 
     QUrl downloadUrl;
+    const QString platform = currentPlatform();
+    const QString arch = QSysInfo::buildCpuArchitecture(); // "x86_64" / "arm64"
     const QJsonArray assets = doc.object().value("assets").toArray();
     for (const QJsonValue &assetVal : assets) {
         const QJsonObject asset = assetVal.toObject();
         const QString name = asset.value("name").toString();
-#if defined(Q_OS_WIN)
-        const bool match = name.contains("Windows") && name.endsWith(".zip");
-#elif defined(Q_OS_MACOS)
-        const bool match = name.contains("macOS") && name.endsWith(".dmg");
-#elif defined(Q_OS_LINUX)
-        const bool match = name.endsWith(".AppImage");
-#else
-        const bool match = false;
-#endif
-        if (match) {
+        if (isMatchingReleaseAsset(name, platform, arch)) {
             downloadUrl = QUrl(asset.value("browser_download_url").toString());
             break;
         }

--- a/App/Core/UpdateChecker.h
+++ b/App/Core/UpdateChecker.h
@@ -49,3 +49,12 @@ private:
 
     QNetworkAccessManager m_network;
 };
+
+/// \brief True when a GitHub release asset filename is the binary for the given
+/// platform ("Windows"/"macOS"/"Linux") and CPU arch token (a QSysInfo arch name,
+/// e.g. "x86_64", "arm64").
+///
+/// \details Exposed for testing. Linux (.AppImage) and Windows (.zip) releases
+/// ship a per-architecture asset, so the arch token must also match; macOS ships
+/// a single universal DMG and is matched on platform alone.
+bool isMatchingReleaseAsset(const QString &name, const QString &platform, const QString &arch);

--- a/Tests/Unit/Core/TestUpdateChecker.cpp
+++ b/Tests/Unit/Core/TestUpdateChecker.cpp
@@ -31,3 +31,43 @@ void TestUpdateChecker::testNetworkError()
     // Should not crash on network error
     QVERIFY(true);
 }
+
+void TestUpdateChecker::testAssetSelection()
+{
+    // Regression: a release ships per-architecture Linux AppImages and Windows
+    // ZIPs. The GitHub API returns assets sorted alphabetically, so "arm64"
+    // precedes "x86_64"; selecting by suffix alone wrongly picked the arm64
+    // binary for x86_64 users. Pin architecture-aware selection here. These are
+    // the real 5.1.2 asset names.
+    const QString linuxArm = "wiRedPanda-5.1.2-Linux-arm64-Qt6.9.3.AppImage";
+    const QString linuxX86 = "wiRedPanda-5.1.2-Linux-x86_64-Qt6.9.3.AppImage";
+    const QString macUniversal = "wiRedPanda-5.1.2-macOS-Qt6.9.3.dmg";
+    const QString winArm = "wiRedPanda-5.1.2-Windows-arm64-Qt6.9.3-Portable.zip";
+    const QString winX86 = "wiRedPanda-5.1.2-Windows-x86_64-Qt6.9.3-Portable.zip";
+
+    // Linux: each arch matches only its own AppImage (the exact reported bug).
+    QVERIFY(isMatchingReleaseAsset(linuxX86, "Linux", "x86_64"));
+    QVERIFY(!isMatchingReleaseAsset(linuxArm, "Linux", "x86_64"));
+    QVERIFY(isMatchingReleaseAsset(linuxArm, "Linux", "arm64"));
+    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Linux", "arm64"));
+
+    // Windows: same latent defect, same guard.
+    QVERIFY(isMatchingReleaseAsset(winX86, "Windows", "x86_64"));
+    QVERIFY(!isMatchingReleaseAsset(winArm, "Windows", "x86_64"));
+    QVERIFY(isMatchingReleaseAsset(winArm, "Windows", "arm64"));
+    QVERIFY(!isMatchingReleaseAsset(winX86, "Windows", "arm64"));
+
+    // A Linux build must never select a Windows or macOS asset, and vice-versa.
+    QVERIFY(!isMatchingReleaseAsset(winX86, "Linux", "x86_64"));
+    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Windows", "x86_64"));
+
+    // macOS: single universal DMG, matched on platform regardless of arch token.
+    QVERIFY(isMatchingReleaseAsset(macUniversal, "macOS", "x86_64"));
+    QVERIFY(isMatchingReleaseAsset(macUniversal, "macOS", "arm64"));
+    QVERIFY(!isMatchingReleaseAsset(linuxX86, "macOS", "x86_64"));
+
+    // Unknown architecture matches nothing where an arch token is required —
+    // the caller then falls back to the release page rather than a wrong binary.
+    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Linux", "ppc64"));
+    QVERIFY(!isMatchingReleaseAsset(winX86, "Windows", "ppc64"));
+}

--- a/Tests/Unit/Core/TestUpdateChecker.h
+++ b/Tests/Unit/Core/TestUpdateChecker.h
@@ -15,4 +15,5 @@ private slots:
     void testUpdateAvailable();
     void testNoUpdate();
     void testNetworkError();
+    void testAssetSelection();
 };


### PR DESCRIPTION
## Problem

A user running wiRedPanda **5.0.1 on Linux (x86_64)** was notified of a newer version. Clicking **Download** fetched the **arm64** AppImage of 5.1.2 — an unrunnable binary on their machine.

`UpdateChecker::onReplyFinished()` selected the download asset by file **suffix only**, ignoring CPU architecture:

```cpp
#elif defined(Q_OS_LINUX)
        const bool match = name.endsWith(".AppImage");   // matches BOTH arches
```

Since 5.1.2 the deploy matrix ships **two** Linux AppImages and **two** Windows ZIPs (x86_64 *and* arm64). The GitHub Releases API returns assets sorted alphabetically, so `arm64` precedes `x86_64` and the loop stops at the first `.AppImage` — the wrong one. Verified via `gh api` on the 5.1.2 release:

```
wiRedPanda-5.1.2-Linux-arm64-Qt6.9.3.AppImage     <- first .AppImage, wrongly chosen
wiRedPanda-5.1.2-Linux-x86_64-Qt6.9.3.AppImage
wiRedPanda-5.1.2-macOS-Qt6.9.3.dmg
wiRedPanda-5.1.2-Windows-arm64-Qt6.9.3-Portable.zip   <- latent same bug on Windows
wiRedPanda-5.1.2-Windows-x86_64-Qt6.9.3-Portable.zip
```

This is deterministic, not a race. Windows had the identical latent defect; macOS ships a single universal DMG and is unaffected.

## Fix

Match the asset's architecture token (`x86_64` / `arm64`, exactly as deploy.yml embeds it) against `QSysInfo::buildCpuArchitecture()`:

- Extracted a pure, testable `isMatchingReleaseAsset(name, platform, arch)` helper plus a compile-time `currentPlatform()`.
- Linux (`.AppImage`) and Windows (`.zip`) now require the arch token; macOS stays platform-only.
- `buildCpuArchitecture()` (compile-time arch of the running binary) guarantees the offered asset actually runs; case-insensitive `contains` guards future casing drift.
- If no asset matches (exotic/unknown arch), `downloadUrl` stays empty and the dialog already degrades gracefully to a "Visit the release page" link — strictly better than a wrong binary.

## Tests

Replaced the placeholder `TestUpdateChecker` with a real cross-platform regression test using the actual 5.1.2 asset names: the exact Linux bug, the latent Windows bug, macOS universal, cross-platform isolation, and the unknown-arch fallback. **6 passed, 0 failed.**

Also empirically confirmed `QSysInfo::buildCpuArchitecture()` returns `"x86_64"` on an x86_64 build, matching the deploy.yml token.

## Limitations

The updater is compiled into each release, so already-shipped 5.0.1/5.1.x binaries keep the buggy matcher — this only helps users who reach a build containing the fix. No server-side mitigation is possible.
