### PR TITLE
fix(fuzz): resolve -Wsign-conversion errors breaking the fuzzer build

### DIFF
--- a/Tests/Fuzz/FuzzOldFormat.cpp
+++ b/Tests/Fuzz/FuzzOldFormat.cpp
@@ -297,8 +297,8 @@ QByteArray buildOldPanda(FuzzedDataProvider &fdp)
         s << static_cast<int>(65538); // QNEConnection::Type = UserType + 2
         const bool useValid = fdp.ConsumeBool() && !outPtrs.isEmpty() && !inPtrs.isEmpty();
         if (useValid) {
-            s << outPtrs[fdp.ConsumeIntegralInRange<size_t>(0, static_cast<size_t>(outPtrs.size()) - 1)];
-            s << inPtrs[fdp.ConsumeIntegralInRange<size_t>(0, static_cast<size_t>(inPtrs.size()) - 1)];
+            s << outPtrs[fdp.ConsumeIntegralInRange<qsizetype>(0, outPtrs.size() - 1)];
+            s << inPtrs[fdp.ConsumeIntegralInRange<qsizetype>(0, inPtrs.size() - 1)];
         } else {
             s << fdp.ConsumeIntegral<quint64>();
             s << fdp.ConsumeIntegral<quint64>();

--- a/Tests/Fuzz/FuzzStructured.cpp
+++ b/Tests/Fuzz/FuzzStructured.cpp
@@ -390,10 +390,10 @@ QByteArray buildPanda(FuzzedDataProvider &fdp)
                                  && !outputIds.isEmpty() && !inputIds.isEmpty();
         quint64 startId, endId;
         if (useValidIds) {
-            startId = outputIds[fdp.ConsumeIntegralInRange<size_t>(
-                0, static_cast<size_t>(outputIds.size()) - 1)];
-            endId = inputIds[fdp.ConsumeIntegralInRange<size_t>(
-                0, static_cast<size_t>(inputIds.size()) - 1)];
+            startId = outputIds[fdp.ConsumeIntegralInRange<qsizetype>(
+                0, outputIds.size() - 1)];
+            endId = inputIds[fdp.ConsumeIntegralInRange<qsizetype>(
+                0, inputIds.size() - 1)];
         } else {
             startId = fdp.ConsumeIntegral<quint64>();
             endId   = fdp.ConsumeIntegral<quint64>();


### PR DESCRIPTION
## Summary

The `fuzzer` preset (`cmake --preset fuzzer && cmake --build --preset fuzzer`) fails to compile `fuzz_old_format` and `fuzz_structured` under `-Werror -Wsign-conversion`. Both harnesses index a `QList<quint64>` with a `FuzzedDataProvider::ConsumeIntegralInRange<size_t>` result; `QList::operator[]` takes `qsizetype` (signed), and the implicit narrowing at the subscript trips the warning.

Fix: call `ConsumeIntegralInRange<qsizetype>` directly instead of `<size_t>` + a `static_cast<size_t>` round-trip on `.size()`, so the consumed range and the index type match `QList`'s own `qsizetype` with no conversion needed.

Discovered as a pre-existing, branch-unrelated issue while sweeping `4-state-v2` (#434) — both files were last touched by `07edfa0df`, well before that branch existed.

## Test plan

- [x] `cmake --preset fuzzer && cmake --build --preset fuzzer` — all 102 targets build clean, zero errors (was previously failing on `fuzz_old_format`/`fuzz_structured`)
- [x] `cmake --build --preset debug` — unaffected, builds clean
- [x] Confirmed no other `ConsumeIntegralInRange<size_t>` call site in `Tests/Fuzz/` has the same issue — the rest index `size_t`-native C arrays or feed `size_t`-native APIs (`ConsumeBytesAsString`), where no signed/unsigned mismatch exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)