### PR TITLE
4-state port visualization: honest Unknown default, unified colors, port shapes

### DIFF
--- a/App/Core/ThemeManager.cpp
+++ b/App/Core/ThemeManager.cpp
@@ -146,7 +146,7 @@ void ThemeManager::setTheme(const Theme theme)
     emit instance().themeChanged();
 }
 
-ThemeAttributes ThemeManager::attributes()
+const ThemeAttributes &ThemeManager::attributes()
 {
     return instance().m_attributes;
 }
@@ -265,20 +265,17 @@ void ThemeAttributes::setTheme(const Theme theme)
 
     // Port brushes mirror the wire colours for consistency so users can visually
     // correlate a wire's colour with the port it connects to.
-    // Output ports use a distinct pink/red hue to visually distinguish them from input ports.
     m_portUnknownBrush = m_connectionUnknown;
     m_portInactiveBrush = m_connectionInactive;
     m_portActiveBrush = m_connectionActive;
     m_portErrorBrush = m_connectionError;
-    m_portOutputBrush = QColor(243, 83, 105); // vivid rose-pink for output ports
 
-    // Port pen colours are theme-invariant (always black/darkRed) because they are drawn
-    // as outlines on top of the brush fill and need consistent contrast
+    // Port pen colours are theme-invariant because they are drawn as outlines
+    // on top of the brush fill and need consistent contrast
     m_portUnknownPen = QColor(120, 120, 120);  // dark gray — distinct from error red
     m_portInactivePen = QColor(Qt::black);
     m_portActivePen = QColor(Qt::black);
     m_portErrorPen = QColor(Qt::red);
-    m_portOutputPen = QColor(Qt::darkRed);
 
     m_portHoverPort = QColor(Qt::yellow); // bright yellow on hover for high visibility regardless of theme
 

--- a/App/Core/ThemeManager.h
+++ b/App/Core/ThemeManager.h
@@ -60,7 +60,6 @@ public:
     QColor m_portInactiveBrush;
     QColor m_portActiveBrush;
     QColor m_portErrorBrush;
-    QColor m_portOutputBrush;
 
     // --- Members: Port Pen Colors ---
 
@@ -68,7 +67,6 @@ public:
     QColor m_portInactivePen;
     QColor m_portActivePen;
     QColor m_portErrorPen;
-    QColor m_portOutputPen;
 
     // --- Members: Port Hover ---
 
@@ -106,8 +104,8 @@ public:
     /// Returns the currently active theme.
     static Theme theme();
 
-    /// Returns a copy of the current ThemeAttributes color set.
-    static ThemeAttributes attributes();
+    /// Returns the current ThemeAttributes color set.
+    static const ThemeAttributes &attributes();
 
     // --- Theme Management ---
 

--- a/App/Element/GraphicElements/InputGND.cpp
+++ b/App/Element/GraphicElements/InputGND.cpp
@@ -5,6 +5,7 @@
 
 #include "App/Element/ElementFactory.h"
 #include "App/Element/ElementInfo.h"
+#include "App/Nodes/QNEPort.h"
 
 template<>
 struct ElementInfo<InputGnd> {
@@ -42,4 +43,7 @@ struct ElementInfo<InputGnd> {
 InputGnd::InputGnd(QGraphicsItem *parent)
     : GraphicElement(ElementType::InputGnd, parent)
 {
+    // GND always outputs logic LOW; set the port default so both the visual
+    // wire colour and the simulation output vector are correct from the start.
+    m_outputPorts.constFirst()->setDefaultStatus(Status::Inactive);
 }

--- a/App/Element/GraphicElements/InputRotary.cpp
+++ b/App/Element/GraphicElements/InputRotary.cpp
@@ -56,6 +56,11 @@ InputRotary::InputRotary(QGraphicsItem *parent)
     setLocked(false);
 
     InputRotary::updatePortsProperties();
+
+    // The dial starts at position 0, which drives HIGH while every other
+    // position drives LOW: push those definite levels to the output ports,
+    // which otherwise stay at the undriven Unknown default.
+    InputRotary::setOn(true, 0);
 }
 
 void InputRotary::refresh()

--- a/App/Element/GraphicElements/InputSwitch.cpp
+++ b/App/Element/GraphicElements/InputSwitch.cpp
@@ -50,6 +50,11 @@ InputSwitch::InputSwitch(QGraphicsItem *parent)
     : GraphicElementInput(ElementType::InputSwitch, parent)
 {
     m_locked = false;
+
+    // A switch drives a definite level from birth: push the OFF state to the
+    // output port, which otherwise stays at the undriven Unknown default.
+    // Base-qualified because the unqualified setOn()/setOff() toggle.
+    GraphicElementInput::setOn(false);
 }
 
 bool InputSwitch::isOn(const int port) const

--- a/App/Nodes/QNEConnection.cpp
+++ b/App/Nodes/QNEConnection.cpp
@@ -30,9 +30,9 @@ QNEConnection::QNEConnection(QGraphicsItem *parent)
     // Draw wires behind elements so port dots and element bodies always render on top
     setZValue(-1);
 
+    // m_status starts at Status::Unknown; updateTheme() applies its pen via
+    // applyStatusPen(). The wire colour is updated once both ports are attached.
     updateTheme();
-    // Start in the Unknown visual state; the wire colour is updated once both ports are attached
-    setPen(QPen(m_unknownColor, 3));
 }
 
 QNEConnection::~QNEConnection()
@@ -281,16 +281,7 @@ void QNEConnection::setStatus(const Status status)
     }
 
     m_status = status;
-
-    // Error wires are drawn thicker (5 px) to draw attention to the problem;
-    // other wires are thinner (3 px) to reduce visual clutter during simulation.
-    // Unknown (undriven) wires use a distinct gray from Error (red).
-    switch (status) {
-    case Status::Unknown:  setPen(QPen(m_unknownColor,  3)); break;
-    case Status::Inactive: setPen(QPen(m_inactiveColor, 3)); break;
-    case Status::Active:   setPen(QPen(m_activeColor,   3)); break;
-    case Status::Error:    setPen(QPen(m_errorColor,    5)); break;
-    }
+    applyStatusPen();
 
     // Propagate to the destination port so its fill colour also reflects the signal state
     if (endPort()) {
@@ -298,14 +289,32 @@ void QNEConnection::setStatus(const Status status)
     }
 }
 
+void QNEConnection::applyStatusPen()
+{
+    // Error wires are drawn thicker (5 px) to draw attention to the problem;
+    // other wires are thinner (3 px) to reduce visual clutter during simulation.
+    // Unknown (undriven) wires use a distinct gray from Error (red).
+    switch (m_status) {
+    case Status::Unknown:  setPen(QPen(m_unknownColor,  3)); break;
+    case Status::Inactive: setPen(QPen(m_inactiveColor, 3)); break;
+    case Status::Active:   setPen(QPen(m_activeColor,   3)); break;
+    case Status::Error:    setPen(QPen(m_errorColor,    5)); break;
+    }
+}
+
 void QNEConnection::updateTheme()
 {
-    const ThemeAttributes theme = ThemeManager::attributes();
+    const auto &theme = ThemeManager::attributes();
     m_unknownColor = theme.m_connectionUnknown;
     m_inactiveColor = theme.m_connectionInactive;
     m_activeColor = theme.m_connectionActive;
     m_errorColor = theme.m_connectionError;
     m_selectedColor = theme.m_connectionSelected;
+
+    // Re-derive the pen from the refreshed palette; without this the wire keeps
+    // the previous theme's colour until its status next changes
+    applyStatusPen();
+
     update();
 }
 

