### PR TITLE
build: bump version to 5.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # explicit cmake_policy(SET) needed.
 cmake_minimum_required(VERSION 3.27...3.31)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
-project(wiredpanda VERSION 5.1.2 LANGUAGES CXX)
+project(wiredpanda VERSION 5.1.3 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Bumps the application version `5.1.2` → `5.1.3` in `CMakeLists.txt`, the single source of truth that feeds `APP_VERSION` → `AppVersion::current` (used by the About dialog and the update checker's own version comparison).

This is the version-bump half of the 5.1.3 release. The updater architecture fix already merged via #427; this completes the bump so the built binary reports `5.1.3` in-app, matching the `5.1.3` release tag/artifacts.

No file-format change: `.panda` files store `FormatRev::current` (still `5.1`), which is independent of the app version — so no `.panda` migration is involved.

### Verification
Reconfiguring CMake confirms the macro propagates: generated build defines `-DAPP_VERSION="5.1.3"`.
