### PR TITLE
ci(codeql): disable Unity/PCH for the C++ scan to fix 112 false-positive alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,7 +85,13 @@ jobs:
     - name: Build
       if: matrix.language == 'cpp'
       run: |
-        cmake --preset release
+        # Unity builds batch multiple .cpp files into generated wrapper translation
+        # units via #include — CodeQL traces whatever the build actually compiles, so
+        # without this it extracts facts from those generated wrappers instead of the
+        # real source files, firing cpp/include-non-header false positives on every
+        # batch (paths-ignore does not apply to files compiled under build-mode:
+        # manual). Build each source file as its own translation unit instead.
+        cmake --preset release -DENABLE_UNITY=OFF -DENABLE_PCH=OFF
         cmake --build --preset release
 
     - name: Perform CodeQL Analysis
@@ -144,7 +150,9 @@ jobs:
 
     - name: Build
       run: |
-        cmake --preset release
+        # See the analyze job's Build step: Unity/PCH must stay off so CodeQL traces
+        # the real source files instead of generated Unity-batch wrapper files.
+        cmake --preset release -DENABLE_UNITY=OFF -DENABLE_PCH=OFF
         cmake --build --preset release
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary

- The CodeQL C++ analysis (`build-mode: manual`) traces whatever the build actually compiles. The release preset enables Unity builds by default, which batch multiple `.cpp` files into generated wrapper translation units via `#include`. CodeQL was extracting facts from those wrapper files instead of the real source, firing `cpp/include-non-header` on every batch.
- The existing `paths-ignore: build-*/**` in `.github/codeql/codeql-config-cpp.yml` (added 2026-05-15) does **not** suppress this — confirmed by checking that the config predates, by nearly two months, the most recent scan (against master's current HEAD) that still reports all 112 of these alerts. This matches GitHub's documented limitation: `paths`/`paths-ignore` don't apply to files actually compiled under `build-mode: manual`.
- Fix: build each C++ file as its own translation unit (`-DENABLE_UNITY=OFF -DENABLE_PCH=OFF`) for both the scheduled `analyze` job and the `experimental` job, so CodeQL extracts from real source files instead of generated wrappers.

Verified master builds clean (0 failures) under this exact config before pushing.

## Test plan

- [x] Local `cmake --preset release -DENABLE_UNITY=OFF -DENABLE_PCH=OFF && cmake --build --preset release -- -k 0` on master — 0 failures, 369/369 targets built.
- [ ] Next scheduled/PR CodeQL run should show the 112 `cpp/include-non-header` alerts drop off (existing open alerts on other branches will auto-close once analysis re-runs clean on their heads; this PR only changes the workflow).