--- a/App/Nodes/QNEConnection.h
+++ b/App/Nodes/QNEConnection.h
@@ -113,6 +113,9 @@ private:
     /// Detaches \a oldPort and attaches \a newPort to this connection (base-pointer version).
     void changePortAttachment(QNEPort *oldPort, QNEPort *newPort);
 
+    /// Sets the pen colour and width for the current status from the cached theme colours.
+    void applyStatusPen();
+
     // --- Members: Theme colors ---
 
     QColor m_activeColor;

--- a/App/Nodes/QNEPort.cpp
+++ b/App/Nodes/QNEPort.cpp
@@ -20,14 +20,17 @@ QNEPort::QNEPort(QGraphicsItem *parent)
     // which keeps connected wires redrawn when the parent element moves
     setFlag(QGraphicsItem::ItemSendsScenePositionChanges);
     setCacheMode(QGraphicsItem::DeviceCoordinateCache);
-    QPainterPath path;
+}
 
-    // Port hit-area / shape: a small square centred on the port's origin (±m_radius).
-    // m_radius = 5 px gives a 10×10 px clickable area which is large enough to hit
-    // reliably without obscuring nearby elements.  The same value is used for the
-    // visual diamond size so appearance and hit-testing stay in sync.
-    path.addPolygon(QRectF(QPointF(-m_radius, -m_radius), QPointF(m_radius, m_radius)));
-    setPath(path);
+QPainterPath QNEPort::shape() const
+{
+    // Hit-area: a small square centred on the port's origin (±m_radius), independent
+    // of the painted glyph.  m_radius = 5 px gives a 10×10 px clickable area which is
+    // large enough to hit reliably without obscuring nearby elements; the direction
+    // shapes (circle/triangle) would otherwise shrink the grab target.
+    QPainterPath path;
+    path.addRect(QRectF(QPointF(-m_radius, -m_radius), QPointF(m_radius, m_radius)));
+    return path;
 }
 
 const QList<QNEConnection *> &QNEPort::connections() const
@@ -246,6 +249,11 @@ void QNEPort::drainConnections(bool isInput)
 QNEInputPort::QNEInputPort(QGraphicsItem *parent)
     : QNEPort(parent)
 {
+    // Circle: neutral connection point — the signal terminates here
+    QPainterPath path;
+    path.addEllipse(QRectF(-m_radius, -m_radius, 2 * m_radius, 2 * m_radius));
+    setPath(path);
+
     // A fresh port is unconnected and required by default, so the validity rule
     // enforced by setStatus()/updateConnections() applies from birth: show Error
     // until a wire arrives or setRequired(false) relaxes the port. Without this,
@@ -300,6 +308,14 @@ bool QNEInputPort::isValid() const
 QNEOutputPort::QNEOutputPort(QGraphicsItem *parent)
     : QNEPort(parent)
 {
+    // Right-pointing triangle: tip toward the wire, indicating signal flows outward
+    QPainterPath path;
+    path.moveTo(-m_radius, -m_radius);
+    path.lineTo(+m_radius, 0);
+    path.lineTo(-m_radius, +m_radius);
+    path.closeSubpath();
+    setPath(path);
+
     // Apply the initial pen/brush directly: setStatus() would early-return here
     // because m_status already holds the Unknown default
     updateTheme();

--- a/App/Nodes/QNEPort.cpp
+++ b/App/Nodes/QNEPort.cpp
@@ -193,6 +193,34 @@ void QNEPort::hoverEnter()
     setBrush(QBrush(ThemeManager::attributes().m_portHoverPort));
 }
 
+void QNEPort::updateTheme()
+{
+    const auto &theme = ThemeManager::attributes();
+
+    switch (m_status) {
+    case Status::Unknown: {
+        setPen(theme.m_portUnknownPen);
+        setCurrentBrush(theme.m_portUnknownBrush);
+        break;
+    }
+    case Status::Inactive: {
+        setPen(theme.m_portInactivePen);
+        setCurrentBrush(theme.m_portInactiveBrush);
+        break;
+    }
+    case Status::Active: {
+        setPen(theme.m_portActivePen);
+        setCurrentBrush(theme.m_portActiveBrush);
+        break;
+    }
+    case Status::Error: {
+        setPen(theme.m_portErrorPen);
+        setCurrentBrush(theme.m_portErrorBrush);
+        break;
+    }
+    }
+}
+
 void QNEPort::drainConnections(bool isInput)
 {
     while (!m_connections.isEmpty()) {
@@ -227,7 +255,7 @@ QNEInputPort::QNEInputPort(QGraphicsItem *parent)
 
     // Style directly: setStatus() would early-return here because m_status
     // already holds its final construction-time value
-    QNEInputPort::updateTheme();
+    updateTheme();
 }
 
 QNEInputPort::~QNEInputPort()
@@ -269,38 +297,12 @@ bool QNEInputPort::isValid() const
     return m_connections.isEmpty() ? !isRequired() : (m_connections.size() == 1);
 }
 
-void QNEInputPort::updateTheme()
-{
-    const auto theme = ThemeManager::attributes();
-
-    switch (m_status) {
-    case Status::Unknown: {
-        setPen(theme.m_portUnknownPen);
-        setCurrentBrush(theme.m_portUnknownBrush);
-        break;
-    }
-    case Status::Inactive: {
-        setPen(theme.m_portInactivePen);
-        setCurrentBrush(theme.m_portInactiveBrush);
-        break;
-    }
-    case Status::Active: {
-        setPen(theme.m_portActivePen);
-        setCurrentBrush(theme.m_portActiveBrush);
-        break;
-    }
-    case Status::Error: {
-        setPen(theme.m_portErrorPen);
-        setCurrentBrush(theme.m_portErrorBrush);
-        break;
-    }
-    }
-}
-
 QNEOutputPort::QNEOutputPort(QGraphicsItem *parent)
     : QNEPort(parent)
 {
-    QNEOutputPort::updateTheme();
+    // Apply the initial pen/brush directly: setStatus() would early-return here
+    // because m_status already holds the Unknown default
+    updateTheme();
 }
 
 QNEOutputPort::~QNEOutputPort()
@@ -317,6 +319,7 @@ void QNEOutputPort::setStatus(const Status status)
     }
 
     m_status = status;
+    updateTheme();
 
     // Fan-out: broadcast the new signal status to every wire leaving this output port;
     // each wire in turn propagates it to the input port at its far end
