### PR TITLE
fix(ci): enable ENABLE_MCP_SERVER for coverage builds regardless of branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,14 @@ add_compile_definitions(
     QT_MESSAGELOGCONTEXT
 )
 
-# MCP Server - disabled on tagged release CI builds, enabled on development branches
+# MCP Server - disabled on tagged release CI builds, enabled on development branches.
+# Coverage builds are CI-only instrumentation artifacts that specifically exist to
+# measure MCP/Server coverage (see MCP/Client/run_tests.py in coverage.yml), so always
+# enable it there regardless of branch — the Coverage workflow only ever runs on master.
 if(DEFINED ENV{GITHUB_REF} AND "$ENV{GITHUB_REF}" MATCHES "^refs/tags/")
     # Tagged release CI build — MCP disabled
+elseif(ENABLE_COVERAGE)
+    add_compile_definitions(ENABLE_MCP_SERVER)
 else()
     find_package(Git QUIET)
     if(GIT_FOUND)


### PR DESCRIPTION
## Summary
- The Coverage workflow (`.github/workflows/coverage.yml`) only triggers on `push: branches: [master]`, but `ENABLE_MCP_SERVER` was disabled whenever the checked-out branch was `master`/`main`, so the "MCP Integration Test (instrumented)" step (added in 7c6128578) could never pass on its actual trigger condition — `wiredpanda --mcp` isn't a recognized option in that build, so `QCommandLineParser` exits(1) immediately.
- Fix: carve out an explicit exception so the `coverage` preset always defines `ENABLE_MCP_SERVER`, ahead of the branch check. Coverage binaries are CI-only instrumentation artifacts never shipped to users, and the step exists specifically to measure MCP/Server coverage, so the "never on a plain master checkout" rationale doesn't apply to them. Other presets (debug/release/sanitizers) are unaffected.

## Test plan
- [x] Configured `coverage` preset on `master` locally — confirmed `ENABLE_MCP_SERVER` now appears in `compile_commands.json`
- [x] Reconfigured `debug` preset on `master` locally — confirmed `ENABLE_MCP_SERVER` is still absent (unaffected)
- [ ] Watch the next `Coverage` workflow run on `master` after merge to confirm the "MCP Integration Test (instrumented)" step passes end-to-end (gcov + Codecov upload)