@@ -340,11 +343,4 @@ bool QNEOutputPort::isValid() const
     // Output ports have unrestricted fan-out and no connectivity constraints;
     // their status is the simulation engine's responsibility, not a validity concern
     return true;
-}
-
-void QNEOutputPort::updateTheme()
-{
-    const auto theme = ThemeManager::attributes();
-    setPen(theme.m_portOutputPen);
-    setCurrentBrush(theme.m_portOutputBrush);
 }

--- a/App/Nodes/QNEPort.cpp
+++ b/App/Nodes/QNEPort.cpp
@@ -162,6 +162,10 @@ bool QNEPort::isRequired() const
 void QNEPort::setRequired(const bool required)
 {
     m_required = required;
+
+    // Requiredness feeds isValid(): re-derive the displayed status so a port
+    // marked optional recovers from Error and a newly required one shows it
+    updateConnections();
 }
 
 void QNEPort::setSerialId(quint64 serialId)
@@ -214,7 +218,16 @@ void QNEPort::drainConnections(bool isInput)
 QNEInputPort::QNEInputPort(QGraphicsItem *parent)
     : QNEPort(parent)
 {
-    QNEInputPort::setStatus(defaultValue());
+    // A fresh port is unconnected and required by default, so the validity rule
+    // enforced by setStatus()/updateConnections() applies from birth: show Error
+    // until a wire arrives or setRequired(false) relaxes the port. Without this,
+    // elements positioned before entering the scene (file load, scripted
+    // creation) never get a scene-position change to trigger the rule.
+    m_status = QNEInputPort::isValid() ? m_status : Status::Error;
+
+    // Style directly: setStatus() would early-return here because m_status
+    // already holds its final construction-time value
+    QNEInputPort::updateTheme();
 }
 
 QNEInputPort::~QNEInputPort()
@@ -236,6 +249,28 @@ void QNEInputPort::setStatus(const Status status)
     // Required-but-unconnected ports also become Error to make missing connections visible.
     m_status = QNEInputPort::isValid() ? status : Status::Error;
 
+    updateTheme();
+}
+
+bool QNEInputPort::isInput() const
+{
+    return true;
+}
+
+bool QNEInputPort::isOutput() const
+{
+    return false;
+}
+
+bool QNEInputPort::isValid() const
+{
+    // Valid states: unconnected and optional (default value is safe to use), OR
+    // exactly one connection (multi-driver wiring is not allowed in this simulation model)
+    return m_connections.isEmpty() ? !isRequired() : (m_connections.size() == 1);
+}
+
+void QNEInputPort::updateTheme()
+{
     const auto theme = ThemeManager::attributes();
 
     switch (m_status) {
@@ -260,27 +295,6 @@ void QNEInputPort::setStatus(const Status status)
         break;
     }
     }
-}
-
-bool QNEInputPort::isInput() const
-{
-    return true;
-}
-
-bool QNEInputPort::isOutput() const
-{
-    return false;
-}
-
-bool QNEInputPort::isValid() const
-{
-    // Valid states: unconnected and optional (default value is safe to use), OR
-    // exactly one connection (multi-driver wiring is not allowed in this simulation model)
-    return m_connections.isEmpty() ? !isRequired() : (m_connections.size() == 1);
-}
-
-void QNEInputPort::updateTheme()
-{
 }
 
 QNEOutputPort::QNEOutputPort(QGraphicsItem *parent)
@@ -323,9 +337,9 @@ bool QNEOutputPort::isOutput() const
 
 bool QNEOutputPort::isValid() const
 {
-    // An output port is valid as long as its driving logic element is valid;
-    // it has no connectivity constraints (fan-out is unrestricted)
-    return (m_status != Status::Unknown && m_status != Status::Error);
+    // Output ports have unrestricted fan-out and no connectivity constraints;
+    // their status is the simulation engine's responsibility, not a validity concern
+    return true;
 }
 
 void QNEOutputPort::updateTheme()

--- a/App/Nodes/QNEPort.h
+++ b/App/Nodes/QNEPort.h
@@ -103,6 +103,9 @@ public:
     /// Reverts hover-enter visual feedback.
     void hoverLeave();
 
+    /// Reapplies the status-based pen and brush from the current ThemeManager palette.
+    void updateTheme();
+
     /**
      * \brief Sets the brush used to fill the port shape.
      * \param currentBrush New brush.
@@ -150,9 +153,6 @@ protected:
 
     /// \reimp
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-
-    /// Refreshes port colours from the current ThemeManager palette. Pure virtual.
-    virtual void updateTheme() = 0;
 
     /**
      * \brief Drains all attached connections, breaking back-references before deletion.
@@ -207,11 +207,6 @@ public:
 
     /// \reimp
     void setStatus(const Status status) override;
-
-    // --- Theme ---
-
-    /// \reimp
-    void updateTheme() override;
 };
 
 Q_DECLARE_METATYPE(QNEInputPort)
@@ -244,11 +239,6 @@ public:
 
     /// \reimp
     void setStatus(const Status status) override;
-
-    // --- Theme ---
-
-    /// \reimp
-    void updateTheme() override;
 };
 
 Q_DECLARE_METATYPE(QNEOutputPort)

--- a/App/Nodes/QNEPort.h
+++ b/App/Nodes/QNEPort.h
@@ -23,9 +23,10 @@ class QNEPort;
  * \class QNEPort
  * \brief Abstract base class for circuit element ports (connection endpoints).
  *
- * \details A port is the small diamond/circle drawn at the edge of a graphic element
- * where wires attach.  It stores a reference to the owning GraphicElement,
- * all attached QNEConnections, and its current logical status.
+ * \details A port is the small glyph drawn at the edge of a graphic element where
+ * wires attach — a circle for inputs, a right-pointing triangle for outputs.
+ * It stores a reference to the owning GraphicElement, all attached
+ * QNEConnections, and its current logical status.
  *
  * Concrete subclasses QNEInputPort and QNEOutputPort differentiate direction.
  */
@@ -36,6 +37,9 @@ public:
 
     enum { Type = QGraphicsItem::UserType + 1 };
     int type() const override { return Type; }
+
+    /// \reimp Hit-testing uses the full ±m_radius square regardless of the painted glyph.
+    QPainterPath shape() const override;
 
     // --- Lifecycle ---
 

--- a/App/Nodes/QNEPort.h
+++ b/App/Nodes/QNEPort.h
@@ -169,7 +169,7 @@ protected:
     QList<QNEConnection *> m_connections; // use smart pointers
     QString m_name;
     Status m_defaultStatus = Status::Unknown;
-    Status m_status = Status::Inactive;
+    Status m_status = Status::Unknown;
     bool m_required = true;
     int m_index = 0;
     int m_radius = 5;

--- a/App/Scene/Commands.cpp
+++ b/App/Scene/Commands.cpp
@@ -541,8 +541,9 @@ SplitCommand::SplitCommand(QNEConnection *conn, QPointF mousePos, Scene *scene, 
 void SplitCommand::redo()
 {
     qCDebug(zero) << text();
-    // Allocating and rewiring QNEConnections while Simulation::m_connections
-    // is still mid-iterate on the old topology faults on the dangling entry.
+    // Block the 1 ms timer while connections and the split node are
+    // deleted/rewired: a tick observing the scene mid-mutation could read a
+    // momentarily detached port or a not-yet-fully-wired element.
     SimulationBlocker blocker(m_scene->simulation());
     auto *conn1 = CommandUtils::findConn(m_scene, m_c1Id);
     auto *elm1 = CommandUtils::findElm(m_scene, m_elm1Id);
@@ -887,7 +888,8 @@ void ChangePortSizeCommand::redo()
 {
     // drainPortConnections() deletes QNEConnections for removed ports; a
     // simulation tick between that delete and setCircuitUpdateRequired()
-    // would see those freed connections in Simulation::m_connections.
+    // could still read a freed port/connection via a live element's
+    // now-stale port list before the topology is rebuilt.
     SimulationBlocker blocker(m_scene->simulation());
 
     const auto elements = this->elements();

--- a/App/Simulation/Simulation.cpp
+++ b/App/Simulation/Simulation.cpp
@@ -157,10 +157,15 @@ void Simulation::update()
     }
     m_visualTickCount = 0;
 
-    // Phase 3: push computed logic values onto the wire (QNEOutputPort) visuals
-    for (auto *connection : std::as_const(m_connections)) {
-        if (connection) {
-            updatePort(connection->startPort());
+    // Phase 3: push computed logic values onto all output port visuals.
+    // Iterating elements (not connections) ensures unconnected output ports
+    // (e.g. -Q of a flip-flop with no wire attached) are also updated.
+    // setStatus() fans out through any attached connections automatically.
+    for (auto *element : std::as_const(m_sortedElements)) {
+        if (element) {
+            for (auto *outputPort : element->outputs()) {
+                updatePort(outputPort);
+            }
         }
     }
 
@@ -213,16 +218,14 @@ void Simulation::updatePort(QNEInputPort *port)
 void Simulation::restart()
 {
     // Invalidate the cached topology. Clearing the flag alone is not
-    // enough: update() iterates m_sortedElements/m_connections/m_clocks/
-    // m_inputs/m_outputs before a re-initialize can run (for instance when
-    // Application::notify() spins a QMessageBox nested event loop), and
-    // any entry that refers to an element we've already freed faults on
-    // its vtable read. Drop every reference so the next tick's
-    // initialize() can rebuild them cleanly.
+    // enough: update() iterates m_sortedElements/m_clocks/m_inputs/m_outputs
+    // before a re-initialize can run (for instance when Application::notify()
+    // spins a QMessageBox nested event loop), and any entry that refers to an
+    // element we've already freed faults on its vtable read. Drop every
+    // reference so the next tick's initialize() can rebuild them cleanly.
     m_initialized = false;
     m_sortedElements.clear();
     m_sequentialElements.clear();
-    m_connections.clear();
     m_clocks.clear();
     m_inputs.clear();
     m_outputs.clear();
@@ -230,7 +233,7 @@ void Simulation::restart()
     // cleared above. This assert documents the invariant for future maintainers
     // and trips immediately if a new vector is forgotten.
     Q_ASSERT(!m_initialized);
-    Q_ASSERT(m_sortedElements.isEmpty() && m_sequentialElements.isEmpty() && m_connections.isEmpty()
+    Q_ASSERT(m_sortedElements.isEmpty() && m_sequentialElements.isEmpty()
           && m_clocks.isEmpty() && m_inputs.isEmpty() && m_outputs.isEmpty());
 }
 
@@ -310,7 +313,6 @@ bool Simulation::initialize()
     m_clocks.clear();
     m_outputs.clear();
     m_inputs.clear();
-    m_connections.clear();
     m_sortedElements.clear();
     m_sequentialElements.clear();
 
@@ -345,13 +347,6 @@ bool Simulation::initialize()
     for (auto *item : std::as_const(items)) {
         if (!item) {
             continue;
-        }
-
-        if (item->type() == QNEConnection::Type) {
-            auto *connection = qgraphicsitem_cast<QNEConnection *>(item);
-            if (connection && connection->startPort() && connection->endPort()) {
-                m_connections.append(connection);
-            }
         }
 
         if (item->type() == GraphicElement::Type) {

--- a/App/Simulation/Simulation.h
+++ b/App/Simulation/Simulation.h
@@ -18,7 +18,6 @@
 class Clock;
 class GraphicElement;
 class GraphicElementInput;
-class QNEConnection;
 class QNEInputPort;
 class QNEOutputPort;
 class Scene;
@@ -158,7 +157,6 @@ private:
     QVector<Clock *> m_clocks;
     QVector<GraphicElement *> m_outputs;
     QVector<GraphicElementInput *> m_inputs;
-    QVector<QNEConnection *> m_connections;
 
     // --- Members: Scene & state ---
 

--- a/Tests/Integration/TestIc.cpp
+++ b/Tests/Integration/TestIc.cpp
@@ -542,9 +542,9 @@ void TestIC::testICNestedCircuitSignalPropagation()
 
     QVERIFY2(ic->outputSize() > 0, "IC should have output ports");
     auto *outputPort = ic->outputPort(0);
-    const Status initialStatus = outputPort->status();
-    QVERIFY2(initialStatus == Status::Active || initialStatus == Status::Inactive,
-             "Output port should be in valid state");
+    // Nothing drives the IC's outputs before the simulation runs, so the
+    // truthful initial state is Unknown (undriven), not a definite level
+    QCOMPARE(outputPort->status(), Status::Unknown);
 }
 
 // File Dependency Resolution Tests

--- a/Tests/Unit/Common/TestThemeManager.cpp
+++ b/Tests/Unit/Common/TestThemeManager.cpp
@@ -214,26 +214,16 @@ void TestThemeManager::testLightThemePortColors()
     QVERIFY(attrs.m_portUnknownBrush.isValid());
     QVERIFY(attrs.m_portInactiveBrush.isValid());
     QVERIFY(attrs.m_portActiveBrush.isValid());
-    QVERIFY(attrs.m_portOutputBrush.isValid());
     QVERIFY(attrs.m_portErrorBrush.isValid());
 
     QVERIFY(attrs.m_portUnknownPen.isValid());
     QVERIFY(attrs.m_portInactivePen.isValid());
     QVERIFY(attrs.m_portActivePen.isValid());
-    QVERIFY(attrs.m_portOutputPen.isValid());
     QVERIFY(attrs.m_portErrorPen.isValid());
 
     // Hover port should be yellow
     QVERIFY(attrs.m_portHoverPort.isValid());
     QCOMPARE(attrs.m_portHoverPort, QColor(Qt::yellow));
-
-    // Output brush should be pinkish (set unconditionally, applies to both themes)
-    // Note: m_portOutputBrush is set in ThemeManager unconditionally after the theme switch,
-    // so it has the same value in both Light and Dark themes
-    QVERIFY(attrs.m_portOutputBrush.red() > 200);      // Strong red component
-    QVERIFY(attrs.m_portOutputBrush.green() < 150);    // Lower green component
-    QVERIFY(attrs.m_portOutputBrush.blue() < 150);     // Lower blue component
-    QVERIFY(attrs.m_portOutputBrush.red() > attrs.m_portOutputBrush.green());  // More red than green
 }
 
 // ============================================================
@@ -316,24 +306,16 @@ void TestThemeManager::testDarkThemePortColors()
     QVERIFY(attrs.m_portUnknownBrush.isValid());
     QVERIFY(attrs.m_portInactiveBrush.isValid());
     QVERIFY(attrs.m_portActiveBrush.isValid());
-    QVERIFY(attrs.m_portOutputBrush.isValid());
     QVERIFY(attrs.m_portErrorBrush.isValid());
 
     QVERIFY(attrs.m_portUnknownPen.isValid());
     QVERIFY(attrs.m_portInactivePen.isValid());
     QVERIFY(attrs.m_portActivePen.isValid());
-    QVERIFY(attrs.m_portOutputPen.isValid());
     QVERIFY(attrs.m_portErrorPen.isValid());
 
     // Hover port should still be yellow
     QVERIFY(attrs.m_portHoverPort.isValid());
     QCOMPARE(attrs.m_portHoverPort, QColor(Qt::yellow));
-
-    // Output brush should be pinkish (reddish tone: high red, moderate green/blue)
-    QVERIFY(attrs.m_portOutputBrush.red() > 200);      // Strong red component
-    QVERIFY(attrs.m_portOutputBrush.green() < 150);    // Lower green component
-    QVERIFY(attrs.m_portOutputBrush.blue() < 150);     // Lower blue component
-    QVERIFY(attrs.m_portOutputBrush.red() > attrs.m_portOutputBrush.green());  // More red than green
 }
 
 // ============================================================

--- a/Tests/Unit/Scene/TestConnectionValidity.cpp
+++ b/Tests/Unit/Scene/TestConnectionValidity.cpp
@@ -23,24 +23,24 @@ void TestConnectionValidity::testConnectionStatusValid()
 {
     Scene scene;
 
-    // Create two AND gates
+    // A driven source and a consumer gate
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
     auto *and1 = ElementFactory::buildElement(ElementType::And);
-    auto *and2 = ElementFactory::buildElement(ElementType::And);
+    scene.addItem(vcc);
     scene.addItem(and1);
-    scene.addItem(and2);
 
     // Get their ports
-    auto *outPort1 = and1->outputPort(0);
-    auto *inPort2 = and2->inputPort(0);
+    auto *outPort = vcc->outputPort(0);
+    auto *inPort = and1->inputPort(0);
 
     // Create a connection
     auto *conn = new QNEConnection();
-    conn->setStartPort(outPort1);
-    conn->setEndPort(inPort2);
+    conn->setStartPort(outPort);
+    conn->setEndPort(inPort);
     scene.addItem(conn);
 
-    // Connection should have a valid status
-    QVERIFY2(conn->status() != Status::Unknown, "and1→and2 connection should be valid after both ports are set");
+    // Attaching both ports propagates the driver's definite level onto the wire
+    QCOMPARE(conn->status(), Status::Active);
 }
 
 void TestConnectionValidity::testConnectionStatusInvalid()
@@ -88,17 +88,17 @@ void TestConnectionValidity::testMultipleConnectionsStatus()
 {
     Scene scene;
 
-    // Create 3 AND gates
-    auto *and1 = ElementFactory::buildElement(ElementType::And);
+    // Create a driven chain: vcc -> and2 -> and3
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
     auto *and2 = ElementFactory::buildElement(ElementType::And);
     auto *and3 = ElementFactory::buildElement(ElementType::And);
-    scene.addItem(and1);
+    scene.addItem(vcc);
     scene.addItem(and2);
     scene.addItem(and3);
 
-    // Create connections: and1->and2->and3
+    // Create connections: vcc->and2->and3
     auto *conn1 = new QNEConnection();
-    conn1->setStartPort(and1->outputPort(0));
+    conn1->setStartPort(vcc->outputPort(0));
     conn1->setEndPort(and2->inputPort(0));
     scene.addItem(conn1);
 
@@ -107,9 +107,11 @@ void TestConnectionValidity::testMultipleConnectionsStatus()
     conn2->setEndPort(and3->inputPort(0));
     scene.addItem(conn2);
 
-    // Both connections should be valid
-    QVERIFY2(conn1->status() != Status::Unknown, "conn1 (and1→and2) should be valid");
-    QVERIFY2(conn2->status() != Status::Unknown, "conn2 (and2→and3) should be valid");
+    // The wire from the driven source carries its level; the wire from the
+    // gate stays Unknown because nothing computes and2's output until the
+    // simulation runs
+    QCOMPARE(conn1->status(), Status::Active);
+    QCOMPARE(conn2->status(), Status::Unknown);
 }
 
 void TestConnectionValidity::testPortValidityWithConnections()
@@ -160,56 +162,74 @@ void TestConnectionValidity::testInputPortWithMultipleConnections()
 {
     Scene scene;
 
-    // Create 3 AND gates
-    auto *and1 = ElementFactory::buildElement(ElementType::And);
-    auto *and2 = ElementFactory::buildElement(ElementType::And);
+    // Two driven sources feeding separate inputs of the same gate
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
+    auto *gnd = ElementFactory::buildElement(ElementType::InputGnd);
     auto *and3 = ElementFactory::buildElement(ElementType::And);
-    scene.addItem(and1);
-    scene.addItem(and2);
+    scene.addItem(vcc);
+    scene.addItem(gnd);
     scene.addItem(and3);
 
-    // Connect both and1 and and2 output to and3 input
+    // Connect vcc and gnd outputs to separate and3 inputs
     auto *conn1 = new QNEConnection();
-    conn1->setStartPort(and1->outputPort(0));
+    conn1->setStartPort(vcc->outputPort(0));
     conn1->setEndPort(and3->inputPort(0));
     scene.addItem(conn1);
 
     auto *conn2 = new QNEConnection();
-    conn2->setStartPort(and2->outputPort(0));
+    conn2->setStartPort(gnd->outputPort(0));
     conn2->setEndPort(and3->inputPort(1));
     scene.addItem(conn2);
 
-    // Both connections should be valid
-    QVERIFY2(conn1->status() != Status::Unknown, "conn1 (and1→and3 input 0) should be valid");
-    QVERIFY2(conn2->status() != Status::Unknown, "conn2 (and2→and3 input 1) should be valid");
+    // Each wire carries its own driver's level
+    QCOMPARE(conn1->status(), Status::Active);
+    QCOMPARE(conn2->status(), Status::Inactive);
 }
 
 void TestConnectionValidity::testOutputPortWithMultipleConnections()
 {
     Scene scene;
 
-    // Create 3 AND gates
-    auto *and1 = ElementFactory::buildElement(ElementType::And);
+    // One driven source fanning out to two gates
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
     auto *and2 = ElementFactory::buildElement(ElementType::And);
     auto *and3 = ElementFactory::buildElement(ElementType::And);
-    scene.addItem(and1);
+    scene.addItem(vcc);
     scene.addItem(and2);
     scene.addItem(and3);
 
-    // Connect and1 output to both and2 and and3 inputs
+    // Connect vcc output to both and2 and and3 inputs
     auto *conn1 = new QNEConnection();
-    conn1->setStartPort(and1->outputPort(0));
+    conn1->setStartPort(vcc->outputPort(0));
     conn1->setEndPort(and2->inputPort(0));
     scene.addItem(conn1);
 
     auto *conn2 = new QNEConnection();
-    conn2->setStartPort(and1->outputPort(0));
+    conn2->setStartPort(vcc->outputPort(0));
     conn2->setEndPort(and3->inputPort(0));
     scene.addItem(conn2);
 
-    // Both connections should be valid
-    QVERIFY2(conn1->status() != Status::Unknown, "conn1 (and1→and2 input 0) should be valid");
-    QVERIFY2(conn2->status() != Status::Unknown, "conn2 (and1→and3 input 0) should be valid");
+    // Fan-out: every wire leaving the output carries the same driven level
+    QCOMPARE(conn1->status(), Status::Active);
+    QCOMPARE(conn2->status(), Status::Active);
+}
+
+void TestConnectionValidity::testPortValidityStyleAtCreation()
+{
+    // Required-but-unconnected inputs must show Error from birth — before any
+    // scene interaction runs updateConnections() — so missing connections are
+    // visible in freshly created and freshly loaded circuits (both position
+    // elements before they enter the scene).
+    auto andGate = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::And));
+    QCOMPARE(andGate->inputPort(0)->status(), Status::Error);
+    QCOMPARE(andGate->inputPort(1)->status(), Status::Error);
+
+    // Ports marked optional after construction recover from the Error override:
+    // no configured default reads as undriven, an explicit default as its level.
+    auto sr = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::SRFlipFlop));
+    QCOMPARE(sr->inputPort(0)->status(), Status::Unknown); // S: optional, no default
+    QCOMPARE(sr->inputPort(1)->status(), Status::Error);   // Clock: required
+    QCOMPARE(sr->inputPort(3)->status(), Status::Active);  // ~Preset: optional, defaults HIGH
 }
 
 void TestConnectionValidity::testIsConnectionAllowedRejectsRxPort()

--- a/Tests/Unit/Scene/TestConnectionValidity.h
+++ b/Tests/Unit/Scene/TestConnectionValidity.h
@@ -23,6 +23,9 @@ private slots:
     void testInputPortWithMultipleConnections();
     void testOutputPortWithMultipleConnections();
 
+    // Construction-time validity styling
+    void testPortValidityStyleAtCreation();
+
     // Wireless connection guard (5 tests)
     void testIsConnectionAllowedRejectsRxPort();
     void testIsConnectionAllowedRejectsTxOutputPort();

--- a/Tests/Unit/Scene/TestSceneConnections.cpp
+++ b/Tests/Unit/Scene/TestSceneConnections.cpp
@@ -289,9 +289,9 @@ void TestSceneConnections::testConnectionStatusTracking()
     // Create a scene
     Scene scene;
 
-    // Create gates
-    auto *gate1 = ElementFactory::buildElement(ElementType::And);
-    scene.addItem(gate1);
+    // Create a driven source and a consumer gate
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
+    scene.addItem(vcc);
 
     auto *gate2 = ElementFactory::buildElement(ElementType::Or);
     gate2->setPos(150, 0);
@@ -299,13 +299,13 @@ void TestSceneConnections::testConnectionStatusTracking()
 
     // Create connection
     auto *connection = new QNEConnection(nullptr);
-    connection->setStartPort(gate1->outputPort(0));
+    connection->setStartPort(vcc->outputPort(0));
     connection->setEndPort(gate2->inputPort(0));
     scene.addItem(connection);
 
-    // Initial status should be inactive or active
+    // The wire tracks its driver's status from the moment it is attached
     Status status = connection->status();
-    QCOMPARE(status, Status::Inactive);
+    QCOMPARE(status, Status::Active);
 }
 
 void TestSceneConnections::testConnectionRemovalUpdatesCounters()

--- a/Tests/Unit/Simulation/TestDanglingPointer.cpp
+++ b/Tests/Unit/Simulation/TestDanglingPointer.cpp
@@ -311,15 +311,21 @@ void TestDanglingPointer::hardening_deleteEditedConnectionMustUseSimulationBlock
     QVERIFY2(body.contains("SimulationBlocker"),
              "ConnectionManager::deleteEditedConnection must open a "
              "SimulationBlocker around the removeItem/delete pair so the "
-             "1 ms simulation timer cannot tick on a freed connection if "
-             "the in-progress wire ever ended up in Simulation::m_connections.");
+             "1 ms simulation timer cannot tick while the in-progress wire "
+             "is being torn down.");
 }
 
-// WIREDPANDA-JD — Simulation::initialize() must exclude in-progress wires
-// (connections with only one port set). Without this filter, a re-initialize
-// while a wire is being drawn adds the in-progress wire to m_connections.
-// A subsequent cancel (deleteEditedConnection) frees it without rebuilding,
-// leaving a dangling pointer that crashes on the next simulation tick.
+// WIREDPANDA-JD — historical: Simulation::initialize() used to collect every
+// QNEConnection unconditionally into Simulation::m_connections, including
+// in-progress wires (only startPort set). A subsequent cancel
+// (deleteEditedConnection) freed the wire without rebuilding, leaving a
+// dangling pointer that the old Phase 3 loop dereferenced on the next tick.
+// Simulation::m_connections was removed entirely once Phase 3 stopped
+// reading it (it now walks m_sortedElements), structurally eliminating the
+// dangling-pointer class rather than filtering it. This regression-tests
+// the resulting behavior: an in-progress wire coexisting with a real
+// connection during a re-initialize must not corrupt or crash the
+// simulation, and the real connection must keep propagating correctly.
 void TestDanglingPointer::jd_initializeMustSkipIncompleteConnections()
 {
     WorkSpace ws;
@@ -338,8 +344,6 @@ void TestDanglingPointer::jd_initializeMustSkipIncompleteConnections()
 
     sim->initialize();
     QVERIFY(sim->m_initialized);
-    QCOMPARE(sim->m_connections.size(), 1);
-    QCOMPARE(sim->m_connections.first(), conn);
 
     // Simulate ConnectionManager::startFromOutput: create an in-progress wire
     // with only startPort set (no endPort — the user is still dragging it).
@@ -350,21 +354,21 @@ void TestDanglingPointer::jd_initializeMustSkipIncompleteConnections()
     // Re-initialize (simulates any command that calls setCircuitUpdateRequired
     // while the user is drawing a wire — e.g. undo/redo, IC hot-reload).
     sim->initialize();
+    QVERIFY(sim->m_initialized);
 
-    // The in-progress wire must NOT appear in m_connections. Pre-fix,
-    // initialize() adds all QNEConnections unconditionally, so this
-    // assertion fails: m_connections.size() == 2.
-    QVERIFY2(sim->m_connections.size() == 1,
-             qPrintable(QString("initialize() picked up an in-progress wire "
-                                "(no endPort) into m_connections: expected 1, "
-                                "got %1")
-                            .arg(sim->m_connections.size())));
+    sw->setOn(true);
+    sim->update();
+    QVERIFY(TestUtils::getInputStatus(led));
 
-    QVERIFY(!sim->m_connections.contains(inProgressWire));
-
-    // Clean up the in-progress wire
+    // Cancel the in-progress wire (mirrors ConnectionManager::deleteEditedConnection)
+    // and tick again — nothing in Simulation held onto the freed wire, so this
+    // must not crash, and the real connection must still function.
     scene->removeItem(inProgressWire);
     delete inProgressWire;
+
+    sw->setOn(false);
+    sim->update();
+    QVERIFY(!TestUtils::getInputStatus(led));
 }
 
 // ==========================================================================
@@ -382,11 +386,10 @@ void TestDanglingPointer::bug8_iterativeSettleMustTolerateNullEntry()
     QVERIFY(true);
 }
 
-// Hardening — Simulation::update() Phase 3 walks m_connections and reads
-// connection->startPort() with no null guard, unlike Phases 1, 2, and 4.
-// Inject a null and tick the simulation; without the guard this dereferences
-// nullptr and SIGSEGVs.
-void TestDanglingPointer::hardening_phase3MustTolerateNullConnection()
+// Hardening — Simulation::update() Phase 3 walks m_sortedElements and reads
+// each element's output ports; a null entry must not crash. Inject a null
+// and tick the simulation to verify the existing `if (element)` guard holds.
+void TestDanglingPointer::hardening_phase3MustTolerateNullElement()
 {
     WorkSpace ws;
     auto *sim = ws.scene()->simulation();
@@ -395,11 +398,11 @@ void TestDanglingPointer::hardening_phase3MustTolerateNullConnection()
     QVERIFY(sim->m_initialized);
 
     // Phase 3 only runs when the visual throttle lets through; force-disable
-    // so update() actually walks m_connections this tick instead of skipping
-    // straight back to Phase 2.
+    // so update() actually walks m_sortedElements this tick instead of
+    // skipping straight back to Phase 2.
     sim->setVisualThrottleEnabled(false);
 
-    sim->m_connections.append(nullptr);
+    sim->m_sortedElements.append(nullptr);
 
     sim->update();
     QVERIFY(true);
@@ -499,11 +502,16 @@ void TestDanglingPointer::integration_simulationTickAfterResetMustNotCrash()
     QVERIFY(true);
 }
 
-// WIREDPANDA-JD — full crash reproduction. An in-progress wire (startPort
-// only, no endPort) is added to the scene. A re-initialize picks it up
-// into Simulation::m_connections. The wire is then deleted (simulating
-// cancel/deleteEditedConnection), leaving a dangling pointer.  The next
-// update() dereferences the freed memory — SIGSEGV pre-fix.
+// WIREDPANDA-JD — historical crash reproduction, kept as defense in depth.
+// An in-progress wire (startPort only, no endPort) is added to the scene, a
+// re-initialize runs while it's present, and the wire is then deleted
+// (simulating cancel/deleteEditedConnection). The next update() must not
+// crash. Originally this SIGSEGVed because Simulation::m_connections
+// unconditionally collected every QNEConnection — including the in-progress
+// one — and the delete above left that entry dangling for the next Phase 3
+// pass to dereference. m_connections no longer exists (Phase 3 walks
+// m_sortedElements instead), so Simulation has no reference left to dangle;
+// this test guards against any future code path reintroducing one.
 void TestDanglingPointer::jd_cancelledWireMustNotLeaveDanglingPointer()
 {
     WorkSpace ws;
@@ -529,16 +537,14 @@ void TestDanglingPointer::jd_cancelledWireMustNotLeaveDanglingPointer()
     inProgressWire->setStartPort(sw->outputPort());
     scene->addItem(inProgressWire);
 
-    // Re-initialize — picks up the in-progress wire into m_connections.
+    // Re-initialize while the in-progress wire is present.
     sim->initialize();
 
     // Delete the in-progress wire (mirrors deleteEditedConnection's bare delete).
     scene->removeItem(inProgressWire);
     delete inProgressWire;
 
-    // Pre-fix: m_connections now holds a dangling pointer to freed memory.
-    // The next update() iterates m_connections, reads connection->startPort()
-    // from the freed object, and crashes with EXCEPTION_ACCESS_VIOLATION_READ.
+    // Must not crash.
     sim->update();
     QVERIFY(true);
 }

--- a/Tests/Unit/Simulation/TestDanglingPointer.h
+++ b/Tests/Unit/Simulation/TestDanglingPointer.h
@@ -53,17 +53,22 @@ private slots:
     void bug6_topologyCommandsMustUseSimulationBlocker();
 
     /// Hardening — ConnectionManager::deleteEditedConnection performs a
-    /// bare delete on the in-progress wire. If a re-initialize has run
-    /// while the wire is on the scene, that pointer ends up in
-    /// Simulation::m_connections and the bare delete leaves it dangling.
-    /// Source-level check, same shape as bug6.
+    /// bare delete on the in-progress wire while the 1 ms simulation timer
+    /// may still be running. A SimulationBlocker scope prevents a tick
+    /// from touching scene state mid-removal. Source-level check, same
+    /// shape as bug6.
     void hardening_deleteEditedConnectionMustUseSimulationBlocker();
 
-    /// WIREDPANDA-JD — Simulation::initialize() must skip in-progress
-    /// wires (connections without both startPort and endPort). Without
-    /// this filter, a re-initialize while a wire is being drawn adds
-    /// it to m_connections; a subsequent cancel/delete leaves a dangling
-    /// pointer that crashes on the next simulation tick.
+    /// WIREDPANDA-JD — historical: Simulation::initialize() used to collect
+    /// every QNEConnection unconditionally into Simulation::m_connections,
+    /// including in-progress wires (only startPort set). A subsequent
+    /// cancel/delete of that wire left a dangling pointer that the old
+    /// Phase 3 loop dereferenced on the next tick. Simulation::m_connections
+    /// was removed entirely once Phase 3 stopped reading it (it now walks
+    /// m_sortedElements), structurally eliminating the dangling-pointer
+    /// class rather than filtering it. This regression-tests the resulting
+    /// behavior: an in-progress wire coexisting with a real connection
+    /// during a re-initialize must not corrupt or crash the simulation.
     void jd_initializeMustSkipIncompleteConnections();
 
     // --- Crash-triggering tests (process dies pre-fix) ---------------
@@ -71,10 +76,10 @@ private slots:
     /// Bug 8 — iterativeSettle() iterates without null checks.
     void bug8_iterativeSettleMustTolerateNullEntry();
 
-    /// Hardening — Simulation::update() Phase 3 dereferences m_connections
-    /// entries without a null guard, unlike the four other phases. Inject
-    /// a null and call update() to verify the new guard.
-    void hardening_phase3MustTolerateNullConnection();
+    /// Hardening — Simulation::update() Phase 3 now walks m_sortedElements
+    /// (rewritten to cover unconnected output ports too). Inject a null
+    /// entry and call update() to verify the existing guard tolerates it.
+    void hardening_phase3MustTolerateNullElement();
 
     /// Bug 2 — IC::updateLogic() dereferences m_sortedInternalElements
     /// entries without a null guard.
@@ -99,9 +104,13 @@ private slots:
     /// FH/EW/G1/GP/HC paint-time _purecall family.
     void hcDrainConnectionsMustCleanRegistry();
 
-    /// WIREDPANDA-JD — full crash reproduction. An in-progress wire
-    /// (startPort only) enters m_connections via initialize(), is then
-    /// deleted without rebuilding the simulation, and the next update()
-    /// dereferences the dangling pointer.
+    /// WIREDPANDA-JD — historical crash reproduction, kept as defense in
+    /// depth. An in-progress wire (startPort only) survives a re-initialize
+    /// and is then deleted without rebuilding the simulation; the next
+    /// update() must not crash. Originally caused by Simulation::m_connections
+    /// holding a dangling pointer to the freed wire — that member no longer
+    /// exists (Phase 3 walks m_sortedElements instead), but this behavior-level
+    /// check remains valid against any future code path that might reintroduce
+    /// a similar dangling reference.
     void jd_cancelledWireMustNotLeaveDanglingPointer();
 };

--- a/Tests/Unit/Simulation/TestSimulation.cpp
+++ b/Tests/Unit/Simulation/TestSimulation.cpp
@@ -3,7 +3,11 @@
 
 #include "Tests/Unit/Simulation/TestSimulation.h"
 
+#include "App/Element/ElementFactory.h"
+#include "App/Element/GraphicElement.h"
 #include "App/Element/GraphicElements/Clock.h"
+#include "App/Nodes/QNEConnection.h"
+#include "App/Nodes/QNEPort.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "Tests/Common/TestUtils.h"
@@ -95,4 +99,33 @@ void TestSimulationUnit::testSimulationStartStopNoBreadcrumbsB22()
     QVERIFY2(!startBody.contains("sentryBreadcrumb"),
              "Simulation::start must not emit a Sentry breadcrumb — every "
              "SimulationBlocker scope hits this and floods the buffer.");
+}
+
+void TestSimulationUnit::testUnconnectedOutputPortVisualUpdates()
+{
+    // Regression: Phase 3 must push computed values onto output-port visuals
+    // even when no wire is attached. A connection-based walk skips them, so a
+    // flip-flop's unwired -Q (or any unwired gate output) keeps a stale color.
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+
+    auto *vcc = ElementFactory::buildElement(ElementType::InputVcc);
+    auto *notGate = ElementFactory::buildElement(ElementType::Not);
+    scene->addItem(vcc);
+    scene->addItem(notGate);
+
+    auto *conn = new QNEConnection();
+    conn->setStartPort(vcc->outputPort(0));
+    conn->setEndPort(notGate->inputPort(0));
+    scene->addItem(conn);
+
+    // The NOT output stays unwired: undriven (Unknown) until a tick computes it
+    QCOMPARE(notGate->outputPort(0)->status(), Status::Unknown);
+
+    Simulation sim(scene);
+    sim.update();
+
+    // NOT(1) = 0 — and the unwired output port's visual must reflect it
+    QCOMPARE(notGate->outputPort(0)->status(), Status::Inactive);
+    QCOMPARE(notGate->outputPort(0)->status(), notGate->outputValue(0));
 }

--- a/Tests/Unit/Simulation/TestSimulation.h
+++ b/Tests/Unit/Simulation/TestSimulation.h
@@ -19,4 +19,7 @@ private slots:
 
     // Regression: B22 — Simulation::start/stop must not emit Sentry breadcrumbs
     void testSimulationStartStopNoBreadcrumbsB22();
+
+    // Regression: Phase 3 must refresh output-port visuals even with no wire attached
+    void testUnconnectedOutputPortVisualUpdates();
 };


### PR DESCRIPTION
## Summary

Ports now visually distinguish four logic states — Unknown (undriven), Inactive, Active, Error — instead of silently defaulting to Inactive before the simulation runs. Recreated from a stale exploratory branch (`4-state`) by re-implementing each commit's intent fresh on top of current `master`, then hardened through five rounds of deep review (diff/hotspot analysis, ASan, UBSan, TSan, release-build test runs, and adversarial regression proofs).

- **Truthful undriven state** — an unconnected port reports `Status::Unknown` (gray) instead of pretending to be `Inactive`, both at construction and for elements positioned before entering the scene (file load, scripted/MCP creation). Required-but-unconnected inputs show `Error` (red) from birth, not just after the first interaction.
- **Unified status colors** — output ports now use the same status-driven pen/brush as input ports (gray/black/red outlines, wire-matching fills), replacing the old fixed rose-pink/darkRed styling that made unconnected elements read as all-red.
- **Port shapes** — input ports are circles, output ports are right-pointing triangles, so direction is readable at a glance; hit-testing stays a full 10×10 px square regardless of the painted glyph.
- **Phase 3 fix** — the simulation's visual-update pass now walks every element's output ports (not just wired connections), so unconnected outputs (e.g. an unwired flip-flop `-Q`) update their color during simulation instead of staying frozen at their initial value.
- **Wire theme fix** — wires now reapply their status pen when the theme changes, matching port behavior (previously they kept the old theme's color until their status next changed).

## Commits

1. `fix: default port status to Unknown and fix updateTheme for input ports`
2. `fix: make port colors uniformly reflect signal status`
3. `feat: distinguish input/output ports by shape`
4. `fix: update unconnected output ports in simulation Phase 3`
5. `fix: reapply wire status pen when the theme changes`

## Test plan

- [x] `ctest --preset debug` — full suite, 176/176 passing
- [x] `ctest --preset release` (`-Werror`) — full suite passing
- [x] ASan + UBSan passes on all branch-touched test classes — clean
- [x] TSan pass — no assertion failures; the only flagged race is pre-existing and unrelated to this branch (`ElementAppearance::setPixmap`'s async SVG loading)
- [x] Adversarial regression proof: reintroduced the historical dangling-pointer bug shape and confirmed the regression test catches it under ASan (`heap-use-after-free` in `QNEConnection::startPort()`), then reverted
- [x] MCP-driven visual verification: port/wire colors correct pre- and post-simulation, both themes, real example circuits (`counter`, `display-4bits-counter`, `sequential`, `mux_demux`), rotate/flip transforms, save/load round-trip, SystemVerilog/Arduino export (no unknown literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)