### PR TITLE
Add circuit Exercises and guided UI Tours

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -9,6 +9,7 @@ on:
       - 'App/**/*.h'
       - 'App/**/*.ui'
       - 'App/Resources/Exercises/**/*.json'
+      - 'App/Resources/Tours/**/*.json'
       - 'CMakeLists.txt'
 
   # Trigger on translation file changes (typically from Weblate)
@@ -18,6 +19,7 @@ on:
       - 'App/Resources/Translations/*.ts'
       - 'App/Resources/Translations/ExerciseTour/*.json'
       - 'App/Resources/Exercises/**/*.json'
+      - 'App/Resources/Tours/**/*.json'
     types: [opened, synchronize, reopened]
 
   # Manual trigger

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -8,6 +8,7 @@ on:
       - 'App/**/*.cpp'
       - 'App/**/*.h'
       - 'App/**/*.ui'
+      - 'App/Resources/Exercises/**/*.json'
       - 'CMakeLists.txt'
 
   # Trigger on translation file changes (typically from Weblate)
@@ -15,6 +16,8 @@ on:
     branches: [master]
     paths:
       - 'App/Resources/Translations/*.ts'
+      - 'App/Resources/Translations/ExerciseTour/*.json'
+      - 'App/Resources/Exercises/**/*.json'
     types: [opened, synchronize, reopened]
 
   # Manual trigger
@@ -121,6 +124,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-utils
+
+      - name: Verify Exercise/Tour content translation catalog is up to date
+        run: python3 Scripts/generate_exercise_tour_catalog.py --check
 
       - name: Validate translation files
         run: |
@@ -242,6 +248,19 @@ jobs:
             if ! lrelease "$ts_file" -qm "/tmp/qm-check/$lang.qm" 2>&1; then
               echo "❌ lrelease failed for $ts_file"
               exit 1
+            fi
+          done
+
+      - name: Validate Exercise/Tour content catalog JSON
+        run: |
+          echo "Checking Weblate-submitted Exercise/Tour catalog files..."
+          for json_file in App/Resources/Translations/ExerciseTour/*.json; do
+            if [[ -f "$json_file" ]]; then
+              if ! python3 -c "import json, sys; json.load(open(sys.argv[1], encoding='utf-8'))" "$json_file"; then
+                echo "❌ Invalid JSON in $json_file"
+                exit 1
+              fi
+              echo "✅ $json_file is valid"
             fi
           done
 

--- a/App/BeWavedDolphin/BeWavedDolphin.cpp
+++ b/App/BeWavedDolphin/BeWavedDolphin.cpp
@@ -32,6 +32,7 @@
 #include "App/Core/Settings.h"
 #include "App/Element/GraphicElement.h"
 #include "App/Element/GraphicElementInput.h"
+#include "App/Exercise/ExerciseOverlay.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/UI/ClockDialog.h"
 #include "App/UI/FileDialogProvider.h"
@@ -300,6 +301,19 @@ void BewavedDolphin::on_actionExit_triggered()
 void BewavedDolphin::closeEvent(QCloseEvent *event)
 {
     (m_askConnection && checkSave()) ? event->accept() : event->ignore();
+}
+
+void BewavedDolphin::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    if (m_exerciseOverlay && m_exerciseOverlay->isVisible()) {
+        m_exerciseOverlay->repositionToParent();
+    }
+}
+
+void BewavedDolphin::setExerciseOverlay(ExerciseOverlay *overlay)
+{
+    m_exerciseOverlay = overlay;
 }
 
 bool BewavedDolphin::checkSave()

--- a/App/BeWavedDolphin/BeWavedDolphin.cpp
+++ b/App/BeWavedDolphin/BeWavedDolphin.cpp
@@ -316,6 +316,21 @@ void BewavedDolphin::setExerciseOverlay(ExerciseOverlay *overlay)
     m_exerciseOverlay = overlay;
 }
 
+QToolBar *BewavedDolphin::mainToolBar() const
+{
+    return m_ui->mainToolBar;
+}
+
+QAction *BewavedDolphin::actionCombinational() const
+{
+    return m_ui->actionCombinational;
+}
+
+void BewavedDolphin::triggerCombinational()
+{
+    on_actionCombinational_triggered();
+}
+
 bool BewavedDolphin::checkSave()
 {
     if (!m_edited) {

--- a/App/BeWavedDolphin/BeWavedDolphin.h
+++ b/App/BeWavedDolphin/BeWavedDolphin.h
@@ -22,6 +22,7 @@
 
 class DolphinHost;
 class DolphinZoom;
+class ExerciseOverlay;
 class WaveformSimulator;
 
 namespace DolphinSerializer { struct WaveformData; }
@@ -125,11 +126,19 @@ public:
     /// Returns the input row index whose element label equals \a label, or -1 (MCP access).
     int inputRow(const QString &label) const;
 
+    // --- Exercise overlay support ---
+
+    /// Registers \a overlay so it is repositioned whenever the window is resized.
+    /// Pass \c nullptr to detach. Does not take ownership.
+    void setExerciseOverlay(ExerciseOverlay *overlay);
+
 protected:
     // --- Qt event overrides ---
 
     /// \reimp
     void closeEvent(QCloseEvent *event) override;
+    /// \reimp
+    void resizeEvent(QResizeEvent *event) override;
     /// \reimp Intercepts the mouse wheel on the table viewport to zoom the columns.
     bool eventFilter(QObject *watched, QEvent *event) override;
 
@@ -222,4 +231,5 @@ private:
     int m_clockPeriod              = 0;               ///< Period used by "Set Clock Wave" (0 = auto).
     int m_inputPorts               = 0;               ///< Number of input ports in the circuit.
     int m_length                   = 32;              ///< Number of simulation time-step columns.
+    ExerciseOverlay *m_exerciseOverlay = nullptr;     ///< Non-owning; repositioned on resize.
 };

--- a/App/BeWavedDolphin/BeWavedDolphin.h
+++ b/App/BeWavedDolphin/BeWavedDolphin.h
@@ -126,11 +126,20 @@ public:
     /// Returns the input row index whose element label equals \a label, or -1 (MCP access).
     int inputRow(const QString &label) const;
 
-    // --- Exercise overlay support ---
+    // --- Tour / Exercise overlay support ---
 
     /// Registers \a overlay so it is repositioned whenever the window is resized.
     /// Pass \c nullptr to detach. Does not take ownership.
     void setExerciseOverlay(ExerciseOverlay *overlay);
+
+    /// Returns the waveform table view (for tour target resolution).
+    QTableView *signalTableView() const { return m_signalTableView; }
+    /// Returns the main toolbar (for tour target resolution).
+    QToolBar   *mainToolBar()        const;
+    /// Returns the combinational action (for tour button spotlighting).
+    QAction    *actionCombinational() const;
+    /// Triggers the combinational input-pattern generator (for tour automation).
+    void triggerCombinational();
 
 protected:
     // --- Qt event overrides ---

--- a/App/Core/ExerciseTourResources.cpp
+++ b/App/Core/ExerciseTourResources.cpp
@@ -1,0 +1,208 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Core/ExerciseTourResources.h"
+
+#include <algorithm>
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QStandardPaths>
+
+#include "App/Core/Settings.h"
+
+QVector<ExerciseTourResourceEntry> ExerciseTourResources::scan(const QString &directory)
+{
+    QVector<ExerciseTourResourceEntry> entries;
+
+    QDir dir(directory);
+    if (!dir.exists()) {
+        qWarning() << "ExerciseTourResources::scan: directory not found:" << directory;
+        return entries;
+    }
+
+    const QStringList jsonFiles = dir.entryList({QStringLiteral("*.json")}, QDir::Files);
+    for (const QString &fileName : jsonFiles) {
+        const QString path = directory + QLatin1Char('/') + fileName;
+
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly)) {
+            qWarning() << "ExerciseTourResources::scan: failed to open" << path;
+            continue;
+        }
+
+        const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+        if (doc.isNull() || !doc.isObject()) {
+            qWarning() << "ExerciseTourResources::scan: malformed JSON in" << path;
+            continue;
+        }
+
+        const QJsonObject root = doc.object();
+        const QString id = root.value(QStringLiteral("id")).toString();
+        const QString title = root.value(QStringLiteral("title")).toString();
+        if (id.isEmpty() || title.isEmpty()) {
+            qWarning() << "ExerciseTourResources::scan: missing id/title in" << path;
+            continue;
+        }
+
+        entries.append({path, id, title, root.value(QStringLiteral("description")).toString()});
+    }
+
+    std::sort(entries.begin(), entries.end(), [](const ExerciseTourResourceEntry &a, const ExerciseTourResourceEntry &b) {
+        return a.id < b.id;
+    });
+
+    return entries;
+}
+
+QVector<ExerciseTourResourceEntry> ExerciseTourResources::mergeUnique(QVector<ExerciseTourResourceEntry> base,
+                                                                       const QVector<ExerciseTourResourceEntry> &additional)
+{
+    for (const ExerciseTourResourceEntry &entry : additional) {
+        const bool alreadyPresent = std::any_of(base.cbegin(), base.cend(), [&entry](const ExerciseTourResourceEntry &existing) {
+            return existing.id == entry.id;
+        });
+        if (alreadyPresent) {
+            qWarning() << "ExerciseTourResources::mergeUnique: skipping duplicate id" << entry.id << "at" << entry.path;
+            continue;
+        }
+        base.append(entry);
+    }
+
+    std::sort(base.begin(), base.end(), [](const ExerciseTourResourceEntry &a, const ExerciseTourResourceEntry &b) {
+        return a.id < b.id;
+    });
+
+    return base;
+}
+
+QString ExerciseTourResources::managedContentDir(const QString &category)
+{
+    const QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QLatin1Char('/') + category;
+    QDir dir(path);
+    if (!dir.exists()) {
+        dir.mkpath(path);
+    }
+    return path;
+}
+
+QStringList ExerciseTourResources::installRelativeCandidates(const QString &category)
+{
+    const QString appDir = QCoreApplication::applicationDirPath();
+
+    QStringList candidates = {
+        appDir + QLatin1Char('/') + category,                       // Windows / dev builds
+    };
+#ifdef Q_OS_MACOS
+    candidates << appDir + QStringLiteral("/../Resources/") + category; // macOS app bundle
+#endif
+#ifdef Q_OS_LINUX
+    candidates << qEnvironmentVariable("APPDIR") + QStringLiteral("/usr/share/wiredpanda/") + category; // AppImage
+#endif
+#ifdef Q_OS_WASM
+    candidates << QStringLiteral("/") + category;                   // WASM virtual filesystem
+#endif
+    candidates << category;                                          // CWD fallback (development)
+
+    return candidates;
+}
+
+QString ExerciseTourResources::installRelativeContentDir(const QString &category)
+{
+    for (const QString &candidate : installRelativeCandidates(category)) {
+        if (!candidate.isEmpty() && QDir(candidate).exists()) {
+            return candidate;
+        }
+    }
+    return {};
+}
+
+QString ExerciseTourResources::documentsFallbackDir(const QString &category)
+{
+    return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QStringLiteral("/wiRedPanda/") + category;
+}
+
+QString ExerciseTourResources::resolveWritableDir(const QStringList &candidates, const QString &documentsFallback)
+{
+    for (const QString &candidate : candidates) {
+        if (candidate.isEmpty()) {
+            continue;
+        }
+        QDir dir(candidate);
+        if ((dir.exists() || dir.mkpath(candidate)) && QFileInfo(candidate).isWritable()) {
+            return candidate;
+        }
+    }
+
+    QDir dir(documentsFallback);
+    if ((dir.exists() || dir.mkpath(documentsFallback)) && QFileInfo(documentsFallback).isWritable()) {
+        return documentsFallback;
+    }
+
+    return {};
+}
+
+QString ExerciseTourResources::preferredContentDir(const QString &category)
+{
+    return resolveWritableDir(installRelativeCandidates(category), documentsFallbackDir(category));
+}
+
+QVector<ExerciseTourResourceEntry> ExerciseTourResources::discover(const QString &category)
+{
+    QVector<ExerciseTourResourceEntry> entries = scan(QStringLiteral(":/") + category);
+
+    entries = mergeUnique(entries, scan(managedContentDir(category)));
+
+    const QString installDir = installRelativeContentDir(category);
+    if (!installDir.isEmpty()) {
+        entries = mergeUnique(entries, scan(installDir));
+    }
+
+    const QString docsDir = documentsFallbackDir(category);
+    if (QDir(docsDir).exists()) {
+        entries = mergeUnique(entries, scan(docsDir));
+    }
+
+    return entries;
+}
+
+QString ExerciseTourResources::translateFromCatalog(const QString &catalogPath, const QString &key,
+                                                      const QString &fallbackEnglish)
+{
+    QFile file(catalogPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return fallbackEnglish;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (!doc.isObject()) {
+        return fallbackEnglish;
+    }
+
+    QJsonValue node = doc.object();
+    const QStringList parts = key.split(QLatin1Char('.'));
+    for (const QString &part : parts) {
+        if (!node.isObject()) {
+            return fallbackEnglish;
+        }
+        node = node.toObject().value(part);
+    }
+
+    return (node.isString() && !node.toString().isEmpty()) ? node.toString() : fallbackEnglish;
+}
+
+QString ExerciseTourResources::translate(const QString &key, const QString &fallbackEnglish)
+{
+    const QString lang = Settings::language();
+    if (lang.isEmpty() || lang == QLatin1String("en")) {
+        return fallbackEnglish;
+    }
+
+    return translateFromCatalog(QStringLiteral(":/i18n/ExerciseTour/%1.json").arg(lang), key, fallbackEnglish);
+}

--- a/App/Core/ExerciseTourResources.h
+++ b/App/Core/ExerciseTourResources.h
@@ -1,0 +1,129 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief Discovery and translation lookup for Exercise/Tour step content.
+ */
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+/// Metadata for one Exercise/Tour content JSON file, as discovered by scanning a directory
+/// (built-in Qt resource, or a real filesystem folder). \a title and \a description are the
+/// raw English-source strings straight from the JSON — NOT translated; callers apply
+/// ExerciseTourResources::translate() themselves (mirrors
+/// LanguageManager::availableLanguages() vs. displayName()).
+struct ExerciseTourResourceEntry {
+    QString path;          ///< ":/Exercises/x.json" (built-in) or a real filesystem path.
+    QString id;            ///< JSON root "id" field.
+    QString title;         ///< JSON root "title" field (raw, English-source).
+    QString description;   ///< JSON root "description" field; "" if absent.
+};
+
+/**
+ * \class ExerciseTourResources
+ * \brief Static utility for discovering Exercise/Tour content and translating its text.
+ *
+ * \details Exercise/Tour JSON files are discovered by scanning directories (scan(), composed
+ * by discover()) instead of a hardcoded list. Built-in content ships embedded at
+ * ":/Exercises"/":/Tours"; on top of that, discover() also finds user-added content in three
+ * real, non-built-in locations, each for a different audience:
+ *  - the install-relative folder (mirrors the existing Examples folder) and, when that isn't
+ *    writable, a Documents-based fallback — both end-user-facing, both opened by the "Open
+ *    Folder" button in the browser dialogs via preferredContentDir();
+ *  - the AppData folder (managedContentDir()) — reserved for a teacher/IT admin to
+ *    pre-provision content in a managed classroom install. It is scanned so provisioned
+ *    content shows up, but deliberately never opened or created by the "Open Folder" button
+ *    or any other end-user-facing code path, so it stays out of ordinary users' way.
+ *
+ * Step text inside the JSON never passes through tr() (lupdate can't see JSON), so
+ * translations instead live in a separate, Weblate-managed catalog at
+ * :/i18n/ExerciseTour/<lang>.json; translate() looks strings up there, falling back to the
+ * JSON's own English text when no translation is installed or found — which is also the
+ * correct, automatic behavior for user-added content that will never have a catalog entry.
+ */
+class ExerciseTourResources
+{
+public:
+    ExerciseTourResources() = delete;
+
+    /// Scans \a directory (a Qt resource path like ":/Exercises", or a plain filesystem
+    /// directory) for *.json files and returns one entry per well-formed file: a root object
+    /// with non-empty "id" and "title". Files that fail to open, aren't valid JSON, aren't a
+    /// JSON object, or are missing id/title are skipped (with a qWarning()); "description" is
+    /// optional and defaults to "". Entries are sorted by id for deterministic UI ordering
+    /// (QDir::entryList's order is not guaranteed).
+    static QVector<ExerciseTourResourceEntry> scan(const QString &directory);
+
+    /// Discovers all content for \a category ("Exercises" or "Tours"): the built-in bundled
+    /// content at ":/<category>", the AppData folder (managedContentDir(), created if
+    /// missing), the install-relative folder if one already exists (read-only check, creates
+    /// nothing), and the Documents-based fallback folder if it happens to already exist
+    /// (created only on demand by preferredContentDir(), never eagerly here). Entries whose id
+    /// collides with one already found are skipped (qWarning()) rather than shown twice —
+    /// earlier-scanned sources win, in this order: built-in, AppData folder, install-relative
+    /// folder, Documents fallback.
+    static QVector<ExerciseTourResourceEntry> discover(const QString &category);
+
+    /// Returns the AppData folder for \a category (e.g. "Exercises"), creating it if it
+    /// doesn't exist yet. Reserved exclusively for teacher/IT-provisioned content in a managed
+    /// classroom install — scanned by discover(), but never opened or created by the "Open
+    /// Folder" button or any other end-user-facing code path.
+    static QString managedContentDir(const QString &category);
+
+    /// Returns the folder the "Open Folder" button should open for \a category: the first
+    /// install-relative candidate (mirroring MainWindow::setupExamplesMenu()'s per-platform
+    /// search paths) that already exists, or can be created, AND is writable — the simple,
+    /// visible location meant for an individual end-user. If none of those are writable (e.g.
+    /// installed under Program Files without admin rights), falls back to a Documents-based
+    /// folder (QStandardPaths::DocumentsLocation + "/wiRedPanda/<category>"), created only at
+    /// this point, on demand. Returns an empty string if even that fails — this never falls
+    /// through to managedContentDir(), which must stay untouched by this path.
+    static QString preferredContentDir(const QString &category);
+
+    /// Merges \a additional into \a base: entries whose id already exists in \a base are
+    /// skipped (qWarning()); the result is re-sorted by id. A public seam so the
+    /// dedup/precedence policy is unit-testable without touching the filesystem or
+    /// QStandardPaths.
+    static QVector<ExerciseTourResourceEntry> mergeUnique(QVector<ExerciseTourResourceEntry> base,
+                                                           const QVector<ExerciseTourResourceEntry> &additional);
+
+    /// Looks up \a key (a dotted path, e.g. "basic-and-gate.title" or
+    /// "basic-and-gate.place-and-gate.instruction") in the Weblate-managed catalog for
+    /// Settings::language(). Returns \a fallbackEnglish immediately, without touching disk,
+    /// when the language is empty or "en". Also returns \a fallbackEnglish if the catalog
+    /// can't be opened/parsed or has no value at \a key.
+    static QString translate(const QString &key, const QString &fallbackEnglish);
+
+    /// Same dotted-path lookup as translate(), but reads \a catalogPath directly instead of
+    /// deriving it from Settings::language(). translate() delegates to this; exposed
+    /// separately so tests can exercise the parsing/fallback logic against a fixture file.
+    static QString translateFromCatalog(const QString &catalogPath, const QString &key,
+                                         const QString &fallbackEnglish);
+
+    /// Tries each of \a candidates in order (create if missing, then check writable),
+    /// returning the first that qualifies; falls back to \a documentsFallback (same
+    /// create-then-check) if none do; returns "" if that also fails. preferredContentDir()
+    /// delegates to this with real, environment-derived arguments; exposed separately, with
+    /// no QStandardPaths/QCoreApplication dependency of its own, so tests can force the
+    /// "nothing in the primary list is writable" branch without real OS permission
+    /// manipulation.
+    static QString resolveWritableDir(const QStringList &candidates, const QString &documentsFallback);
+
+private:
+    /// Builds the per-platform install-relative candidate list for \a category, mirroring
+    /// MainWindow::setupExamplesMenu()'s search paths (app dir, macOS bundle Resources,
+    /// Linux AppImage share dir, WASM virtual path, CWD dev fallback) with the folder name
+    /// parameterized instead of hardcoded to "Examples".
+    static QStringList installRelativeCandidates(const QString &category);
+
+    /// Returns the first install-relative candidate that already exists on disk, or "" if
+    /// none do. Read-only — creates nothing; used by discover() for scanning.
+    static QString installRelativeContentDir(const QString &category);
+
+    /// Computes (does not create) the Documents-based fallback path for \a category.
+    static QString documentsFallbackDir(const QString &category);
+};

--- a/App/Core/Settings.cpp
+++ b/App/Core/Settings.cpp
@@ -213,3 +213,26 @@ void Settings::setUpdateCheckSkippedVersion(const QString &version)
 {
     setValue("updateCheck/skippedVersion", version);
 }
+
+// Exercise progress
+
+QStringList Settings::completedExercises()
+{
+    return value("exercises/completed").toStringList();
+}
+
+void Settings::setCompletedExercises(const QStringList &ids)
+{
+    setValue("exercises/completed", ids);
+}
+
+int Settings::exerciseProgress(const QString &exerciseId)
+{
+    const QVariant v = value(QStringLiteral("exercises/progress/") + exerciseId);
+    return v.isValid() ? v.toInt() : -1;
+}
+
+void Settings::setExerciseProgress(const QString &exerciseId, int step)
+{
+    setValue(QStringLiteral("exercises/progress/") + exerciseId, step);
+}

--- a/App/Core/Settings.cpp
+++ b/App/Core/Settings.cpp
@@ -236,3 +236,26 @@ void Settings::setExerciseProgress(const QString &exerciseId, int step)
 {
     setValue(QStringLiteral("exercises/progress/") + exerciseId, step);
 }
+
+// Tour progress
+
+QStringList Settings::completedTours()
+{
+    return value("tours/completed").toStringList();
+}
+
+void Settings::setCompletedTours(const QStringList &ids)
+{
+    setValue("tours/completed", ids);
+}
+
+int Settings::tourProgress(const QString &tourId)
+{
+    const QVariant v = value(QStringLiteral("tours/progress/") + tourId);
+    return v.isValid() ? v.toInt() : -1;
+}
+
+void Settings::setTourProgress(const QString &tourId, int step)
+{
+    setValue(QStringLiteral("tours/progress/") + tourId, step);
+}

--- a/App/Core/Settings.h
+++ b/App/Core/Settings.h
@@ -83,6 +83,12 @@ public:
     static int         exerciseProgress(const QString &exerciseId); ///< Returns -1 if no record.
     static void        setExerciseProgress(const QString &exerciseId, int step);
 
+    // Tour progress
+    static QStringList completedTours();
+    static void        setCompletedTours(const QStringList &ids);
+    static int         tourProgress(const QString &tourId); ///< Returns -1 if no record.
+    static void        setTourProgress(const QString &tourId, int step);
+
 private:
     static QVariant value(const QString &key);
     static void setValue(const QString &key, const QVariant &value);

--- a/App/Core/Settings.h
+++ b/App/Core/Settings.h
@@ -77,6 +77,12 @@ public:
     static QString updateCheckSkippedVersion();
     static void setUpdateCheckSkippedVersion(const QString &version);
 
+    // Exercise progress
+    static QStringList completedExercises();
+    static void        setCompletedExercises(const QStringList &ids);
+    static int         exerciseProgress(const QString &exerciseId); ///< Returns -1 if no record.
+    static void        setExerciseProgress(const QString &exerciseId, int step);
+
 private:
     static QVariant value(const QString &key);
     static void setValue(const QString &key, const QVariant &value);

--- a/App/Exercise/ExerciseBrowserDialog.cpp
+++ b/App/Exercise/ExerciseBrowserDialog.cpp
@@ -1,0 +1,82 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Exercise/ExerciseBrowserDialog.h"
+
+#include <QDesktopServices>
+#include <QIcon>
+#include <QListWidgetItem>
+#include <QMessageBox>
+#include <QStyle>
+#include <QUrl>
+
+#include "App/Core/ExerciseTourResources.h"
+#include "App/Core/Settings.h"
+
+ExerciseBrowserDialog::ExerciseBrowserDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_ui(std::make_unique<ExerciseBrowserDialogUi>())
+{
+    m_ui->setupUi(this);
+    populateList();
+
+    connect(m_ui->exerciseList, &QListWidget::itemSelectionChanged,
+            this, &ExerciseBrowserDialog::onSelectionChanged);
+    connect(m_ui->exerciseList, &QListWidget::itemDoubleClicked,
+            this, [this] {
+                if (m_ui->startButton->isEnabled()) {
+                    accept();
+                }
+            });
+    connect(m_ui->openFolderButton, &QPushButton::clicked, this, [this] {
+        const QString dir = ExerciseTourResources::preferredContentDir(QStringLiteral("Exercises"));
+        if (dir.isEmpty()) {
+            QMessageBox::warning(this, windowTitle(),
+                tr("Could not create or access a folder for custom exercises."));
+            return;
+        }
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
+    });
+
+#ifdef Q_OS_WASM
+    m_ui->openFolderButton->setVisible(false);
+#endif
+}
+
+ExerciseBrowserDialog::~ExerciseBrowserDialog() = default;
+
+QString ExerciseBrowserDialog::selectedExercisePath() const
+{
+    return m_selectedPath;
+}
+
+void ExerciseBrowserDialog::populateList()
+{
+    const QStringList completed = Settings::completedExercises();
+    const QIcon checkIcon = style()->standardIcon(QStyle::SP_DialogApplyButton);
+    const QIcon circleIcon = style()->standardIcon(QStyle::SP_ArrowRight);
+
+    for (const ExerciseTourResourceEntry &entry : ExerciseTourResources::discover(QStringLiteral("Exercises"))) {
+        auto *item = new QListWidgetItem(m_ui->exerciseList);
+        item->setText(ExerciseTourResources::translate(entry.id + QStringLiteral(".title"), entry.title));
+        item->setData(Qt::UserRole,        entry.path);
+        item->setData(Qt::UserRole + 1,    ExerciseTourResources::translate(entry.id + QStringLiteral(".description"), entry.description));
+        item->setIcon(completed.contains(entry.id) ? checkIcon : circleIcon);
+    }
+}
+
+void ExerciseBrowserDialog::onSelectionChanged()
+{
+    const QList<QListWidgetItem *> sel = m_ui->exerciseList->selectedItems();
+    const bool hasSelection = !sel.isEmpty();
+
+    m_ui->startButton->setEnabled(hasSelection);
+
+    if (hasSelection) {
+        m_selectedPath = sel.first()->data(Qt::UserRole).toString();
+        m_ui->descriptionLabel->setText(sel.first()->data(Qt::UserRole + 1).toString());
+    } else {
+        m_selectedPath.clear();
+        m_ui->descriptionLabel->clear();
+    }
+}

--- a/App/Exercise/ExerciseBrowserDialog.h
+++ b/App/Exercise/ExerciseBrowserDialog.h
@@ -1,0 +1,31 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <QDialog>
+#include <QString>
+
+#include "App/Exercise/ExerciseBrowserDialogUI.h"
+
+/// Dialog for browsing and launching available circuit exercises.
+class ExerciseBrowserDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ExerciseBrowserDialog(QWidget *parent = nullptr);
+    ~ExerciseBrowserDialog() override;
+
+    /// Returns the resource path of the selected exercise, or empty if cancelled.
+    QString selectedExercisePath() const;
+
+private:
+    void populateList();
+    void onSelectionChanged();
+
+    std::unique_ptr<ExerciseBrowserDialogUi> m_ui;
+    QString m_selectedPath;
+};

--- a/App/Exercise/ExerciseBrowserDialogUI.cpp
+++ b/App/Exercise/ExerciseBrowserDialogUI.cpp
@@ -1,0 +1,51 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Exercise/ExerciseBrowserDialogUI.h"
+
+void ExerciseBrowserDialogUi::setupUi(QDialog *dialog)
+{
+    dialog->resize(420, 300);
+
+    auto *mainLayout = new QVBoxLayout(dialog);
+    mainLayout->setContentsMargins(12, 12, 12, 12);
+    mainLayout->setSpacing(8);
+
+    titleLabel = new QLabel(dialog);
+    QFont titleFont = titleLabel->font();
+    titleFont.setPointSize(titleFont.pointSize() + 2);
+    titleFont.setBold(true);
+    titleLabel->setFont(titleFont);
+    mainLayout->addWidget(titleLabel);
+
+    exerciseList = new QListWidget(dialog);
+    exerciseList->setSelectionMode(QAbstractItemView::SingleSelection);
+    mainLayout->addWidget(exerciseList, 1);
+
+    descriptionLabel = new QLabel(dialog);
+    descriptionLabel->setWordWrap(true);
+    descriptionLabel->setStyleSheet("color: gray; font-size: 11px;");
+    mainLayout->addWidget(descriptionLabel);
+
+    buttonBox = new QDialogButtonBox(dialog);
+    openFolderButton = new QPushButton(dialog);
+    buttonBox->addButton(openFolderButton, QDialogButtonBox::ActionRole);
+    startButton = new QPushButton(dialog);
+    startButton->setEnabled(false);
+    buttonBox->addButton(startButton, QDialogButtonBox::AcceptRole);
+    buttonBox->addButton(QDialogButtonBox::Close);
+    mainLayout->addWidget(buttonBox);
+
+    retranslateUi(dialog);
+
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
+}
+
+void ExerciseBrowserDialogUi::retranslateUi(QDialog *dialog)
+{
+    dialog->setWindowTitle(QCoreApplication::translate("ExerciseBrowserDialog", "Circuit Exercises"));
+    titleLabel->setText(QCoreApplication::translate("ExerciseBrowserDialog", "Choose an Exercise"));
+    startButton->setText(QCoreApplication::translate("ExerciseBrowserDialog", "Start"));
+    openFolderButton->setText(QCoreApplication::translate("ExerciseBrowserDialog", "Open My Exercises Folder"));
+}

--- a/App/Exercise/ExerciseBrowserDialogUI.h
+++ b/App/Exercise/ExerciseBrowserDialogUI.h
@@ -1,0 +1,30 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+class ExerciseBrowserDialogUi
+{
+public:
+    ExerciseBrowserDialogUi() = default;
+    ExerciseBrowserDialogUi(const ExerciseBrowserDialogUi &) = delete;
+    ExerciseBrowserDialogUi &operator=(const ExerciseBrowserDialogUi &) = delete;
+
+    void setupUi(QDialog *dialog);
+    void retranslateUi(QDialog *dialog);
+
+    QLabel          *titleLabel       = nullptr;
+    QListWidget     *exerciseList     = nullptr;
+    QLabel          *descriptionLabel = nullptr;
+    QDialogButtonBox *buttonBox       = nullptr;
+    QPushButton     *startButton      = nullptr;
+    QPushButton     *openFolderButton = nullptr;
+};

--- a/App/Exercise/ExerciseEngine.cpp
+++ b/App/Exercise/ExerciseEngine.cpp
@@ -1,0 +1,290 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Exercise/ExerciseEngine.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "App/Core/ExerciseTourResources.h"
+#include "App/Core/Settings.h"
+#include "App/Element/ElementFactory.h"
+#include "App/Element/GraphicElement.h"
+#include "App/Scene/Scene.h"
+#include "App/Wiring/Connection.h"
+#include "App/Wiring/Port.h"
+
+ExerciseEngine::ExerciseEngine(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool ExerciseEngine::loadFromResource(const QString &resourcePath)
+{
+    m_active = false;
+    m_steps.clear();
+    m_currentStep = 0;
+    m_id.clear();
+    m_title.clear();
+
+    QFile file(resourcePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isNull() || !doc.isObject()) {
+        return false;
+    }
+
+    const QJsonObject root = doc.object();
+    m_id = root.value("id").toString();
+    const QString rawTitle = root.value("title").toString();
+
+    if (m_id.isEmpty() || rawTitle.isEmpty()) {
+        return false;
+    }
+
+    m_title = ExerciseTourResources::translate(m_id + QStringLiteral(".title"), rawTitle);
+
+    const QJsonArray stepsArray = root.value("steps").toArray();
+    if (stepsArray.isEmpty()) {
+        return false;
+    }
+
+    for (const QJsonValue &stepVal : stepsArray) {
+        const QJsonObject stepObj = stepVal.toObject();
+        ExerciseStep step;
+
+        const QString stepKey       = stepObj.value("key").toString();
+        const QString rawInstruction = stepObj.value("instruction").toString();
+        const QString rawHint        = stepObj.value("hint").toString();
+
+        if (stepKey.isEmpty()) {
+            step.instruction = rawInstruction;
+            step.hint        = rawHint;
+        } else {
+            const QString keyPrefix = m_id + QLatin1Char('.') + stepKey + QLatin1Char('.');
+            step.instruction = ExerciseTourResources::translate(keyPrefix + QStringLiteral("instruction"), rawInstruction);
+            step.hint        = ExerciseTourResources::translate(keyPrefix + QStringLiteral("hint"), rawHint);
+        }
+
+        for (const QJsonValue &elemVal : stepObj.value("requiredElements").toArray()) {
+            const QJsonObject elemObj = elemVal.toObject();
+            ExerciseElementRequirement req;
+            req.typeName  = elemObj.value("type").toString();
+            req.minCount  = elemObj.value("minCount").toInt(1);
+            step.requiredElements.append(req);
+        }
+
+        for (const QJsonValue &connVal : stepObj.value("requiredConnections").toArray()) {
+            const QJsonObject connObj = connVal.toObject();
+            ExerciseConnectionRequirement req;
+            req.fromTypeName = connObj.value("fromType").toString();
+            req.toTypeName   = connObj.value("toType").toString();
+            req.minCount     = connObj.value("minCount").toInt(1);
+            step.requiredConnections.append(req);
+        }
+
+        step.click   = stepObj.value("click").toVariant().toStringList();
+        step.context = stepObj.value("context").toString();
+        m_steps.append(step);
+    }
+
+    return true;
+}
+
+void ExerciseEngine::setScene(Scene *scene)
+{
+    if (m_scene) {
+        disconnect(m_scene, &Scene::circuitHasChanged, this, &ExerciseEngine::onCircuitChanged);
+    }
+    m_scene = scene;
+    if (m_scene && m_active) {
+        connect(m_scene, &Scene::circuitHasChanged, this, &ExerciseEngine::onCircuitChanged);
+    }
+}
+
+const ExerciseStep &ExerciseEngine::currentStepData() const
+{
+    static ExerciseStep empty;
+    if (m_steps.isEmpty() || m_currentStep < 0 || m_currentStep >= m_steps.size()) {
+        return empty;
+    }
+    return m_steps.at(m_currentStep);
+}
+
+void ExerciseEngine::start()
+{
+    if (m_steps.isEmpty()) {
+        return;
+    }
+    m_currentStep = Settings::exerciseProgress(m_id);
+    if (m_currentStep < 0 || m_currentStep >= m_steps.size()) {
+        m_currentStep = 0;
+    }
+    m_active = true;
+
+    if (m_scene) {
+        connect(m_scene, &Scene::circuitHasChanged, this, &ExerciseEngine::onCircuitChanged);
+    }
+
+    emitCurrentStep();
+}
+
+void ExerciseEngine::stop()
+{
+    if (!m_active) {
+        return;
+    }
+    m_active = false;
+    if (m_scene) {
+        disconnect(m_scene, &Scene::circuitHasChanged, this, &ExerciseEngine::onCircuitChanged);
+    }
+    emit exerciseStopped();
+}
+
+void ExerciseEngine::goToPreviousStep()
+{
+    if (!m_active || m_currentStep <= 0) {
+        return;
+    }
+    --m_currentStep;
+    Settings::setExerciseProgress(m_id, m_currentStep);
+    emitCurrentStep();
+}
+
+void ExerciseEngine::advanceStep()
+{
+    if (!m_active || m_steps.isEmpty()) {
+        return;
+    }
+    if (m_currentStep >= m_steps.size() - 1) {
+        markCompleted();
+        return;
+    }
+    emit stepCompleted(m_currentStep);
+    ++m_currentStep;
+    Settings::setExerciseProgress(m_id, m_currentStep);
+    emitCurrentStep();
+}
+
+void ExerciseEngine::onCircuitChanged()
+{
+    if (!m_active || !validateCurrentStep()) {
+        return;
+    }
+
+    if (m_currentStep >= m_steps.size() - 1) {
+        markCompleted();
+        return;
+    }
+
+    emit stepCompleted(m_currentStep);
+    ++m_currentStep;
+    Settings::setExerciseProgress(m_id, m_currentStep);
+    emitCurrentStep();
+}
+
+bool ExerciseEngine::validateCurrentStep() const
+{
+    if (!m_active || m_steps.isEmpty() || !m_scene) {
+        return false;
+    }
+    const ExerciseStep &step = m_steps.at(m_currentStep);
+
+    // Observe steps (both vectors empty) never auto-advance.
+    if (step.requiredElements.isEmpty() && step.requiredConnections.isEmpty()) {
+        return false;
+    }
+
+    return validateElements(step.requiredElements)
+        && validateConnections(step.requiredConnections);
+}
+
+bool ExerciseEngine::validateElements(const QVector<ExerciseElementRequirement> &reqs) const
+{
+    if (reqs.isEmpty()) {
+        return true;
+    }
+
+    const QVector<GraphicElement *> elements = m_scene->elements();
+
+    for (const ExerciseElementRequirement &req : reqs) {
+        const ElementType required = ElementFactory::textToType(req.typeName);
+        if (required == ElementType::Unknown) {
+            return false;
+        }
+        int count = 0;
+        for (const GraphicElement *elm : elements) {
+            if (elm->elementType() == required) {
+                ++count;
+            }
+        }
+        if (count < req.minCount) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ExerciseEngine::validateConnections(const QVector<ExerciseConnectionRequirement> &reqs) const
+{
+    if (reqs.isEmpty()) {
+        return true;
+    }
+
+    const QVector<GraphicElement *> elements = m_scene->elements();
+
+    for (const ExerciseConnectionRequirement &req : reqs) {
+        const ElementType toType   = ElementFactory::textToType(req.toTypeName);
+        const ElementType fromType = ElementFactory::textToType(req.fromTypeName);
+        if (toType == ElementType::Unknown || fromType == ElementType::Unknown) {
+            return false;
+        }
+
+        int count = 0;
+        for (const GraphicElement *elm : elements) {
+            if (elm->elementType() != toType) {
+                continue;
+            }
+            for (const InputPort *port : elm->inputs()) {
+                for (const Connection *conn : port->connections()) {
+                    if (conn->startPort()
+                            && conn->startPort()->graphicElement()
+                            && conn->startPort()->graphicElement()->elementType() == fromType) {
+                        ++count;
+                    }
+                }
+            }
+        }
+        if (count < req.minCount) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void ExerciseEngine::emitCurrentStep()
+{
+    emit stepChanged(m_currentStep, static_cast<int>(m_steps.size()), currentStepData());
+}
+
+void ExerciseEngine::markCompleted()
+{
+    m_active = false;
+    if (m_scene) {
+        disconnect(m_scene, &Scene::circuitHasChanged, this, &ExerciseEngine::onCircuitChanged);
+    }
+
+    QStringList completed = Settings::completedExercises();
+    if (!completed.contains(m_id)) {
+        completed.append(m_id);
+        Settings::setCompletedExercises(completed);
+    }
+    Settings::setExerciseProgress(m_id, 0);
+
+    emit exerciseCompleted();
+}

--- a/App/Exercise/ExerciseEngine.h
+++ b/App/Exercise/ExerciseEngine.h
@@ -1,0 +1,72 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QVector>
+
+#include "App/Exercise/ExerciseStep.h"
+
+class Scene;
+
+class ExerciseEngine : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ExerciseEngine(QObject *parent = nullptr);
+
+    /// Loads an exercise from a Qt resource path (e.g. ":/Exercises/basic-and-gate.json").
+    /// Returns false and leaves the engine inactive if the resource is missing or malformed.
+    bool loadFromResource(const QString &resourcePath);
+
+    QString exerciseId()    const { return m_id; }
+    QString exerciseTitle() const { return m_title; }
+
+    /// Binds the engine to \a scene. Disconnects the previous scene if any.
+    /// Pass nullptr to detach without binding a new scene.
+    void setScene(Scene *scene);
+
+    int  currentStep() const { return m_currentStep; }
+    int  totalSteps()  const { return static_cast<int>(m_steps.size()); }
+    bool isActive()    const { return m_active; }
+
+    /// Returns the data for the current step. Caller must check isActive() first.
+    const ExerciseStep &currentStepData() const;
+
+    void start();
+    void stop();
+    void goToPreviousStep();
+
+    /// Manually advances one step (used by the overlay Next/Finish button for observe steps).
+    void advanceStep();
+
+signals:
+    void stepChanged(int step, int total, const ExerciseStep &data);
+    void stepCompleted(int step);
+    void exerciseCompleted();
+    void exerciseStopped();
+
+private slots:
+    void onCircuitChanged();
+
+private:
+    /// Returns true when the current step's requirements are satisfied by the current scene.
+    /// Always returns false for observe steps (both requirement vectors empty).
+    bool validateCurrentStep() const;
+
+    bool validateElements(const QVector<ExerciseElementRequirement> &reqs) const;
+    bool validateConnections(const QVector<ExerciseConnectionRequirement> &reqs) const;
+
+    void emitCurrentStep();
+    void markCompleted();
+
+    QString               m_id;
+    QString               m_title;
+    QVector<ExerciseStep> m_steps;
+    int                   m_currentStep = 0;
+    bool                  m_active = false;
+    QPointer<Scene>       m_scene;
+};

--- a/App/Exercise/ExerciseOverlay.cpp
+++ b/App/Exercise/ExerciseOverlay.cpp
@@ -1,0 +1,221 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Exercise/ExerciseOverlay.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "App/Core/ThemeManager.h"
+#include "App/Exercise/ExerciseEngine.h"
+
+ExerciseOverlay::ExerciseOverlay(ExerciseEngine *engine, QWidget *parent)
+    : QWidget(parent)
+    , m_engine(engine)
+{
+    setFixedWidth(480);
+    setAttribute(Qt::WA_TranslucentBackground);
+
+    setupUi();
+
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, &ExerciseOverlay::applyTheme);
+}
+
+void ExerciseOverlay::setupUi()
+{
+    auto *outerLayout = new QVBoxLayout(this);
+    outerLayout->setContentsMargins(12, 12, 12, 12);
+    outerLayout->setSpacing(8);
+
+    // Step counter row
+    auto *topRow = new QHBoxLayout;
+    m_stepCounter = new QLabel(this);
+    topRow->addWidget(m_stepCounter);
+    topRow->addStretch();
+    outerLayout->addLayout(topRow);
+
+    // Instruction text
+    m_instructionLabel = new QLabel(this);
+    m_instructionLabel->setWordWrap(true);
+    outerLayout->addWidget(m_instructionLabel);
+
+    // Hint text (hidden by default)
+    m_hintLabel = new QLabel(this);
+    m_hintLabel->setWordWrap(true);
+    m_hintLabel->hide();
+    outerLayout->addWidget(m_hintLabel);
+
+    // Navigation row: [Exit] [Hint] ←stretch→ [← Back] [Next →]
+    auto *btnRow = new QHBoxLayout;
+    btnRow->setSpacing(6);
+
+    m_closeButton = new QPushButton(tr("Exit"), this);
+    m_closeButton->setToolTip(tr("Close exercise"));
+
+    m_hintButton = new QPushButton(tr("Hint"), this);
+
+    m_prevButton = new QPushButton(tr("← Back"), this);
+
+    m_nextButton = new QPushButton(tr("Next →"), this);
+    m_nextButton->setEnabled(false);
+
+    btnRow->addWidget(m_closeButton);
+    btnRow->addWidget(m_hintButton);
+    btnRow->addStretch();
+    btnRow->addWidget(m_prevButton);
+    btnRow->addWidget(m_nextButton);
+    outerLayout->addLayout(btnRow);
+
+    adjustSize();
+
+    connect(m_closeButton, &QPushButton::clicked, this, &ExerciseOverlay::closeRequested);
+    connect(m_hintButton,  &QPushButton::clicked, this, [this] {
+        m_hintVisible = !m_hintVisible;
+        m_hintLabel->setVisible(m_hintVisible);
+        m_hintButton->setText(m_hintVisible ? tr("Hide hint") : tr("Hint"));
+        adjustSize();
+        repositionToParent();
+    });
+    connect(m_prevButton, &QPushButton::clicked, this, [this] {
+        m_engine->goToPreviousStep();
+    });
+    connect(m_nextButton, &QPushButton::clicked, this, [this] {
+        m_engine->advanceStep();
+    });
+
+    applyTheme();
+}
+
+void ExerciseOverlay::applyTheme()
+{
+    const bool dark = (ThemeManager::effectiveTheme() == Theme::Dark);
+
+    if (dark) {
+        m_bgColor      = QColor(30, 30, 30, 200);
+        m_textColor    = QColor(255, 255, 255);
+        m_hintColor    = QColor(255, 255, 180, 230);
+        m_counterColor = QColor(255, 255, 255, 200);
+
+        const QString navStyle =
+            "QPushButton { color: white; background: rgba(255,255,255,40);"
+            " border: 1px solid rgba(255,255,255,80); border-radius: 4px;"
+            " padding: 3px 10px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(255,255,255,60); }"
+            "QPushButton:disabled { color: rgba(255,255,255,80); background: rgba(80,80,80,60); }";
+        m_closeButton->setStyleSheet(navStyle);
+        m_hintButton->setStyleSheet(navStyle);
+        m_prevButton->setStyleSheet(navStyle);
+        m_nextButton->setStyleSheet(
+            "QPushButton { color: white; background: rgba(60,150,60,180);"
+            " border: 1px solid rgba(255,255,255,80); border-radius: 4px;"
+            " padding: 3px 10px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(60,180,60,200); }"
+            "QPushButton:disabled { background: rgba(100,100,100,80);"
+            " color: rgba(255,255,255,100); }");
+    } else {
+        m_bgColor      = QColor(245, 245, 245, 230);
+        m_textColor    = QColor(20, 20, 20);
+        m_hintColor    = QColor(110, 90, 0, 230);
+        m_counterColor = QColor(80, 80, 80, 200);
+
+        const QString navStyle =
+            "QPushButton { color: rgb(20,20,20); background: rgba(0,0,0,20);"
+            " border: 1px solid rgba(0,0,0,80); border-radius: 4px;"
+            " padding: 3px 10px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(0,0,0,40); }"
+            "QPushButton:disabled { color: rgba(0,0,0,60); background: rgba(0,0,0,10); }";
+        m_closeButton->setStyleSheet(navStyle);
+        m_hintButton->setStyleSheet(navStyle);
+        m_prevButton->setStyleSheet(navStyle);
+        m_nextButton->setStyleSheet(
+            "QPushButton { color: white; background: rgba(40,130,40,220);"
+            " border: 1px solid rgba(0,100,0,150); border-radius: 4px;"
+            " padding: 3px 10px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(40,160,40,230); }"
+            "QPushButton:disabled { background: rgba(150,150,150,80);"
+            " color: rgba(255,255,255,120); }");
+    }
+
+    m_stepCounter->setStyleSheet(
+        QString("color: rgba(%1,%2,%3,%4); font-size: 12px;")
+            .arg(m_counterColor.red()).arg(m_counterColor.green())
+            .arg(m_counterColor.blue()).arg(m_counterColor.alpha()));
+    m_instructionLabel->setStyleSheet(
+        QString("color: rgb(%1,%2,%3); font-size: 14px; font-weight: bold;")
+            .arg(m_textColor.red()).arg(m_textColor.green()).arg(m_textColor.blue()));
+    m_hintLabel->setStyleSheet(
+        QString("color: rgba(%1,%2,%3,%4); font-size: 13px;")
+            .arg(m_hintColor.red()).arg(m_hintColor.green())
+            .arg(m_hintColor.blue()).arg(m_hintColor.alpha()));
+
+    update();
+}
+
+void ExerciseOverlay::repositionToParent()
+{
+    if (!parentWidget()) {
+        return;
+    }
+    adjustSize();
+    const int x = (parentWidget()->width() - width()) / 2;
+    const int y = parentWidget()->height() - height() - 12;
+    move(x, y);
+}
+
+void ExerciseOverlay::onStepChanged(int step, int total, const ExerciseStep &stepData)
+{
+    m_stepCounter->setText(tr("Step %1 of %2").arg(step + 1).arg(total));
+    m_instructionLabel->setText(stepData.instruction);
+    m_hintLabel->setText(stepData.hint);
+
+    // Reset hint state on step change
+    m_hintVisible = false;
+    m_hintLabel->hide();
+    m_hintButton->setText(tr("Hint"));
+
+    const bool isObserveStep = stepData.requiredElements.isEmpty() && stepData.requiredConnections.isEmpty();
+    const bool isLastStep    = (step == total - 1);
+
+    updateNextButton(isLastStep);
+    // Next button enabled only for observe steps (auto-advance handles others)
+    m_nextButton->setEnabled(isObserveStep);
+
+    m_prevButton->setEnabled(step > 0);
+
+    adjustSize();
+    repositionToParent();
+}
+
+void ExerciseOverlay::onExerciseCompleted()
+{
+    m_stepCounter->setText({});
+    m_instructionLabel->setText(tr("Exercise complete! Well done."));
+    m_hintLabel->hide();
+    m_hintButton->hide();
+    m_prevButton->hide();
+    m_nextButton->setText(tr("Close"));
+    m_nextButton->setEnabled(true);
+    disconnect(m_nextButton, &QPushButton::clicked, nullptr, nullptr);
+    connect(m_nextButton, &QPushButton::clicked, this, &ExerciseOverlay::closeRequested);
+    adjustSize();
+    repositionToParent();
+}
+
+void ExerciseOverlay::updateNextButton(bool isLastStep)
+{
+    m_nextButton->setText(isLastStep ? tr("Finish") : tr("Next →"));
+}
+
+void ExerciseOverlay::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setBrush(m_bgColor);
+    painter.setPen(Qt::NoPen);
+    painter.drawRoundedRect(rect(), 8, 8);
+}

--- a/App/Exercise/ExerciseOverlay.h
+++ b/App/Exercise/ExerciseOverlay.h
@@ -1,0 +1,58 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QColor>
+#include <QWidget>
+
+#include "App/Exercise/ExerciseStep.h"
+
+class QLabel;
+class QPushButton;
+class ExerciseEngine;
+
+/// Semi-transparent overlay displayed at the bottom of the canvas during a circuit exercise.
+class ExerciseOverlay : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ExerciseOverlay(ExerciseEngine *engine, QWidget *parent = nullptr);
+
+    /// Repositions the overlay to the bottom-centre of its parent widget.
+    /// Called by WorkSpace::resizeEvent and after reparenting.
+    void repositionToParent();
+
+public slots:
+    void onStepChanged(int step, int total, const ExerciseStep &stepData);
+    void onExerciseCompleted();
+
+signals:
+    void closeRequested();
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    void setupUi();
+    void updateNextButton(bool isLastStep);
+    void applyTheme();
+
+    ExerciseEngine *m_engine;
+
+    QColor m_bgColor;
+    QColor m_textColor;
+    QColor m_hintColor;
+    QColor m_counterColor;
+
+    QLabel       *m_stepCounter      = nullptr;
+    QLabel       *m_instructionLabel = nullptr;
+    QLabel       *m_hintLabel        = nullptr;
+    QPushButton  *m_hintButton       = nullptr;
+    QPushButton  *m_prevButton       = nullptr;
+    QPushButton  *m_nextButton       = nullptr;
+    QPushButton  *m_closeButton      = nullptr;
+
+    bool m_hintVisible = false;
+};

--- a/App/Exercise/ExerciseStep.h
+++ b/App/Exercise/ExerciseStep.h
@@ -1,0 +1,33 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+struct ExerciseElementRequirement {
+    QString typeName;
+    int     minCount = 1;
+};
+
+struct ExerciseConnectionRequirement {
+    QString fromTypeName;
+    QString toTypeName;
+    int     minCount = 1;
+};
+
+/// One step in a circuit exercise.
+/// A step whose requiredElements AND requiredConnections are both empty is an
+/// "observe" step: the engine never auto-advances it; the user must click Next/Finish.
+///
+/// \a click lists widget/action IDs handled by MainWindow before the step is presented.
+struct ExerciseStep {
+    QString instruction;
+    QString hint;
+    QVector<ExerciseElementRequirement>    requiredElements;
+    QVector<ExerciseConnectionRequirement> requiredConnections;
+    QStringList click;   ///< Widget/action IDs to activate on step enter.
+    QString context;     ///< "" or "circuit" → overlay on WorkSpace; "bwd" → overlay on BeWavedDolphin.
+};

--- a/App/Resources/Exercises/README.md
+++ b/App/Resources/Exercises/README.md
@@ -97,9 +97,10 @@ can never be satisfied.
 
 `click` IDs are a **closed, hardcoded** set understood only by `MainWindow::clickTarget()`
 (`App/UI/MainWindow.cpp`) — not data-driven. Currently valid: `ioTab`, `gatesTab`,
-`combinational`, `memoryTab`, `actionPlay`, `actionWaveform`. Referencing an ID outside this
-list is silently a no-op. If your exercise needs to trigger something not in this list, add a
-case to `clickTarget()` first — there's no way to do it from JSON alone.
+`combinational`, `memoryTab`, `actionPlay`, `actionWaveform`, `bwd:actionCombinational`,
+`setupElementEditorDemo`, `setupWaveformDemo`. Referencing an ID outside this list is silently a
+no-op. If your exercise needs to trigger something not in this list, add a case to
+`clickTarget()` first — there's no way to do it from JSON alone.
 
 ## Translations
 
@@ -111,4 +112,5 @@ is generated from this folder's content by `Scripts/generate_exercise_tour_catal
 Non-English `ExerciseTour/<lang>.json` files are submitted by translators through Weblate's
 normal web UI (a *separate* "JSON file" component from the app's main `.ts` component) —
 translators never touch this folder's `.json` files directly. If a translation is missing or a
-step has no `key`, the app falls back to the raw English text here.
+step has no `key`, the app falls back to the raw English text here. See
+`../Tours/README.md` for the equivalent for guided UI tours.

--- a/App/Resources/Exercises/README.md
+++ b/App/Resources/Exercises/README.md
@@ -1,0 +1,114 @@
+# Exercises
+
+An Exercise is a step-by-step circuit-building challenge, validated against the live scene as
+the user works. Each `.json` file in this folder is one exercise; `App/Exercise/ExerciseEngine`
+loads and drives it, `App/Exercise/ExerciseBrowserDialog` lists all of them for the user to pick
+from.
+
+## Adding a new built-in exercise (for contributors)
+
+Drop a new `.json` file in this folder with a globally unique `id` (unique across **both**
+`App/Resources/Exercises/` and `App/Resources/Tours/` — the translation catalog described below
+is keyed by `id` alone, with no folder namespacing). Reconfigure (`cmake --preset debug`) so the
+new file is picked up — no C++ or `.qrc` edit needed, it's discovered automatically. Then run the
+catalog generator and commit the result:
+
+```bash
+python3 Scripts/generate_exercise_tour_catalog.py
+```
+
+## Adding your own exercise without building from source
+
+The built-in exercises above ship compiled into the app. Anyone running an already-installed
+copy of wiRedPanda can add their own exercises too — no C++ toolchain needed — by dropping a
+`.json` file (same schema as below) into one of two other real, on-disk locations, each aimed
+at a different audience. `App/Core/ExerciseTourResources::discover()` merges all of them (plus
+the built-in content above) into one list every time the Circuit Exercises dialog opens; if an
+`id` collides across sources, the built-in file wins and the duplicate is silently skipped.
+
+**For an individual user**: click **"Open My Exercises Folder"** in the Circuit Exercises
+dialog. It opens (creating if needed) a simple, visible folder next to the installed app —
+normally `<install dir>/Exercises`. If that location isn't writable (e.g. installed under
+`Program Files` without admin rights), the button transparently falls back to a folder under
+your Documents folder instead (`Documents/wiRedPanda/Exercises`) — either way, whatever it
+opens is where you drop your `.json` file; reopen the dialog and it appears.
+
+**For a teacher/IT admin provisioning a shared/managed install** (e.g. a school computer lab
+image or a login script): place `.json` files in
+`<AppData>/wiRedPanda/Exercises` — the platform-specific location
+`QStandardPaths::AppDataLocation` resolves to, e.g.
+`%APPDATA%\GIBIS-UNIFESP\wiRedPanda\Exercises` on Windows,
+`~/.local/share/wiRedPanda/Exercises` on Linux, or
+`~/Library/Application Support/wiRedPanda/Exercises` on macOS. This folder is auto-created the
+first time the dialog opens, is always scanned, but is **never** opened or created by the "Open
+Folder" button and has no other in-app affordance — it's deliberately not something an ordinary
+end-user needs to know about or stumble onto while browsing.
+
+## Schema
+
+```json
+{
+  "id": "basic-and-gate",
+  "title": "Building an AND Gate Circuit",
+  "description": "Learn to place logic gates, add inputs and outputs, and wire them together.",
+  "steps": [
+    {
+      "key": "place-and-gate",
+      "instruction": "Place an AND gate on the canvas",
+      "hint": "Click the Gates tab in the left panel, then drag the AND gate onto the canvas.",
+      "requiredElements": [
+        { "type": "And", "minCount": 1 }
+      ],
+      "requiredConnections": [],
+      "click": ["gatesTab"]
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Globally unique (see above). Used as the progress/completion key and as the translation-catalog namespace. |
+| `title` | string | yes | Shown in the exercise browser dialog. |
+| `description` | string | no | Shown below the title in the exercise browser dialog. |
+| `steps` | array | yes | At least one step. |
+| `steps[].key` | string | no | Stable slug (e.g. `"place-and-gate"`), unique within this file's `steps[]`. Used **only** to build translation-catalog keys — never read by engine logic. Omit it and the step's text is simply not translatable (English-only fallback, not an error). Give every step a `key` unless you're certain it'll never need translation. |
+| `steps[].instruction` | string | yes | Main instruction text shown while this step is active. |
+| `steps[].hint` | string | no | Extra help text. |
+| `steps[].requiredElements` | array | no | `{ "type": "<ElementType>", "minCount": N }`. The step auto-advances once the scene contains at least `minCount` elements of each listed type. |
+| `steps[].requiredConnections` | array | no | `{ "fromType": "<ElementType>", "toType": "<ElementType>", "minCount": N }`. Counts connections whose source element is `fromType` and destination element is `toType`. |
+| `steps[].click` | array of strings | no | Widget/action IDs handled by `MainWindow` before the step is presented. See "Closed widget vocabulary" below. |
+| `steps[].context` | string | no | `""` or `"circuit"` (default) overlays on the main canvas; `"bwd"` overlays on the BeWavedDolphin waveform window instead. |
+
+A step whose `requiredElements` **and** `requiredConnections` are both empty/absent is an
+"observe" step: the engine never auto-advances it — the user must click Next/Finish. The last
+example step in `basic-and-gate.json` (toggle the switches and observe the LED) is one of these.
+
+### Element type names
+
+`requiredElements[].type` / `requiredConnections[].fromType` / `.toType` must exactly match one
+of the enum keys in `Enums::ElementType` (`App/Core/Enums.h`), resolved at load time by
+`ElementFactory::textToType()` via `QMetaEnum` — case-sensitive, exactly as spelled there. A
+handful for orientation: `"And"`, `"InputSwitch"`, `"Led"`, `"Clock"`. Check `Enums.h` directly
+for the full list; an unrecognized name resolves to `ElementType::Unknown` and that requirement
+can never be satisfied.
+
+### Closed widget/action vocabulary
+
+`click` IDs are a **closed, hardcoded** set understood only by `MainWindow::clickTarget()`
+(`App/UI/MainWindow.cpp`) — not data-driven. Currently valid: `ioTab`, `gatesTab`,
+`combinational`, `memoryTab`, `actionPlay`, `actionWaveform`. Referencing an ID outside this
+list is silently a no-op. If your exercise needs to trigger something not in this list, add a
+case to `clickTarget()` first — there's no way to do it from JSON alone.
+
+## Translations
+
+Step text (`instruction`, `hint`) and the root `title`/`description` never pass through Qt's
+`tr()` — this is JSON, and `lupdate` only scans `.cpp`/`.h`/`.ui`. Instead, a separate,
+Weblate-managed catalog carries the translations: `App/Resources/Translations/ExerciseTour/en.json`
+is generated from this folder's content by `Scripts/generate_exercise_tour_catalog.py`, keyed
+`<id>.title`, `<id>.description`, `<id>.<step key>.instruction`, `<id>.<step key>.hint`.
+Non-English `ExerciseTour/<lang>.json` files are submitted by translators through Weblate's
+normal web UI (a *separate* "JSON file" component from the app's main `.ts` component) —
+translators never touch this folder's `.json` files directly. If a translation is missing or a
+step has no `key`, the app falls back to the raw English text here.

--- a/App/Resources/Exercises/basic-and-gate.json
+++ b/App/Resources/Exercises/basic-and-gate.json
@@ -1,0 +1,62 @@
+{
+  "id": "basic-and-gate",
+  "title": "Building an AND Gate Circuit",
+  "description": "Learn to place logic gates, add inputs and outputs, and wire them together.",
+  "steps": [
+    {
+      "key": "place-and-gate",
+      "instruction": "Place an AND gate on the canvas",
+      "hint": "Click the Gates tab in the left panel, then drag the AND gate onto the canvas.",
+      "requiredElements": [
+        { "type": "And", "minCount": 1 }
+      ],
+      "requiredConnections": [],
+      "click": ["gatesTab"]
+    },
+    {
+      "key": "add-inputs",
+      "instruction": "Add two InputSwitch elements to the canvas",
+      "hint": "Click the I/O tab in the left panel, then drag two InputSwitch elements onto the canvas and place them to the left of the AND gate.",
+      "requiredElements": [
+        { "type": "And", "minCount": 1 },
+        { "type": "InputSwitch", "minCount": 2 }
+      ],
+      "requiredConnections": [],
+      "click": ["ioTab"]
+    },
+    {
+      "key": "connect-inputs",
+      "instruction": "Connect both input switches to the AND gate",
+      "hint": "Click and drag from an InputSwitch output port (right side) to one of the AND gate input ports (left side). Repeat for the second switch.",
+      "requiredElements": [
+        { "type": "And", "minCount": 1 },
+        { "type": "InputSwitch", "minCount": 2 }
+      ],
+      "requiredConnections": [
+        { "fromType": "InputSwitch", "toType": "And", "minCount": 2 }
+      ]
+    },
+    {
+      "key": "add-output",
+      "instruction": "Add a LED and connect it to the AND gate output",
+      "hint": "Drag a Led from the I/O tab and place it to the right of the AND gate. Then connect the AND gate output port (right side) to the LED input port (left side).",
+      "click": ["ioTab"],
+      "requiredElements": [
+        { "type": "And", "minCount": 1 },
+        { "type": "InputSwitch", "minCount": 2 },
+        { "type": "Led", "minCount": 1 }
+      ],
+      "requiredConnections": [
+        { "fromType": "InputSwitch", "toType": "And", "minCount": 2 },
+        { "fromType": "And", "toType": "Led" }
+      ]
+    },
+    {
+      "key": "toggle-observe",
+      "instruction": "Toggle the switches and observe the LED — this is AND logic!",
+      "hint": "Click an InputSwitch to toggle it. The LED only lights up when BOTH switches are ON. That is because AND outputs 1 only when all inputs are 1.",
+      "requiredElements": [],
+      "requiredConnections": []
+    }
+  ]
+}

--- a/App/Resources/Exercises/clock-led-waveform.json
+++ b/App/Resources/Exercises/clock-led-waveform.json
@@ -1,0 +1,64 @@
+{
+  "id": "clock-led-waveform",
+  "title": "Clock and LED: Waveform Basics",
+  "description": "Build a minimal Clock–LED circuit and explore the waveform viewer: combinational mode and manual cell editing.",
+  "steps": [
+    {
+      "key": "place-clock",
+      "instruction": "Place a Clock element on the canvas",
+      "hint": "Click the I/O tab on the left panel, then drag the Clock element onto the canvas.",
+      "requiredElements": [
+        { "type": "Clock", "minCount": 1 }
+      ],
+      "requiredConnections": [],
+      "click": ["ioTab"]
+    },
+    {
+      "key": "place-led",
+      "instruction": "Place a LED on the canvas",
+      "hint": "Still in the I/O tab, drag a Led element onto the canvas to the right of the Clock.",
+      "requiredElements": [
+        { "type": "Clock", "minCount": 1 },
+        { "type": "Led",   "minCount": 1 }
+      ],
+      "requiredConnections": []
+    },
+    {
+      "key": "connect-clock-led",
+      "instruction": "Connect the Clock output to the LED input",
+      "hint": "Click and drag from the Clock's output port (right side) to the LED's input port (left side).",
+      "requiredElements": [
+        { "type": "Clock", "minCount": 1 },
+        { "type": "Led",   "minCount": 1 }
+      ],
+      "requiredConnections": [
+        { "fromType": "Clock", "toType": "Led" }
+      ]
+    },
+    {
+      "key": "open-waveform",
+      "instruction": "The waveform viewer is now open — take a look!",
+      "hint": "BeWavedDolphin shows your circuit signals as rows. The Clock row is the input, and the Led row is the output. Each column is one simulation time step.",
+      "context": "bwd",
+      "click": ["actionWaveform"],
+      "requiredElements": [],
+      "requiredConnections": []
+    },
+    {
+      "key": "combinational-mode",
+      "instruction": "Generate all input combinations automatically",
+      "hint": "Click Edit → Combinational in BeWavedDolphin's menu bar. This fills the Clock row with all possible values and computes the LED output for each — a full truth table in one click.",
+      "context": "bwd",
+      "requiredElements": [],
+      "requiredConnections": []
+    },
+    {
+      "key": "toggle-cell",
+      "instruction": "Toggle a Clock cell manually",
+      "hint": "Double-click any cell in the Clock row to flip it between 0 and 1. Watch the Led row update instantly to reflect the new output.",
+      "context": "bwd",
+      "requiredElements": [],
+      "requiredConnections": []
+    }
+  ]
+}

--- a/App/Resources/Tours/README.md
+++ b/App/Resources/Tours/README.md
@@ -1,0 +1,53 @@
+# Tours
+
+A Tour is a guided walkthrough of the UI: a sequence of spotlighted widgets with explanatory
+callouts. Each `.json` file in this folder is one tour; `App/Tour/TourEngine` loads and drives
+it, `App/Tour/TourBrowserDialog` lists all of them for the user to pick from.
+
+For the general authoring workflow (adding a new file, running the translation-catalog
+generator, the `key` field, how translation works, and the three discovery locations — built-in,
+the install-relative/Documents-fallback pair opened by the **"Open My Tours Folder"** button,
+and the AppData folder reserved for teacher/IT provisioning) see
+[`../Exercises/README.md`](../Exercises/README.md) — it's identical for Tours, just with
+"Tours" in place of "Exercises" throughout. This file covers only what's different: the
+Tour-specific schema and the `target` vocabulary.
+
+## Schema
+
+```json
+{
+  "id": "ui-overview",
+  "title": "wiRedPanda Interface Tour",
+  "description": "A guided walkthrough of the main interface — palette, canvas, toolbar, and properties panel.",
+  "steps": [
+    {
+      "key": "logic-gates",
+      "title": "Logic Gates",
+      "body": "The Gates tab contains AND, OR, NOT, NAND, NOR, XOR, and other fundamental logic gates.",
+      "target": "gatesTab",
+      "click": ["gatesTab"]
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Globally unique across **both** `Exercises/` and `Tours/` (see Exercises README). |
+| `title` | string | yes | Shown in the tour browser dialog. |
+| `description` | string | no | Shown below the title in the tour browser dialog. |
+| `steps` | array | yes | At least one step. |
+| `steps[].key` | string | no | Same purpose as in Exercises — translation-catalog key only, unique within this file. |
+| `steps[].title` | string | yes | Callout heading for this step. |
+| `steps[].body` | string | no | Callout body text. |
+| `steps[].target` | string | no | Which widget to spotlight — see "Closed `target` vocabulary" below. Empty string or `"none"` shows a centered callout with the whole window dimmed uniformly, no spotlight. |
+| `steps[].click` | array of strings | no | Same as Exercises — widget/action IDs run before the step is presented. |
+
+### Closed `target` vocabulary
+
+Like `click` (shared with Exercises, see the Exercises README), `target` is a **closed,
+hardcoded** set resolved only by `MainWindow::resolveTourTarget()` (`App/UI/MainWindow.cpp`) —
+not data-driven. Currently valid: `toolbar`, `elementPalette`, `gatesTab`, `ioTab`, `canvasArea`,
+`elementEditor`, `searchBar`, `bwd:tableView`, `bwd:toolbar`, `bwd:menuBar`, plus empty string /
+`"none"` for the centered, un-spotlit callout. A tour step that needs to point at a widget
+outside this list requires a `resolveTourTarget()` code change first.

--- a/App/Resources/Tours/ui-overview.json
+++ b/App/Resources/Tours/ui-overview.json
@@ -1,0 +1,71 @@
+{
+  "id": "ui-overview",
+  "title": "wiRedPanda Interface Tour",
+  "description": "A guided walkthrough of the main interface — palette, canvas, toolbar, and properties panel.",
+  "steps": [
+    {
+      "key": "welcome",
+      "title": "Welcome to wiRedPanda!",
+      "body": "wiRedPanda is a digital logic circuit simulator. You can build circuits by placing components and wiring them together. This tour will show you the main parts of the interface.",
+      "target": ""
+    },
+    {
+      "key": "component-palette",
+      "title": "Component Palette",
+      "body": "This panel lists all available components — logic gates, inputs, outputs, flip-flops, and more. Components are organized by category using the tabs at the top. Click a tab to browse its category.",
+      "target": "elementPalette"
+    },
+    {
+      "key": "logic-gates",
+      "title": "Logic Gates",
+      "body": "The Gates tab contains AND, OR, NOT, NAND, NOR, XOR, and other fundamental logic gates. Drag any gate from this list onto the canvas to add it to your circuit.",
+      "target": "gatesTab",
+      "click": ["gatesTab"]
+    },
+    {
+      "key": "canvas",
+      "title": "The Canvas",
+      "body": "Build your circuit here. Drag components from the palette, then connect them by clicking and dragging from an output port (right side of a component) to an input port (left side of another).",
+      "target": "canvasArea"
+    },
+    {
+      "key": "search-bar",
+      "title": "Search Bar",
+      "body": "Use the search bar to quickly find any component by name. As you type, a filtered list appears below showing matching components across all categories.",
+      "target": "searchBar"
+    },
+    {
+      "key": "element-properties",
+      "title": "Element Properties",
+      "body": "When you select a component on the canvas, its properties appear here. You can set labels, colors, trigger types, and other component-specific settings. Try selecting a placed component to see its options.",
+      "target": "elementEditor",
+      "click": ["setupElementEditorDemo"]
+    },
+    {
+      "key": "waveform-viewer",
+      "title": "Waveform Viewer",
+      "body": "wiRedPanda includes a waveform viewer called BeWavedDolphin. It shows how every signal in your circuit changes over time — inputs as rows at the top, outputs below, with each column representing one simulation time step. Click the highlighted toolbar button to open it.",
+      "target": "toolbar"
+    },
+    {
+      "key": "waveform-table",
+      "title": "Reading the Waveform Table",
+      "body": "The waveform table shows every signal in your circuit. The Clock row is the input; the Led row is the computed output. Each column is one simulation time step — you can see exactly how the output follows the input.",
+      "target": "bwd:tableView",
+      "click": ["setupWaveformDemo", "actionWaveform"]
+    },
+    {
+      "key": "combinational-mode",
+      "title": "Combinational Mode",
+      "body": "The highlighted button (Combinational) was just triggered automatically — it fills the input rows with every possible 0/1 combination, giving you a complete truth table in one click.",
+      "target": "bwd:toolbar",
+      "click": ["bwd:actionCombinational"]
+    },
+    {
+      "key": "editing-cells",
+      "title": "Editing Cells Manually",
+      "body": "You can also edit the waveform by hand. Double-click any cell in the Clock row to flip it between 0 and 1 — the Led row updates instantly to reflect the new output.",
+      "target": "bwd:tableView"
+    }
+  ]
+}

--- a/App/Resources/Translations/ExerciseTour/en.json
+++ b/App/Resources/Translations/ExerciseTour/en.json
@@ -1,0 +1,54 @@
+{
+  "basic-and-gate": {
+    "add-inputs": {
+      "hint": "Click the I/O tab in the left panel, then drag two InputSwitch elements onto the canvas and place them to the left of the AND gate.",
+      "instruction": "Add two InputSwitch elements to the canvas"
+    },
+    "add-output": {
+      "hint": "Drag a Led from the I/O tab and place it to the right of the AND gate. Then connect the AND gate output port (right side) to the LED input port (left side).",
+      "instruction": "Add a LED and connect it to the AND gate output"
+    },
+    "connect-inputs": {
+      "hint": "Click and drag from an InputSwitch output port (right side) to one of the AND gate input ports (left side). Repeat for the second switch.",
+      "instruction": "Connect both input switches to the AND gate"
+    },
+    "description": "Learn to place logic gates, add inputs and outputs, and wire them together.",
+    "place-and-gate": {
+      "hint": "Click the Gates tab in the left panel, then drag the AND gate onto the canvas.",
+      "instruction": "Place an AND gate on the canvas"
+    },
+    "title": "Building an AND Gate Circuit",
+    "toggle-observe": {
+      "hint": "Click an InputSwitch to toggle it. The LED only lights up when BOTH switches are ON. That is because AND outputs 1 only when all inputs are 1.",
+      "instruction": "Toggle the switches and observe the LED — this is AND logic!"
+    }
+  },
+  "clock-led-waveform": {
+    "combinational-mode": {
+      "hint": "Click Edit → Combinational in BeWavedDolphin's menu bar. This fills the Clock row with all possible values and computes the LED output for each — a full truth table in one click.",
+      "instruction": "Generate all input combinations automatically"
+    },
+    "connect-clock-led": {
+      "hint": "Click and drag from the Clock's output port (right side) to the LED's input port (left side).",
+      "instruction": "Connect the Clock output to the LED input"
+    },
+    "description": "Build a minimal Clock–LED circuit and explore the waveform viewer: combinational mode and manual cell editing.",
+    "open-waveform": {
+      "hint": "BeWavedDolphin shows your circuit signals as rows. The Clock row is the input, and the Led row is the output. Each column is one simulation time step.",
+      "instruction": "The waveform viewer is now open — take a look!"
+    },
+    "place-clock": {
+      "hint": "Click the I/O tab on the left panel, then drag the Clock element onto the canvas.",
+      "instruction": "Place a Clock element on the canvas"
+    },
+    "place-led": {
+      "hint": "Still in the I/O tab, drag a Led element onto the canvas to the right of the Clock.",
+      "instruction": "Place a LED on the canvas"
+    },
+    "title": "Clock and LED: Waveform Basics",
+    "toggle-cell": {
+      "hint": "Double-click any cell in the Clock row to flip it between 0 and 1. Watch the Led row update instantly to reflect the new output.",
+      "instruction": "Toggle a Clock cell manually"
+    }
+  }
+}

--- a/App/Resources/Translations/ExerciseTour/en.json
+++ b/App/Resources/Translations/ExerciseTour/en.json
@@ -50,5 +50,49 @@
       "hint": "Double-click any cell in the Clock row to flip it between 0 and 1. Watch the Led row update instantly to reflect the new output.",
       "instruction": "Toggle a Clock cell manually"
     }
+  },
+  "ui-overview": {
+    "canvas": {
+      "body": "Build your circuit here. Drag components from the palette, then connect them by clicking and dragging from an output port (right side of a component) to an input port (left side of another).",
+      "title": "The Canvas"
+    },
+    "combinational-mode": {
+      "body": "The highlighted button (Combinational) was just triggered automatically — it fills the input rows with every possible 0/1 combination, giving you a complete truth table in one click.",
+      "title": "Combinational Mode"
+    },
+    "component-palette": {
+      "body": "This panel lists all available components — logic gates, inputs, outputs, flip-flops, and more. Components are organized by category using the tabs at the top. Click a tab to browse its category.",
+      "title": "Component Palette"
+    },
+    "description": "A guided walkthrough of the main interface — palette, canvas, toolbar, and properties panel.",
+    "editing-cells": {
+      "body": "You can also edit the waveform by hand. Double-click any cell in the Clock row to flip it between 0 and 1 — the Led row updates instantly to reflect the new output.",
+      "title": "Editing Cells Manually"
+    },
+    "element-properties": {
+      "body": "When you select a component on the canvas, its properties appear here. You can set labels, colors, trigger types, and other component-specific settings. Try selecting a placed component to see its options.",
+      "title": "Element Properties"
+    },
+    "logic-gates": {
+      "body": "The Gates tab contains AND, OR, NOT, NAND, NOR, XOR, and other fundamental logic gates. Drag any gate from this list onto the canvas to add it to your circuit.",
+      "title": "Logic Gates"
+    },
+    "search-bar": {
+      "body": "Use the search bar to quickly find any component by name. As you type, a filtered list appears below showing matching components across all categories.",
+      "title": "Search Bar"
+    },
+    "title": "wiRedPanda Interface Tour",
+    "waveform-table": {
+      "body": "The waveform table shows every signal in your circuit. The Clock row is the input; the Led row is the computed output. Each column is one simulation time step — you can see exactly how the output follows the input.",
+      "title": "Reading the Waveform Table"
+    },
+    "waveform-viewer": {
+      "body": "wiRedPanda includes a waveform viewer called BeWavedDolphin. It shows how every signal in your circuit changes over time — inputs as rows at the top, outputs below, with each column representing one simulation time step. Click the highlighted toolbar button to open it.",
+      "title": "Waveform Viewer"
+    },
+    "welcome": {
+      "body": "wiRedPanda is a digital logic circuit simulator. You can build circuits by placing components and wiring them together. This tour will show you the main parts of the interface.",
+      "title": "Welcome to wiRedPanda!"
+    }
   }
 }

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -18,6 +18,7 @@
 #include "App/Core/Settings.h"
 #include "App/Element/GraphicElement.h"
 #include "App/Element/IC.h"
+#include "App/Exercise/ExerciseOverlay.h"
 #include "App/IO/FileUtils.h"
 #include "App/IO/Serialization.h"
 #include "App/IO/SerializationContext.h"
@@ -762,4 +763,17 @@ void WorkSpace::setCurrentFile(const QString &filePath)
 {
     m_fileInfo = QFileInfo(filePath);
     m_scene.setContextDir(m_fileInfo.absolutePath());
+}
+
+void WorkSpace::setExerciseOverlay(ExerciseOverlay *overlay)
+{
+    m_exerciseOverlay = overlay;
+}
+
+void WorkSpace::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    if (m_exerciseOverlay && m_exerciseOverlay->isVisible()) {
+        m_exerciseOverlay->repositionToParent();
+    }
 }

--- a/App/Scene/Workspace.h
+++ b/App/Scene/Workspace.h
@@ -15,6 +15,7 @@
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Scene.h"
 
+class ExerciseOverlay;
 class GraphicsView;
 class Simulation;
 
@@ -128,6 +129,13 @@ public:
      */
     void setLastId(int newLastId);
 
+    /// Registers an exercise overlay so WorkSpace can reposition it on resize.
+    /// Pass nullptr to detach. Does not take ownership.
+    void setExerciseOverlay(ExerciseOverlay *overlay);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
 signals:
     /**
      * \brief Emitted whenever the file info of this workspace changes (load/save).
@@ -168,4 +176,7 @@ private:
     QPointer<WorkSpace> m_parentWorkspace;
     int m_parentICElementId = -1;
     QString m_inlineBlobName;
+
+    // Exercise overlay — non-owning pointer
+    ExerciseOverlay *m_exerciseOverlay = nullptr;
 };

--- a/App/Tour/TourBrowserDialog.cpp
+++ b/App/Tour/TourBrowserDialog.cpp
@@ -1,0 +1,82 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Tour/TourBrowserDialog.h"
+
+#include <QDesktopServices>
+#include <QIcon>
+#include <QListWidgetItem>
+#include <QMessageBox>
+#include <QStyle>
+#include <QUrl>
+
+#include "App/Core/Settings.h"
+#include "App/Core/ExerciseTourResources.h"
+
+TourBrowserDialog::TourBrowserDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_ui(std::make_unique<TourBrowserDialogUi>())
+{
+    m_ui->setupUi(this);
+    populateList();
+
+    connect(m_ui->tourList, &QListWidget::itemSelectionChanged,
+            this, &TourBrowserDialog::onSelectionChanged);
+    connect(m_ui->tourList, &QListWidget::itemDoubleClicked,
+            this, [this] {
+                if (m_ui->startButton->isEnabled()) {
+                    accept();
+                }
+            });
+    connect(m_ui->openFolderButton, &QPushButton::clicked, this, [this] {
+        const QString dir = ExerciseTourResources::preferredContentDir(QStringLiteral("Tours"));
+        if (dir.isEmpty()) {
+            QMessageBox::warning(this, windowTitle(),
+                tr("Could not create or access a folder for custom tours."));
+            return;
+        }
+        QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
+    });
+
+#ifdef Q_OS_WASM
+    m_ui->openFolderButton->setVisible(false);
+#endif
+}
+
+TourBrowserDialog::~TourBrowserDialog() = default;
+
+QString TourBrowserDialog::selectedTourPath() const
+{
+    return m_selectedPath;
+}
+
+void TourBrowserDialog::populateList()
+{
+    const QStringList completed = Settings::completedTours();
+    const QIcon checkIcon  = style()->standardIcon(QStyle::SP_DialogApplyButton);
+    const QIcon circleIcon = style()->standardIcon(QStyle::SP_ArrowRight);
+
+    for (const ExerciseTourResourceEntry &entry : ExerciseTourResources::discover(QStringLiteral("Tours"))) {
+        auto *item = new QListWidgetItem(m_ui->tourList);
+        item->setText(ExerciseTourResources::translate(entry.id + QStringLiteral(".title"), entry.title));
+        item->setData(Qt::UserRole,     entry.path);
+        item->setData(Qt::UserRole + 1, ExerciseTourResources::translate(entry.id + QStringLiteral(".description"), entry.description));
+        item->setIcon(completed.contains(entry.id) ? checkIcon : circleIcon);
+    }
+}
+
+void TourBrowserDialog::onSelectionChanged()
+{
+    const QList<QListWidgetItem *> sel = m_ui->tourList->selectedItems();
+    const bool hasSelection = !sel.isEmpty();
+
+    m_ui->startButton->setEnabled(hasSelection);
+
+    if (hasSelection) {
+        m_selectedPath = sel.first()->data(Qt::UserRole).toString();
+        m_ui->descriptionLabel->setText(sel.first()->data(Qt::UserRole + 1).toString());
+    } else {
+        m_selectedPath.clear();
+        m_ui->descriptionLabel->clear();
+    }
+}

--- a/App/Tour/TourBrowserDialog.h
+++ b/App/Tour/TourBrowserDialog.h
@@ -1,0 +1,31 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <QDialog>
+#include <QString>
+
+#include "App/Tour/TourBrowserDialogUI.h"
+
+/// Dialog for browsing and launching available guided tours.
+class TourBrowserDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TourBrowserDialog(QWidget *parent = nullptr);
+    ~TourBrowserDialog() override;
+
+    /// Returns the resource path of the selected tour, or empty if cancelled.
+    QString selectedTourPath() const;
+
+private:
+    void populateList();
+    void onSelectionChanged();
+
+    std::unique_ptr<TourBrowserDialogUi> m_ui;
+    QString m_selectedPath;
+};

--- a/App/Tour/TourBrowserDialogUI.cpp
+++ b/App/Tour/TourBrowserDialogUI.cpp
@@ -1,0 +1,51 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Tour/TourBrowserDialogUI.h"
+
+void TourBrowserDialogUi::setupUi(QDialog *dialog)
+{
+    dialog->resize(420, 300);
+
+    auto *mainLayout = new QVBoxLayout(dialog);
+    mainLayout->setContentsMargins(12, 12, 12, 12);
+    mainLayout->setSpacing(8);
+
+    titleLabel = new QLabel(dialog);
+    QFont titleFont = titleLabel->font();
+    titleFont.setPointSize(titleFont.pointSize() + 2);
+    titleFont.setBold(true);
+    titleLabel->setFont(titleFont);
+    mainLayout->addWidget(titleLabel);
+
+    tourList = new QListWidget(dialog);
+    tourList->setSelectionMode(QAbstractItemView::SingleSelection);
+    mainLayout->addWidget(tourList, 1);
+
+    descriptionLabel = new QLabel(dialog);
+    descriptionLabel->setWordWrap(true);
+    descriptionLabel->setStyleSheet("color: gray; font-size: 11px;");
+    mainLayout->addWidget(descriptionLabel);
+
+    buttonBox = new QDialogButtonBox(dialog);
+    openFolderButton = new QPushButton(dialog);
+    buttonBox->addButton(openFolderButton, QDialogButtonBox::ActionRole);
+    startButton = new QPushButton(dialog);
+    startButton->setEnabled(false);
+    buttonBox->addButton(startButton, QDialogButtonBox::AcceptRole);
+    buttonBox->addButton(QDialogButtonBox::Close);
+    mainLayout->addWidget(buttonBox);
+
+    retranslateUi(dialog);
+
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
+}
+
+void TourBrowserDialogUi::retranslateUi(QDialog *dialog)
+{
+    dialog->setWindowTitle(QCoreApplication::translate("TourBrowserDialog", "Interactive Tours"));
+    titleLabel->setText(QCoreApplication::translate("TourBrowserDialog", "Choose a Tour"));
+    startButton->setText(QCoreApplication::translate("TourBrowserDialog", "Start"));
+    openFolderButton->setText(QCoreApplication::translate("TourBrowserDialog", "Open My Tours Folder"));
+}

--- a/App/Tour/TourBrowserDialogUI.h
+++ b/App/Tour/TourBrowserDialogUI.h
@@ -1,0 +1,30 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+class TourBrowserDialogUi
+{
+public:
+    TourBrowserDialogUi() = default;
+    TourBrowserDialogUi(const TourBrowserDialogUi &) = delete;
+    TourBrowserDialogUi &operator=(const TourBrowserDialogUi &) = delete;
+
+    void setupUi(QDialog *dialog);
+    void retranslateUi(QDialog *dialog);
+
+    QLabel          *titleLabel       = nullptr;
+    QListWidget     *tourList         = nullptr;
+    QLabel          *descriptionLabel = nullptr;
+    QDialogButtonBox *buttonBox       = nullptr;
+    QPushButton     *startButton      = nullptr;
+    QPushButton     *openFolderButton = nullptr;
+};

--- a/App/Tour/TourEngine.cpp
+++ b/App/Tour/TourEngine.cpp
@@ -1,0 +1,149 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Tour/TourEngine.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "App/Core/Settings.h"
+#include "App/Core/ExerciseTourResources.h"
+
+TourEngine::TourEngine(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool TourEngine::loadFromResource(const QString &resourcePath)
+{
+    m_active = false;
+    m_steps.clear();
+    m_currentStep = 0;
+    m_id.clear();
+    m_title.clear();
+
+    QFile file(resourcePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isNull() || !doc.isObject()) {
+        return false;
+    }
+
+    const QJsonObject root = doc.object();
+    m_id = root.value("id").toString();
+    const QString rawTitle = root.value("title").toString();
+
+    if (m_id.isEmpty() || rawTitle.isEmpty()) {
+        return false;
+    }
+
+    m_title = ExerciseTourResources::translate(m_id + QStringLiteral(".title"), rawTitle);
+
+    const QJsonArray stepsArray = root.value("steps").toArray();
+    if (stepsArray.isEmpty()) {
+        return false;
+    }
+
+    for (const QJsonValue &stepVal : stepsArray) {
+        const QJsonObject stepObj = stepVal.toObject();
+        TourStep step;
+
+        const QString stepKey = stepObj.value("key").toString();
+        const QString rawStepTitle = stepObj.value("title").toString();
+        const QString rawBody      = stepObj.value("body").toString();
+
+        if (stepKey.isEmpty()) {
+            step.title = rawStepTitle;
+            step.body  = rawBody;
+        } else {
+            const QString keyPrefix = m_id + QLatin1Char('.') + stepKey + QLatin1Char('.');
+            step.title = ExerciseTourResources::translate(keyPrefix + QStringLiteral("title"), rawStepTitle);
+            step.body  = ExerciseTourResources::translate(keyPrefix + QStringLiteral("body"), rawBody);
+        }
+
+        step.target = stepObj.value("target").toString();
+        step.click  = stepObj.value("click").toVariant().toStringList();
+        m_steps.append(step);
+    }
+
+    return true;
+}
+
+const TourStep &TourEngine::currentStepData() const
+{
+    static TourStep empty;
+    if (m_steps.isEmpty() || m_currentStep < 0 || m_currentStep >= m_steps.size()) {
+        return empty;
+    }
+    return m_steps.at(m_currentStep);
+}
+
+void TourEngine::start()
+{
+    if (m_steps.isEmpty()) {
+        return;
+    }
+    m_currentStep = Settings::tourProgress(m_id);
+    if (m_currentStep < 0 || m_currentStep >= m_steps.size()) {
+        m_currentStep = 0;
+    }
+    m_active = true;
+    emitCurrentStep();
+}
+
+void TourEngine::stop()
+{
+    if (!m_active) {
+        return;
+    }
+    m_active = false;
+    emit tourStopped();
+}
+
+void TourEngine::goToPreviousStep()
+{
+    if (!m_active || m_currentStep <= 0) {
+        return;
+    }
+    --m_currentStep;
+    Settings::setTourProgress(m_id, m_currentStep);
+    emitCurrentStep();
+}
+
+void TourEngine::advanceStep()
+{
+    if (!m_active || m_steps.isEmpty()) {
+        return;
+    }
+    if (m_currentStep >= m_steps.size() - 1) {
+        markCompleted();
+        return;
+    }
+    ++m_currentStep;
+    Settings::setTourProgress(m_id, m_currentStep);
+    emitCurrentStep();
+}
+
+void TourEngine::emitCurrentStep()
+{
+    emit stepChanged(m_currentStep, static_cast<int>(m_steps.size()), currentStepData());
+}
+
+void TourEngine::markCompleted()
+{
+    m_active = false;
+
+    QStringList completed = Settings::completedTours();
+    if (!completed.contains(m_id)) {
+        completed.append(m_id);
+        Settings::setCompletedTours(completed);
+    }
+    Settings::setTourProgress(m_id, 0);
+
+    emit tourCompleted();
+}

--- a/App/Tour/TourEngine.h
+++ b/App/Tour/TourEngine.h
@@ -1,0 +1,51 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QVector>
+
+#include "App/Tour/TourStep.h"
+
+class TourEngine : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit TourEngine(QObject *parent = nullptr);
+
+    /// Loads a tour from a Qt resource path (e.g. ":/Tours/ui-overview.json").
+    /// Returns false and leaves the engine inactive if the resource is missing or malformed.
+    bool loadFromResource(const QString &resourcePath);
+
+    QString tourId()    const { return m_id; }
+    QString tourTitle() const { return m_title; }
+
+    int  currentStep() const { return m_currentStep; }
+    int  totalSteps()  const { return static_cast<int>(m_steps.size()); }
+    bool isActive()    const { return m_active; }
+
+    /// Returns the data for the current step.
+    const TourStep &currentStepData() const;
+
+    void start();
+    void stop();
+    void goToPreviousStep();
+    void advanceStep();
+
+signals:
+    void stepChanged(int step, int total, const TourStep &data);
+    void tourCompleted();
+    void tourStopped();
+
+private:
+    void emitCurrentStep();
+    void markCompleted();
+
+    QString           m_id;
+    QString           m_title;
+    QVector<TourStep> m_steps;
+    int               m_currentStep = 0;
+    bool              m_active = false;
+};

--- a/App/Tour/TourOverlay.cpp
+++ b/App/Tour/TourOverlay.cpp
@@ -1,0 +1,288 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Tour/TourOverlay.h"
+
+#include <QEvent>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "App/Core/ThemeManager.h"
+#include "App/Tour/TourEngine.h"
+
+static constexpr int kCalloutWidth   = 360;
+static constexpr int kSpotlightPad   = 6;
+static constexpr int kCalloutMargin  = 12;
+
+TourOverlay::TourOverlay(TourEngine *engine, QWidget *parent)
+    : QWidget(parent)
+    , m_engine(engine)
+{
+    // Cover the entire parent from the start
+    if (parent) {
+        resize(parent->size());
+        parent->installEventFilter(this);
+    }
+
+    setupUi();
+
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged, this, &TourOverlay::applyTheme);
+}
+
+void TourOverlay::setTargetResolver(TargetResolver resolver)
+{
+    m_resolver = std::move(resolver);
+}
+
+void TourOverlay::setParentWindow(QWidget *newParent)
+{
+    if (parentWidget()) {
+        parentWidget()->removeEventFilter(this);
+    }
+    setParent(newParent);
+    if (newParent) {
+        resize(newParent->size());
+        newParent->installEventFilter(this);
+    }
+}
+
+void TourOverlay::setupUi()
+{
+    // --- Callout panel ---
+    m_callout = new QFrame(this);
+    m_callout->setFixedWidth(kCalloutWidth);
+
+    auto *layout = new QVBoxLayout(m_callout);
+    layout->setContentsMargins(14, 14, 14, 14);
+    layout->setSpacing(8);
+
+    // Top row: step counter
+    auto *topRow = new QHBoxLayout;
+    m_stepCounter = new QLabel(m_callout);
+    topRow->addWidget(m_stepCounter);
+    topRow->addStretch();
+    layout->addLayout(topRow);
+
+    m_titleLabel = new QLabel(m_callout);
+    m_titleLabel->setWordWrap(true);
+    layout->addWidget(m_titleLabel);
+
+    m_bodyLabel = new QLabel(m_callout);
+    m_bodyLabel->setWordWrap(true);
+    layout->addWidget(m_bodyLabel);
+
+    // Navigation row: [Exit] [← Back] ←stretch→ [Next →]
+    auto *btnRow = new QHBoxLayout;
+    btnRow->setSpacing(6);
+
+    m_closeButton = new QPushButton(tr("Exit"), m_callout);
+    m_closeButton->setToolTip(tr("Stop the tour"));
+
+    m_prevButton = new QPushButton(tr("← Back"), m_callout);
+
+    m_nextButton = new QPushButton(tr("Next →"), m_callout);
+
+    btnRow->addWidget(m_closeButton);
+    btnRow->addWidget(m_prevButton);
+    btnRow->addStretch();
+    btnRow->addWidget(m_nextButton);
+    layout->addLayout(btnRow);
+
+    m_callout->adjustSize();
+
+    connect(m_closeButton, &QPushButton::clicked, this, &TourOverlay::closeRequested);
+    connect(m_prevButton,  &QPushButton::clicked, this, [this] { m_engine->goToPreviousStep(); });
+    connect(m_nextButton,  &QPushButton::clicked, this, [this] { m_engine->advanceStep(); });
+
+    applyTheme();
+}
+
+void TourOverlay::applyTheme()
+{
+    const bool dark = (ThemeManager::effectiveTheme() == Theme::Dark);
+
+    if (dark) {
+        m_dimColor       = QColor(0, 0, 0, 160);
+        m_spotlightColor = QColor(255, 200, 50, 220);
+
+        m_callout->setStyleSheet(
+            "QFrame {"
+            "  background: rgba(20,20,20,240);"
+            "  border: 1px solid rgba(255,200,50,120);"
+            "  border-radius: 8px;"
+            "}"
+            "QLabel { background: transparent; border: none; }"
+            "QPushButton { border-radius: 4px; padding: 4px 12px; font-size: 13px; }"
+        );
+        m_stepCounter->setStyleSheet("color: rgba(255,200,50,200); font-size: 12px;");
+        m_titleLabel->setStyleSheet("color: white; font-size: 16px; font-weight: bold;");
+        m_bodyLabel->setStyleSheet("color: rgba(220,220,220,230); font-size: 14px;");
+
+        const QString navStyle =
+            "QPushButton { color: white; background: rgba(255,255,255,40);"
+            " border: 1px solid rgba(255,255,255,80); border-radius: 4px;"
+            " padding: 4px 12px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(255,255,255,60); }"
+            "QPushButton:disabled { color: rgba(255,255,255,80); background: rgba(80,80,80,60); }";
+        m_closeButton->setStyleSheet(navStyle);
+        m_prevButton->setStyleSheet(navStyle);
+        m_nextButton->setStyleSheet(
+            "QPushButton { color: white; background: rgba(255,160,20,200);"
+            " border: 1px solid rgba(255,200,50,150); border-radius: 4px;"
+            " padding: 4px 12px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(255,180,40,230); }");
+    } else {
+        m_dimColor       = QColor(0, 0, 0, 90);
+        m_spotlightColor = QColor(0, 120, 210, 220);
+
+        m_callout->setStyleSheet(
+            "QFrame {"
+            "  background: rgba(255,255,255,240);"
+            "  border: 1px solid rgba(0,100,200,150);"
+            "  border-radius: 8px;"
+            "}"
+            "QLabel { background: transparent; border: none; }"
+            "QPushButton { border-radius: 4px; padding: 4px 12px; font-size: 13px; }"
+        );
+        m_stepCounter->setStyleSheet("color: rgba(0,100,200,200); font-size: 12px;");
+        m_titleLabel->setStyleSheet("color: rgb(20,20,20); font-size: 16px; font-weight: bold;");
+        m_bodyLabel->setStyleSheet("color: rgba(50,50,50,230); font-size: 14px;");
+
+        const QString navStyle =
+            "QPushButton { color: rgb(20,20,20); background: rgba(0,0,0,20);"
+            " border: 1px solid rgba(0,0,0,80); border-radius: 4px;"
+            " padding: 4px 12px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(0,0,0,40); }"
+            "QPushButton:disabled { color: rgba(0,0,0,60); background: rgba(0,0,0,10); }";
+        m_closeButton->setStyleSheet(navStyle);
+        m_prevButton->setStyleSheet(navStyle);
+        m_nextButton->setStyleSheet(
+            "QPushButton { color: white; background: rgba(0,120,210,200);"
+            " border: 1px solid rgba(0,100,200,150); border-radius: 4px;"
+            " padding: 4px 12px; font-size: 13px; }"
+            "QPushButton:hover { background: rgba(0,140,230,230); }");
+    }
+
+    update();
+}
+
+bool TourOverlay::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == parentWidget() && event->type() == QEvent::Resize) {
+        resize(parentWidget()->size());
+        repositionCallout();
+    }
+    return QWidget::eventFilter(obj, event);
+}
+
+void TourOverlay::onStepChanged(int step, int total, const TourStep &stepData)
+{
+    m_callout->hide();
+
+    m_stepCounter->setText(tr("Step %1 of %2").arg(step + 1).arg(total));
+    m_titleLabel->setText(stepData.title);
+    m_bodyLabel->setText(stepData.body);
+
+    m_prevButton->setEnabled(step > 0);
+    m_nextButton->setText(step == total - 1 ? tr("Finish") : tr("Next →"));
+
+    m_currentTarget = stepData.target;
+    m_highlightRect = QRect{};
+    if (m_resolver && !stepData.target.isEmpty() && stepData.target != "none") {
+        m_highlightRect = m_resolver(stepData.target);
+    }
+
+    m_callout->adjustSize();
+    repositionCallout();
+    // Use update() (deferred) instead of repaint() (synchronous) so that all
+    // pending QEvent::LayoutRequest events are processed before paintEvent
+    // re-resolves the spotlight geometry.
+    update();
+    m_callout->show();
+}
+
+void TourOverlay::onTourFinished()
+{
+    hide();
+    emit closeRequested();
+}
+
+void TourOverlay::repositionCallout()
+{
+    const int pad = kCalloutMargin;
+    const int cw  = m_callout->width();
+    const int ch  = m_callout->height();
+    const int ow  = width();
+    const int oh  = height();
+
+    if (m_highlightRect.isEmpty()) {
+        // Center the callout in the overlay
+        m_callout->move((ow - cw) / 2, (oh - ch) / 2);
+        return;
+    }
+
+    const QRect spot = m_highlightRect.adjusted(-kSpotlightPad, -kSpotlightPad,
+                                                 kSpotlightPad, kSpotlightPad);
+
+    // Try below the spotlight
+    int cx = qBound(pad, spot.left() + (spot.width() - cw) / 2, ow - cw - pad);
+    int cy = spot.bottom() + pad;
+
+    if (cy + ch + pad > oh) {
+        // Not enough room below — try above
+        cy = spot.top() - ch - pad;
+    }
+
+    if (cy < pad) {
+        // No room above either — center vertically, shift right of spotlight
+        cy = (oh - ch) / 2;
+        cx = qMin(spot.right() + pad, ow - cw - pad);
+        if (cx + cw + pad > ow) {
+            cx = qMax(pad, spot.left() - cw - pad);
+        }
+    }
+
+    m_callout->move(cx, qBound(pad, cy, oh - ch - pad));
+}
+
+void TourOverlay::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+
+    // Re-resolve at paint time: Qt guarantees all QEvent::LayoutRequest events
+    // are processed before paintEvent fires, so the geometry is always settled.
+    if (m_resolver && !m_currentTarget.isEmpty() && m_currentTarget != "none") {
+        const QRect liveRect = m_resolver(m_currentTarget);
+        if (liveRect != m_highlightRect) {
+            m_highlightRect = liveRect;
+            repositionCallout();
+        }
+    }
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    if (m_highlightRect.isEmpty()) {
+        p.fillRect(rect(), m_dimColor);
+        return;
+    }
+
+    const QRect spot = m_highlightRect.adjusted(-kSpotlightPad, -kSpotlightPad,
+                                                 kSpotlightPad, kSpotlightPad);
+
+    QPainterPath full;
+    full.addRect(rect());
+    QPainterPath hole;
+    hole.addRoundedRect(spot, 6, 6);
+    p.fillPath(full.subtracted(hole), m_dimColor);
+
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(m_spotlightColor, 2));
+    p.drawRoundedRect(spot, 6, 6);
+}

--- a/App/Tour/TourOverlay.h
+++ b/App/Tour/TourOverlay.h
@@ -1,0 +1,72 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <functional>
+
+#include <QRect>
+#include <QWidget>
+
+class QFrame;
+
+#include "App/Tour/TourStep.h"
+
+class QLabel;
+class QPushButton;
+class TourEngine;
+
+/// Full-window overlay for the guided interface tour.
+///
+/// Dims the entire centralWidget area and punches a spotlight hole over the
+/// target widget.  A floating callout panel shows the step title, body text,
+/// and Prev/Next navigation buttons.
+class TourOverlay : public QWidget
+{
+    Q_OBJECT
+
+public:
+    using TargetResolver = std::function<QRect(const QString &targetId)>;
+
+    explicit TourOverlay(TourEngine *engine, QWidget *parent = nullptr);
+
+    /// Registers a callback that maps a target-id string to a highlight rect
+    /// in the overlay's local coordinate space.  Called once after construction.
+    void setTargetResolver(TargetResolver resolver);
+
+    /// Re-parents the overlay to \a newParent and reinstalls the resize event filter.
+    void setParentWindow(QWidget *newParent);
+
+public slots:
+    void onStepChanged(int step, int total, const TourStep &stepData);
+    void onTourFinished();
+
+signals:
+    void closeRequested();
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private:
+    void setupUi();
+    void repositionCallout();
+
+    TourEngine     *m_engine          = nullptr;
+    TargetResolver  m_resolver;
+    QString         m_currentTarget;
+    QRect           m_highlightRect;
+    QColor          m_dimColor;
+    QColor          m_spotlightColor;
+
+    // Callout panel (child of this overlay)
+    QFrame      *m_callout        = nullptr;
+    QLabel      *m_stepCounter    = nullptr;
+    QLabel      *m_titleLabel     = nullptr;
+    QLabel      *m_bodyLabel      = nullptr;
+    QPushButton *m_prevButton     = nullptr;
+    QPushButton *m_nextButton     = nullptr;
+    QPushButton *m_closeButton    = nullptr;
+
+    void applyTheme();
+};

--- a/App/Tour/TourStep.h
+++ b/App/Tour/TourStep.h
@@ -1,0 +1,20 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+/// One step in a guided interface tour.
+/// \a target is a string key resolved by MainWindow::resolveTourTarget() to
+/// the widget that should be spotlighted.  An empty or "none" target shows
+/// a centered callout with the whole window dimmed uniformly.
+///
+/// \a click lists widget/action IDs handled by MainWindow before the spotlight is painted.
+struct TourStep {
+    QString title;
+    QString body;
+    QString target;
+    QStringList click;  ///< Widget/action IDs to activate on step enter.
+};

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include <QPixmapCache>
 #include <QPushButton>
 #include <QShortcut>
+#include <QTabBar>
 
 #ifdef Q_OS_MAC
 #include <QSvgRenderer>
@@ -47,6 +48,9 @@
 #include "App/Scene/ICRegistry.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
+#include "App/Tour/TourBrowserDialog.h"
+#include "App/Tour/TourEngine.h"
+#include "App/Tour/TourOverlay.h"
 #include "App/UI/ElementPalette.h"
 #include "App/UI/ExportController.h"
 #include "App/UI/ICController.h"
@@ -56,6 +60,7 @@
 #include "App/UI/UpdateController.h"
 #include "App/UI/WorkspaceManager.h"
 #include "App/Versions.h"
+#include "App/Wiring/Connection.h"
 
 #ifdef Q_OS_MAC
 void ensureSvgUsage() {
@@ -116,6 +121,7 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
     setupConnections();
 
     m_exerciseEngine = new ExerciseEngine(this);
+    m_tourEngine     = new TourEngine(this);
 
     qCDebug(zero) << "Checking playing simulation.";
     // Start simulation running by default so the circuit is live on open.
@@ -269,6 +275,7 @@ void MainWindow::setupConnections()
     connect(m_ui->tab, &QTabWidget::tabCloseRequested, m_workspaceManager, &WorkspaceManager::closeTab);
 
     connect(m_ui->actionExercises,             &QAction::triggered,       this,                &MainWindow::on_actionExercises_triggered);
+    connect(m_ui->actionTours,                 &QAction::triggered,       this,                &MainWindow::on_actionTours_triggered);
     connect(m_ui->actionAbout,                 &QAction::triggered,       this,                &MainWindow::on_actionAbout_triggered);
     connect(m_ui->actionAboutQt,               &QAction::triggered,       this,                &MainWindow::on_actionAboutQt_triggered);
     connect(m_ui->actionAboutThisVersion,      &QAction::triggered,       this,                &MainWindow::aboutThisVersion);
@@ -1173,6 +1180,125 @@ void MainWindow::startExercise(const QString &resourcePath)
     m_exerciseOverlay->raise();
 }
 
+void MainWindow::on_actionTours_triggered()
+{
+    TourBrowserDialog dialog(this);
+    if (dialog.exec() == QDialog::Accepted) {
+        startTour(dialog.selectedTourPath());
+    }
+}
+
+void MainWindow::startTour(const QString &resourcePath)
+{
+    if (resourcePath.isEmpty()) {
+        return;
+    }
+    if (!m_tourEngine->loadFromResource(resourcePath)) {
+        qWarning() << "TourEngine: failed to load" << resourcePath;
+        return;
+    }
+
+    delete m_tourOverlay;
+    m_tourOverlay = new TourOverlay(m_tourEngine, this);
+    m_tourOverlay->setTargetResolver([this](const QString &id) {
+        return resolveTourTarget(id);
+    });
+
+    // Must be connected before stepChanged→onStepChanged so click executes before
+    // resolveTourTarget computes widget rects.
+    connect(m_tourEngine, &TourEngine::stepChanged, this,
+            [this](int, int, const TourStep &step) {
+        for (const QString &id : step.click) clickTarget(id);
+
+        TourOverlay *overlay = m_tourOverlay;
+        if (!overlay) {
+            return;
+        }
+        const bool wantBwd = step.target.startsWith("bwd:");
+        if (wantBwd && m_bwd) {
+            if (overlay->parentWidget() != m_bwd) {
+                overlay->setParentWindow(m_bwd);
+            }
+            overlay->show();
+            overlay->raise();
+        } else if (!wantBwd && overlay->parentWidget() != this) {
+            overlay->setParentWindow(this);
+            overlay->show();
+            overlay->raise();
+        }
+    });
+    connect(m_tourEngine, &TourEngine::stepChanged,
+            m_tourOverlay, &TourOverlay::onStepChanged);
+    connect(m_tourEngine, &TourEngine::tourCompleted,
+            m_tourOverlay, &TourOverlay::onTourFinished);
+    connect(m_tourEngine, &TourEngine::tourStopped,
+            m_tourOverlay, &TourOverlay::onTourFinished);
+    connect(m_tourOverlay, &TourOverlay::closeRequested, this, [this] {
+        if (!m_tourOverlay) return;
+        TourOverlay *overlay = m_tourOverlay;
+        m_tourOverlay = nullptr;
+        m_tourEngine->stop();
+        overlay->deleteLater();
+    });
+
+    auto *esc = new QShortcut(QKeySequence(Qt::Key_Escape), m_tourOverlay);
+    connect(esc, &QShortcut::activated, m_tourOverlay, &TourOverlay::closeRequested);
+
+    m_tourEngine->start();
+
+    m_tourOverlay->show();
+    m_tourOverlay->raise();
+}
+
+QRect MainWindow::resolveTourTarget(const QString &id) const
+{
+    if (!m_tourOverlay || id.isEmpty() || id == "none") {
+        return {};
+    }
+
+    auto mapWidget = [this](QWidget *w) -> QRect {
+        if (!w) return {};
+        const QPoint topLeft = m_tourOverlay->mapFromGlobal(w->mapToGlobal(QPoint(0, 0)));
+        return QRect(topLeft, w->size());
+    };
+
+    if (id == "toolbar")        return mapWidget(m_ui->mainToolBar->widgetForAction(m_ui->actionWaveform));
+    if (id == "elementPalette") return mapWidget(m_ui->tabElements);
+    if (id == "gatesTab") {
+        QTabBar *bar = m_ui->tabElements->tabBar();
+        const QRect tabRect = bar->tabRect(1);
+        const QPoint topLeft = m_tourOverlay->mapFromGlobal(bar->mapToGlobal(tabRect.topLeft()));
+        return QRect(topLeft, tabRect.size());
+    }
+    if (id == "ioTab") {
+        QTabBar *bar = m_ui->tabElements->tabBar();
+        const QRect tabRect = bar->tabRect(0);
+        const QPoint topLeft = m_tourOverlay->mapFromGlobal(bar->mapToGlobal(tabRect.topLeft()));
+        return QRect(topLeft, tabRect.size());
+    }
+    if (id == "canvasArea" && currentTab()) return mapWidget(currentTab()->view());
+    if (id == "elementEditor")  return mapWidget(m_ui->elementEditor);
+    if (id == "searchBar")      return mapWidget(m_ui->lineEditSearch);
+
+    BewavedDolphin *bwd = m_bwd;
+    if (id.startsWith("bwd:") && bwd) {
+        auto mapBwd = [this](QWidget *w) -> QRect {
+            if (!w || !m_tourOverlay) {
+                return {};
+            }
+            const QPoint tl = m_tourOverlay->mapFromGlobal(w->mapToGlobal(QPoint(0, 0)));
+            return QRect(tl, w->size());
+        };
+        const QString sub = id.sliced(4);
+        if (sub == "tableView") return mapBwd(bwd->signalTableView());
+        if (sub == "toolbar")   return mapBwd(bwd->mainToolBar()->widgetForAction(bwd->actionCombinational()));
+        if (sub == "menuBar")   return mapBwd(bwd->menuBar());
+        return {};
+    }
+
+    return {};
+}
+
 void MainWindow::clickTarget(const QString &id)
 {
     if      (id == "ioTab")          m_ui->tabElements->setCurrentIndex(0);
@@ -1181,4 +1307,50 @@ void MainWindow::clickTarget(const QString &id)
     else if (id == "memoryTab")      m_ui->tabElements->setCurrentIndex(3);
     else if (id == "actionPlay")     m_ui->actionPlay->trigger();
     else if (id == "actionWaveform") m_ui->actionWaveform->trigger();
+    else if (id == "bwd:actionCombinational" && m_bwd) m_bwd->triggerCombinational();
+    else if (id == "setupElementEditorDemo") {
+        if (!currentTab()) {
+            return;
+        }
+        Scene *scene = currentTab()->scene();
+        scene->clearSelection();
+        auto *sw = ElementFactory::buildElement(ElementType::InputSwitch);
+        sw->setPos(0, 0);
+        scene->addItem(sw);
+        sw->setSelected(true);
+    }
+    else if (id == "setupWaveformDemo") {
+        if (!currentTab()) {
+            return;
+        }
+        Scene *scene = currentTab()->scene();
+        scene->clearSelection();
+        auto *clock1 = ElementFactory::buildElement(ElementType::Clock);
+        auto *clock2 = ElementFactory::buildElement(ElementType::Clock);
+        auto *gate   = ElementFactory::buildElement(ElementType::And);
+        auto *led    = ElementFactory::buildElement(ElementType::Led);
+        clock1->setPos(-160, -60);
+        clock2->setPos(-160,  60);
+        gate->setPos(0, 0);
+        led->setPos(160, 0);
+        scene->addItem(clock1);
+        scene->addItem(clock2);
+        scene->addItem(gate);
+        scene->addItem(led);
+        auto *conn1 = new Connection();
+        conn1->setStartPort(clock1->outputPort(0));
+        conn1->setEndPort(gate->inputPort(0));
+        scene->addItem(conn1);
+        conn1->updatePath();
+        auto *conn2 = new Connection();
+        conn2->setStartPort(clock2->outputPort(0));
+        conn2->setEndPort(gate->inputPort(1));
+        scene->addItem(conn2);
+        conn2->updatePath();
+        auto *conn3 = new Connection();
+        conn3->setStartPort(gate->outputPort(0));
+        conn3->setEndPort(led->inputPort(0));
+        scene->addItem(conn3);
+        conn3->updatePath();
+    }
 }

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -39,6 +39,9 @@
 #include "App/Element/ElementLabel.h"
 #include "App/Element/IC.h"
 #include "App/Element/ICPreviewPopup.h"
+#include "App/Exercise/ExerciseBrowserDialog.h"
+#include "App/Exercise/ExerciseEngine.h"
+#include "App/Exercise/ExerciseOverlay.h"
 #include "App/IO/RecentFiles.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/ICRegistry.h"
@@ -111,6 +114,8 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
 
     qCDebug(zero) << "Setting connections";
     setupConnections();
+
+    m_exerciseEngine = new ExerciseEngine(this);
 
     qCDebug(zero) << "Checking playing simulation.";
     // Start simulation running by default so the circuit is live on open.
@@ -263,6 +268,7 @@ void MainWindow::setupConnections()
     connect(m_ui->tab, &QTabWidget::currentChanged,    m_workspaceManager, &WorkspaceManager::onCurrentIndexChanged);
     connect(m_ui->tab, &QTabWidget::tabCloseRequested, m_workspaceManager, &WorkspaceManager::closeTab);
 
+    connect(m_ui->actionExercises,             &QAction::triggered,       this,                &MainWindow::on_actionExercises_triggered);
     connect(m_ui->actionAbout,                 &QAction::triggered,       this,                &MainWindow::on_actionAbout_triggered);
     connect(m_ui->actionAboutQt,               &QAction::triggered,       this,                &MainWindow::on_actionAboutQt_triggered);
     connect(m_ui->actionAboutThisVersion,      &QAction::triggered,       this,                &MainWindow::aboutThisVersion);
@@ -641,10 +647,25 @@ void MainWindow::onCurrentTabChanged(WorkSpace *newTab)
 {
     // Reaction to WorkspaceManager::currentTabChanged: rebind the shared chrome to the
     // new scene and refresh the tab-navigation view state (file-based IC list, buttons).
+    // currentTab() already reflects newTab here (WorkspaceManager updates its current-tab
+    // field before emitting this signal), so the tab actually being left is tracked
+    // separately in m_previousTab rather than read via currentTab().
+    WorkSpace *prevTab = m_previousTab;
+    m_previousTab = newTab;
+
     m_binder->unbind(); // tear down the previously bound tab's chrome wiring
     // Hide the editor panel during the transition; SceneUiBinder::bind restores it
     // once the new scene's selection is known.
     m_ui->elementEditor->hide();
+
+    // Detach exercise overlay from the leaving tab
+    if (prevTab) {
+        prevTab->setExerciseOverlay(nullptr);
+    }
+    if (m_exerciseOverlay && m_exerciseEngine && m_exerciseEngine->isActive()) {
+        m_exerciseOverlay->hide();
+        m_exerciseOverlay->setParent(nullptr);
+    }
 
     if (!newTab) {
         // All tabs were closed; reset state.
@@ -659,6 +680,16 @@ void MainWindow::onCurrentTabChanged(WorkSpace *newTab)
     // Hide management buttons for inline IC tabs (they use currentFile/currentDir which are empty)
     setICButtonsVisible(!newTab->isInlineIC());
     refreshICButtonsEnabled();
+
+    // Re-attach exercise overlay to the arriving tab
+    if (m_exerciseEngine && m_exerciseEngine->isActive() && m_exerciseOverlay) {
+        m_exerciseEngine->setScene(newTab->scene());
+        m_exerciseOverlay->setParent(newTab);
+        newTab->setExerciseOverlay(m_exerciseOverlay);
+        m_exerciseOverlay->repositionToParent();
+        m_exerciseOverlay->show();
+        m_exerciseOverlay->raise();
+    }
 }
 
 void MainWindow::on_actionGates_triggered(const bool checked)
@@ -906,15 +937,27 @@ void MainWindow::on_actionFastMode_triggered(const bool checked)
 void MainWindow::on_actionWaveform_triggered()
 {
     Application::guardedSlot(this, [this] {
+        if (m_bwd) {
+            m_bwd->raise();
+            m_bwd->activateWindow();
+            return;
+        }
         if (!currentTab()) {
             return;
         }
 
         sentryBreadcrumb("ui", QStringLiteral("Waveform dialog opened"));
         qCDebug(zero) << "BD fileName: " << currentTab()->dolphinFileName();
-        auto *bewavedDolphin = new BewavedDolphin(currentTab()->scene(), true, this);
-        bewavedDolphin->createWaveform(currentTab()->dolphinFileName());
-        bewavedDolphin->show();
+        auto *bwd = new BewavedDolphin(currentTab()->scene(), true, this);
+        bwd->createWaveform(currentTab()->dolphinFileName());
+        m_bwd = bwd;
+        connect(bwd, &QObject::destroyed, this, [this] {
+            if (m_exerciseOverlay && m_exerciseEngine && m_exerciseEngine->isActive()) {
+                m_exerciseOverlay->hide();
+                m_exerciseOverlay->setParent(nullptr);
+            }
+        });
+        bwd->show();
     });
 }
 
@@ -1048,4 +1091,94 @@ bool MainWindow::event(QEvent *event)
     };
 
     return QMainWindow::event(event);
+}
+
+void MainWindow::on_actionExercises_triggered()
+{
+    ExerciseBrowserDialog dialog(this);
+    if (dialog.exec() == QDialog::Accepted) {
+        startExercise(dialog.selectedExercisePath());
+    }
+}
+
+void MainWindow::startExercise(const QString &resourcePath)
+{
+    if (!currentTab() || resourcePath.isEmpty()) {
+        return;
+    }
+    if (!m_exerciseEngine->loadFromResource(resourcePath)) {
+        qWarning() << "ExerciseEngine: failed to load" << resourcePath;
+        return;
+    }
+
+    if (currentTab()) {
+        currentTab()->setExerciseOverlay(nullptr);
+    }
+    delete m_exerciseOverlay;
+    m_exerciseOverlay = new ExerciseOverlay(m_exerciseEngine, currentTab());
+
+    // Must precede stepChanged→onStepChanged so actions run before the overlay updates.
+    connect(m_exerciseEngine, &ExerciseEngine::stepChanged, this,
+            [this](int, int, const ExerciseStep &step) {
+        for (const QString &id : step.click) clickTarget(id);
+
+        if (!m_exerciseOverlay) {
+            return;
+        }
+        const bool wantBwd = (step.context == "bwd");
+        if (wantBwd && m_bwd) {
+            m_exerciseOverlay->setParent(m_bwd->centralWidget());
+            m_bwd->setExerciseOverlay(m_exerciseOverlay);
+            if (currentTab()) {
+                currentTab()->setExerciseOverlay(nullptr);
+            }
+        } else if (!wantBwd && currentTab()) {
+            m_exerciseOverlay->setParent(currentTab());
+            currentTab()->setExerciseOverlay(m_exerciseOverlay);
+            if (m_bwd) {
+                m_bwd->setExerciseOverlay(nullptr);
+            }
+        }
+        m_exerciseOverlay->repositionToParent();
+        m_exerciseOverlay->show();
+        m_exerciseOverlay->raise();
+    });
+    connect(m_exerciseEngine, &ExerciseEngine::stepChanged,
+            m_exerciseOverlay, &ExerciseOverlay::onStepChanged);
+    connect(m_exerciseEngine, &ExerciseEngine::exerciseCompleted,
+            m_exerciseOverlay, &ExerciseOverlay::onExerciseCompleted);
+    connect(m_exerciseOverlay, &ExerciseOverlay::closeRequested, this, [this] {
+        if (!m_exerciseOverlay) return;
+        ExerciseOverlay *overlay = m_exerciseOverlay;
+        m_exerciseOverlay = nullptr;
+        m_exerciseEngine->stop();
+        if (currentTab()) {
+            currentTab()->setExerciseOverlay(nullptr);
+        }
+        if (m_bwd) {
+            m_bwd->setExerciseOverlay(nullptr);
+        }
+        overlay->deleteLater();
+    });
+
+    auto *esc = new QShortcut(QKeySequence(Qt::Key_Escape), m_exerciseOverlay);
+    connect(esc, &QShortcut::activated, m_exerciseOverlay, &ExerciseOverlay::closeRequested);
+
+    currentTab()->setExerciseOverlay(m_exerciseOverlay);
+    m_exerciseEngine->setScene(currentTab()->scene());
+    m_exerciseEngine->start();
+
+    m_exerciseOverlay->repositionToParent();
+    m_exerciseOverlay->show();
+    m_exerciseOverlay->raise();
+}
+
+void MainWindow::clickTarget(const QString &id)
+{
+    if      (id == "ioTab")          m_ui->tabElements->setCurrentIndex(0);
+    else if (id == "gatesTab")       m_ui->tabElements->setCurrentIndex(1);
+    else if (id == "combinational")  m_ui->tabElements->setCurrentIndex(2);
+    else if (id == "memoryTab")      m_ui->tabElements->setCurrentIndex(3);
+    else if (id == "actionPlay")     m_ui->actionPlay->trigger();
+    else if (id == "actionWaveform") m_ui->actionWaveform->trigger();
 }

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -18,8 +18,12 @@
 #include "App/UI/MainWindowHost.h"
 #include "App/UI/MainWindowUI.h"
 
+class BewavedDolphin;
 class ElementLabel;
 class ElementPalette;
+class ExerciseBrowserDialog;
+class ExerciseEngine;
+class ExerciseOverlay;
 class ExportController;
 class ICController;
 class ICPreviewPopup;
@@ -215,6 +219,11 @@ private:
 
     // --- Action Handlers ---
 
+    void on_actionExercises_triggered();
+    void startExercise(const QString &resourcePath);
+
+    void clickTarget(const QString &id);
+
     static void on_actionDarkTheme_triggered();
     static void on_actionLightTheme_triggered();
     static void on_actionSystemTheme_triggered();
@@ -275,6 +284,17 @@ private:
     ICController     *m_icController      = nullptr;
     SceneUiBinder    *m_binder            = nullptr;
     WorkspaceManager *m_workspaceManager  = nullptr;
+
+    ExerciseEngine  *m_exerciseEngine  = nullptr;
+    ExerciseOverlay *m_exerciseOverlay = nullptr;
+
+    QPointer<BewavedDolphin> m_bwd;
+
+    /// The tab being left, captured for onCurrentTabChanged(): by the time that slot runs,
+    /// currentTab() already reflects the arriving tab (WorkspaceManager updates its current-tab
+    /// field before emitting the signal), so this is tracked separately. QPointer since the
+    /// previous tab may already be mid-close (deleteLater) by the time it's read.
+    QPointer<WorkSpace> m_previousTab;
 
     /// Shared IC-hover preview, parented to this MainWindow.
     /// QPointer so accesses during teardown are safe regardless of child-destruction order.

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -18,7 +18,6 @@
 #include "App/UI/MainWindowHost.h"
 #include "App/UI/MainWindowUI.h"
 
-class BewavedDolphin;
 class ElementLabel;
 class ElementPalette;
 class ExerciseBrowserDialog;
@@ -28,8 +27,12 @@ class ExportController;
 class ICController;
 class ICPreviewPopup;
 class LanguageManager;
+class BewavedDolphin;
 class RecentFiles;
 class SceneUiBinder;
+class TourBrowserDialog;
+class TourEngine;
+class TourOverlay;
 class WorkSpace;
 class WorkspaceManager;
 
@@ -221,6 +224,9 @@ private:
 
     void on_actionExercises_triggered();
     void startExercise(const QString &resourcePath);
+    void on_actionTours_triggered();
+    void startTour(const QString &resourcePath);
+    QRect resolveTourTarget(const QString &id) const;
 
     void clickTarget(const QString &id);
 
@@ -287,6 +293,11 @@ private:
 
     ExerciseEngine  *m_exerciseEngine  = nullptr;
     ExerciseOverlay *m_exerciseOverlay = nullptr;
+
+    TourEngine  *m_tourEngine  = nullptr;
+    /// QPointer: can be destroyed as a side effect of a WA_DeleteOnClose window
+    /// (e.g. BeWavedDolphin) it was reparented onto, outside our own control.
+    QPointer<TourOverlay> m_tourOverlay;
 
     QPointer<BewavedDolphin> m_bwd;
 

--- a/App/UI/MainWindowUI.cpp
+++ b/App/UI/MainWindowUI.cpp
@@ -595,6 +595,10 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuSimulation->setObjectName("menuSimulation");
     menuExamples = new QMenu(menuBar);
     menuExamples->setObjectName("menuExamples");
+    menuExercises = new QMenu(menuBar);
+    menuExercises->setObjectName("menuExercises");
+    actionExercises = new QAction(MainWindow);
+    actionExercises->setObjectName("actionExercises");
     MainWindow->setMenuBar(menuBar);
     QWidget::setTabOrder(lineEditSearch, tabElements);
     QWidget::setTabOrder(tabElements, scrollAreaInOut);
@@ -625,6 +629,7 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuBar->addAction(menuView->menuAction());
     menuBar->addAction(menuSimulation->menuAction());
     menuBar->addAction(menuExamples->menuAction());
+    menuBar->addAction(menuExercises->menuAction());
     menuBar->addAction(menuLanguage->menuAction());
     menuBar->addAction(menuTranslation->menuAction());
     menuBar->addAction(menuHelp->menuAction());
@@ -662,6 +667,7 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuEdit->addSeparator();
     menuEdit->addAction(actionSelectAll);
     menuEdit->addAction(actionClearSelection);
+    menuExercises->addAction(actionExercises);
     menuHelp->addAction(actionAbout);
     menuHelp->addAction(actionAboutQt);
     menuHelp->addAction(actionAboutThisVersion);
@@ -814,4 +820,6 @@ void MainWindowUi::retranslateUi()
     menuLanguage->setTitle(QCoreApplication::translate("MainWindow", "&Language"));
     menuSimulation->setTitle(QCoreApplication::translate("MainWindow", "Sim&ulation"));
     menuExamples->setTitle(QCoreApplication::translate("MainWindow", "Examples"));
+    menuExercises->setTitle(QCoreApplication::translate("MainWindow", "&Exercises"));
+    actionExercises->setText(QCoreApplication::translate("MainWindow", "&Circuit Exercises..."));
 }

--- a/App/UI/MainWindowUI.cpp
+++ b/App/UI/MainWindowUI.cpp
@@ -599,6 +599,10 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuExercises->setObjectName("menuExercises");
     actionExercises = new QAction(MainWindow);
     actionExercises->setObjectName("actionExercises");
+    menuTours = new QMenu(menuBar);
+    menuTours->setObjectName("menuTours");
+    actionTours = new QAction(MainWindow);
+    actionTours->setObjectName("actionTours");
     MainWindow->setMenuBar(menuBar);
     QWidget::setTabOrder(lineEditSearch, tabElements);
     QWidget::setTabOrder(tabElements, scrollAreaInOut);
@@ -630,6 +634,7 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuBar->addAction(menuSimulation->menuAction());
     menuBar->addAction(menuExamples->menuAction());
     menuBar->addAction(menuExercises->menuAction());
+    menuBar->addAction(menuTours->menuAction());
     menuBar->addAction(menuLanguage->menuAction());
     menuBar->addAction(menuTranslation->menuAction());
     menuBar->addAction(menuHelp->menuAction());
@@ -668,6 +673,7 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuEdit->addAction(actionSelectAll);
     menuEdit->addAction(actionClearSelection);
     menuExercises->addAction(actionExercises);
+    menuTours->addAction(actionTours);
     menuHelp->addAction(actionAbout);
     menuHelp->addAction(actionAboutQt);
     menuHelp->addAction(actionAboutThisVersion);
@@ -822,4 +828,6 @@ void MainWindowUi::retranslateUi()
     menuExamples->setTitle(QCoreApplication::translate("MainWindow", "Examples"));
     menuExercises->setTitle(QCoreApplication::translate("MainWindow", "&Exercises"));
     actionExercises->setText(QCoreApplication::translate("MainWindow", "&Circuit Exercises..."));
+    menuTours->setTitle(QCoreApplication::translate("MainWindow", "&Tours"));
+    actionTours->setText(QCoreApplication::translate("MainWindow", "&Interactive Tours..."));
 }

--- a/App/UI/MainWindowUI.h
+++ b/App/UI/MainWindowUI.h
@@ -105,8 +105,9 @@ public:
     QAction *actionExportToImage = nullptr;
     QAction *actionMakeSelfContained = nullptr;
 
-    // Exercise actions
+    // Exercise and Tour actions
     QAction *actionExercises = nullptr;
+    QAction *actionTours = nullptr;
 
     // Help / about actions
     QAction *actionAbout = nullptr;
@@ -230,6 +231,7 @@ public:
     QMenu *menuSimulation = nullptr;
     QMenu *menuExamples = nullptr;
     QMenu *menuExercises = nullptr;
+    QMenu *menuTours = nullptr;
     QMenu *menuHelp = nullptr;
 
 };

--- a/App/UI/MainWindowUI.h
+++ b/App/UI/MainWindowUI.h
@@ -105,6 +105,9 @@ public:
     QAction *actionExportToImage = nullptr;
     QAction *actionMakeSelfContained = nullptr;
 
+    // Exercise actions
+    QAction *actionExercises = nullptr;
+
     // Help / about actions
     QAction *actionAbout = nullptr;
     QAction *actionAboutQt = nullptr;
@@ -226,6 +229,7 @@ public:
     QMenu *menuTranslation = nullptr;
     QMenu *menuSimulation = nullptr;
     QMenu *menuExamples = nullptr;
+    QMenu *menuExercises = nullptr;
     QMenu *menuHelp = nullptr;
 
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Advanced development features supported:
 
 - **CRITICAL**: Always use `cmake --build --preset debug --target update_translations` to refresh `.ts` files — never call `lupdate` directly or use any other target.
 - This target passes `-tr-function-alias tr+=PANDACEPTION` so strings wrapped in the `PANDACEPTION()` macro are correctly extracted. Using any other invocation silently discards those strings.
+- **Exercise/Tour content translations**: Exercise step text (`App/Resources/Exercises/*.json`) never passes through `tr()` — it's JSON, so `lupdate` can't see it. It goes through a *separate* Weblate "JSON file" component and a generated catalog, `App/Resources/Translations/ExerciseTour/en.json` (`Scripts/generate_exercise_tour_catalog.py`). Regenerating it is wired into the same `update_translations` target above — still one command. See "Exercise Content" below.
 
 ## Project Structure
 
@@ -186,6 +187,46 @@ if (elapsed > m_interval) {
 #### **Verdict: Conceptually Correct for Educational Purpose**
 
 The simulation accurately represents **ideal digital logic behavior** while deliberately abstracting **physical implementation details**. This approach is pedagogically sound - students learn fundamental concepts correctly without being overwhelmed by timing complexities that would obscure the core logic principles.
+
+## Exercise Content
+
+**Exercises** (`App/Exercise/`): circuit-building challenges validated against the live `Scene`, driven by JSON step content (`App/Resources/Exercises/*.json`).
+
+### Content discovery: flat directory scan, not hardcoded lists
+
+`ExerciseBrowserDialog` calls `ExerciseTourResources::discover("Exercises")` (`App/Core/ExerciseTourResources.h`), which merges four sources rather than one: the built-in bundled content (`scan(":/Exercises")`, mirroring `LanguageManager::availableLanguages()`'s `QDir(prefix).entryList({"*.json"}, QDir::Files)` pattern) plus three real, on-disk, end-user-writable locations — see below. Dropping a new built-in `.json` file into `App/Resources/Exercises/` (with a globally unique `id`) is picked up automatically on the next reconfigure — no C++ or `.qrc` edits.
+
+### End-user-writable discovery: three locations, two audiences
+
+Built-in content only solves *contributor* flexibility (source-tree + reconfigure). Getting a
+custom exercise into an already-*compiled* app needs a real filesystem location, and this
+splits by audience — deliberately kept separate, not merged into one "user folder":
+
+- **`ExerciseTourResources::preferredContentDir(category)`** — what the **"Open Folder" button**
+  in the browser dialog opens: the install-relative folder next to the app (mirrors
+  `MainWindow::setupExamplesMenu()`'s per-platform search paths, parameterized instead of
+  hardcoded to `"Examples"`), or, if that isn't writable (e.g. installed under Program Files
+  without admin rights), a `Documents/wiRedPanda/<category>` fallback created only at that
+  point. Both are simple, visible, end-user-facing locations.
+- **`ExerciseTourResources::managedContentDir(category)`** — `QStandardPaths::AppDataLocation + "/" + category"` (same idiom as `Workspace.cpp`'s autosaves folder). Reserved *exclusively* for a
+  teacher/IT admin to pre-provision content in a managed classroom install. `discover()` scans
+  it, but **no code path ever opens or is allowed to fall back into it from the button** — that
+  invariant is deliberate and is exercised by
+  `TestExerciseTourResources::testPreferredContentDirReturnsWritablePathOutsideManagedDir`.
+
+`discover()`'s merge order is built-in → AppData → install-relative → Documents fallback; a
+colliding `id` is dropped from whichever source loses, via the testable `mergeUnique()` seam,
+never silently overwriting an earlier entry.
+
+### Resource embedding: CMake glob, no `.qrc`
+
+Exercise JSON is intentionally **not** listed in a `.qrc` (`rcc` can't glob, which would reintroduce the hardcoded-list problem). `CMakeLists.txt` globs the folder with `CONFIGURE_DEPENDS` and calls the target-based `qt6_add_resources(wiredpanda_resources "<name>" PREFIX ... BASE ... FILES ...)` API directly on the `wiredpanda_resources` OBJECT library, after it exists.
+
+### i18n: a separate Weblate "JSON file" component
+
+Step text never passes through `tr()`. `App/Resources/Translations/ExerciseTour/en.json` is the generated, committed English-source catalog (`Scripts/generate_exercise_tour_catalog.py`), keyed `<fileId>.title`, `<fileId>.description`, `<fileId>.<stepKey>.instruction`/`.hint`. Every translatable step has a stable, contributor-authored `"key"` used only to build these keys — never read by engine logic. `ExerciseTour/<lang>.json` files are Weblate-managed and embedded at `:/i18n/ExerciseTour/<lang>.json`. `ExerciseTourResources::translate(key, fallbackEnglish)` reloads the small catalog fresh on every call (no cache) — cheap given usage frequency (dialog open / exercise start), and always falls back to the raw English text.
+
+See `App/Resources/Exercises/README.md` for the full schema and the closed `click` vocabulary.
 
 ## Development Container
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Advanced development features supported:
 
 - **CRITICAL**: Always use `cmake --build --preset debug --target update_translations` to refresh `.ts` files — never call `lupdate` directly or use any other target.
 - This target passes `-tr-function-alias tr+=PANDACEPTION` so strings wrapped in the `PANDACEPTION()` macro are correctly extracted. Using any other invocation silently discards those strings.
-- **Exercise/Tour content translations**: Exercise step text (`App/Resources/Exercises/*.json`) never passes through `tr()` — it's JSON, so `lupdate` can't see it. It goes through a *separate* Weblate "JSON file" component and a generated catalog, `App/Resources/Translations/ExerciseTour/en.json` (`Scripts/generate_exercise_tour_catalog.py`). Regenerating it is wired into the same `update_translations` target above — still one command. See "Exercise Content" below.
+- **Exercise/Tour content translations**: Exercise/Tour step text (`App/Resources/Exercises/*.json`, `App/Resources/Tours/*.json`) never passes through `tr()` — it's JSON, so `lupdate` can't see it. It goes through a *separate* Weblate "JSON file" component and a generated catalog, `App/Resources/Translations/ExerciseTour/en.json` (`Scripts/generate_exercise_tour_catalog.py`). Regenerating it is wired into the same `update_translations` target above — still one command. See "Exercise/Tour Content" below.
 
 ## Project Structure
 
@@ -188,22 +188,25 @@ if (elapsed > m_interval) {
 
 The simulation accurately represents **ideal digital logic behavior** while deliberately abstracting **physical implementation details**. This approach is pedagogically sound - students learn fundamental concepts correctly without being overwhelmed by timing complexities that would obscure the core logic principles.
 
-## Exercise Content
+## Exercise/Tour Content
 
-**Exercises** (`App/Exercise/`): circuit-building challenges validated against the live `Scene`, driven by JSON step content (`App/Resources/Exercises/*.json`).
+Two JSON-driven, in-app learning features share one architecture:
+
+- **Exercises** (`App/Exercise/`): circuit-building challenges validated against the live `Scene` (`App/Resources/Exercises/*.json`).
+- **Tours** (`App/Tour/`): guided UI walkthroughs with a spotlight overlay (`App/Resources/Tours/*.json`).
 
 ### Content discovery: flat directory scan, not hardcoded lists
 
-`ExerciseBrowserDialog` calls `ExerciseTourResources::discover("Exercises")` (`App/Core/ExerciseTourResources.h`), which merges four sources rather than one: the built-in bundled content (`scan(":/Exercises")`, mirroring `LanguageManager::availableLanguages()`'s `QDir(prefix).entryList({"*.json"}, QDir::Files)` pattern) plus three real, on-disk, end-user-writable locations — see below. Dropping a new built-in `.json` file into `App/Resources/Exercises/` (with a globally unique `id`) is picked up automatically on the next reconfigure — no C++ or `.qrc` edits.
+`ExerciseBrowserDialog`/`TourBrowserDialog` call `ExerciseTourResources::discover("Exercises")`/`discover("Tours")` (`App/Core/ExerciseTourResources.h`), which merges four sources rather than one: the built-in bundled content (`scan(":/Exercises")`, mirroring `LanguageManager::availableLanguages()`'s `QDir(prefix).entryList({"*.json"}, QDir::Files)` pattern) plus three real, on-disk, end-user-writable locations — see below. Dropping a new built-in `.json` file into `App/Resources/Exercises/` or `App/Resources/Tours/` (with a globally unique `id`) is picked up automatically on the next reconfigure — no C++ or `.qrc` edits.
 
 ### End-user-writable discovery: three locations, two audiences
 
 Built-in content only solves *contributor* flexibility (source-tree + reconfigure). Getting a
-custom exercise into an already-*compiled* app needs a real filesystem location, and this
-splits by audience — deliberately kept separate, not merged into one "user folder":
+custom exercise or tour into an already-*compiled* app needs a real filesystem location, and
+this splits by audience — deliberately kept separate, not merged into one "user folder":
 
 - **`ExerciseTourResources::preferredContentDir(category)`** — what the **"Open Folder" button**
-  in the browser dialog opens: the install-relative folder next to the app (mirrors
+  in the browser dialogs opens: the install-relative folder next to the app (mirrors
   `MainWindow::setupExamplesMenu()`'s per-platform search paths, parameterized instead of
   hardcoded to `"Examples"`), or, if that isn't writable (e.g. installed under Program Files
   without admin rights), a `Documents/wiRedPanda/<category>` fallback created only at that
@@ -220,13 +223,13 @@ never silently overwriting an earlier entry.
 
 ### Resource embedding: CMake glob, no `.qrc`
 
-Exercise JSON is intentionally **not** listed in a `.qrc` (`rcc` can't glob, which would reintroduce the hardcoded-list problem). `CMakeLists.txt` globs the folder with `CONFIGURE_DEPENDS` and calls the target-based `qt6_add_resources(wiredpanda_resources "<name>" PREFIX ... BASE ... FILES ...)` API directly on the `wiredpanda_resources` OBJECT library, after it exists.
+Exercise/Tour JSON is intentionally **not** listed in a `.qrc` (`rcc` can't glob, which would reintroduce the hardcoded-list problem). `CMakeLists.txt` globs the folders with `CONFIGURE_DEPENDS` and calls the target-based `qt6_add_resources(wiredpanda_resources "<name>" PREFIX ... BASE ... FILES ...)` API directly on the `wiredpanda_resources` OBJECT library, after it exists.
 
 ### i18n: a separate Weblate "JSON file" component
 
-Step text never passes through `tr()`. `App/Resources/Translations/ExerciseTour/en.json` is the generated, committed English-source catalog (`Scripts/generate_exercise_tour_catalog.py`), keyed `<fileId>.title`, `<fileId>.description`, `<fileId>.<stepKey>.instruction`/`.hint`. Every translatable step has a stable, contributor-authored `"key"` used only to build these keys — never read by engine logic. `ExerciseTour/<lang>.json` files are Weblate-managed and embedded at `:/i18n/ExerciseTour/<lang>.json`. `ExerciseTourResources::translate(key, fallbackEnglish)` reloads the small catalog fresh on every call (no cache) — cheap given usage frequency (dialog open / exercise start), and always falls back to the raw English text.
+Step text never passes through `tr()`. `App/Resources/Translations/ExerciseTour/en.json` is the generated, committed English-source catalog (`Scripts/generate_exercise_tour_catalog.py`), keyed `<fileId>.title`, `<fileId>.description`, `<fileId>.<stepKey>.instruction`/`.hint` (Exercises) or `.title`/`.body` (Tours). Every translatable step has a stable, contributor-authored `"key"` used only to build these keys — never read by engine logic. `ExerciseTour/<lang>.json` files are Weblate-managed and embedded at `:/i18n/ExerciseTour/<lang>.json`. `ExerciseTourResources::translate(key, fallbackEnglish)` reloads the small catalog fresh on every call (no cache) — cheap given usage frequency (dialog open / exercise or tour start), and always falls back to the raw English text.
 
-See `App/Resources/Exercises/README.md` for the full schema and the closed `click` vocabulary.
+See `App/Resources/Exercises/README.md` and `App/Resources/Tours/README.md` for the full schema and the closed `target`/`click` vocabulary.
 
 ## Development Container
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,14 @@ endif()
 include(CMakeSources.cmake)
 
 # Find available translation files
-file(GLOB_RECURSE TS_FILES App/Resources/Translations/wpanda_*.ts)
+file(GLOB_RECURSE TS_FILES CONFIGURE_DEPENDS App/Resources/Translations/wpanda_*.ts)
+
+# Exercise content and its Weblate-managed translation catalog.
+# CONFIGURE_DEPENDS re-runs CMake's configure step when a file is added/removed here
+# (best-effort per CMake docs; works with the Ninja generator this project requires), so a
+# new .json file is picked up automatically — no CMake or .qrc edits needed.
+file(GLOB EXERCISE_JSON_FILES CONFIGURE_DEPENDS App/Resources/Exercises/*.json)
+file(GLOB EXERCISE_TOUR_CATALOG_JSON_FILES CONFIGURE_DEPENDS App/Resources/Translations/ExerciseTour/*.json)
 
 # Use the COMPONENTS form so cross-compile builds (WASM) consult QT_HOST_PATH
 # for host-only tools.  The bare `find_package(Qt6LinguistTools)` form only
@@ -255,10 +262,22 @@ file(GLOB_RECURSE TS_FILES App/Resources/Translations/wpanda_*.ts)
 # tools like lrelease aren't shipped.
 find_package(Qt6 QUIET COMPONENTS LinguistTools)
 
+# Only used to wire the Exercise/Tour translation-catalog regeneration into
+# update_translations below — lupdate can't parse the JSON that catalog is generated from.
+find_package(Python3 QUIET COMPONENTS Interpreter)
+
 qt6_add_resources(RESOURCES_RCC ${RESOURCES})
 
 add_library(wiredpanda_resources OBJECT ${RESOURCES_RCC})
 set_target_properties(wiredpanda_resources PROPERTIES UNITY_BUILD OFF)
+
+# Embed Exercise content JSON and its translation catalog directly onto the
+# wiredpanda_resources target. Deliberately NOT a .qrc file: rcc can't glob, so a .qrc would
+# reintroduce the hardcoded file list this mechanism is meant to eliminate.
+qt6_add_resources(wiredpanda_resources "exercises" PREFIX "/Exercises"
+    BASE App/Resources/Exercises FILES ${EXERCISE_JSON_FILES})
+qt6_add_resources(wiredpanda_resources "exercise-tour-catalog" PREFIX "/i18n/ExerciseTour"
+    BASE App/Resources/Translations/ExerciseTour FILES ${EXERCISE_TOUR_CATALOG_JSON_FILES})
 
 # ELF platforms only: wiredpanda_resources is a CMake OBJECT library, which means
 # its object files are compiled independently and do not inherit POSITION_INDEPENDENT_CODE
@@ -427,6 +446,27 @@ if(Qt6LinguistTools_FOUND)
         ${_merge_qt_translations}
         ${_lupdate_opts}
     )
+
+    # Regenerate the Weblate-managed Exercise/Tour content catalog (App/Resources/Translations/
+    # ExerciseTour/en.json) as part of the same command used for .ts sources, so contributors
+    # still only need to remember one target. A separate custom target because lupdate can't
+    # parse JSON. update_translations itself doesn't exist yet at this point: since no
+    # SOURCE_TARGETS was passed above, qt_add_translations() deferred its real work (including
+    # creating update_translations) to the end of this directory's scope via
+    # cmake_language(DEFER ...) instead of running it immediately. The add_dependencies() call
+    # below must be deferred the same way so it runs after that — deferred calls execute in the
+    # order they were scheduled, and this one is scheduled after Qt's.
+    if(Python3_FOUND)
+        add_custom_target(update_exercise_tour_catalog
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Scripts/generate_exercise_tour_catalog.py
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMENT "Regenerating Weblate Exercise/Tour content translation catalog"
+            VERBATIM
+        )
+        cmake_language(EVAL CODE
+            "cmake_language(DEFER DIRECTORY \"${PROJECT_SOURCE_DIR}\" CALL add_dependencies update_translations update_exercise_tour_catalog)"
+        )
+    endif()
 endif()
 
 # Preload example files into Emscripten's virtual filesystem
@@ -827,6 +867,7 @@ add_test(NAME TestSimulationUnit COMMAND test_wiredpanda TestSimulationUnit WORK
 add_test(NAME TestDanglingPointer COMMAND test_wiredpanda TestDanglingPointer WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestSystemVerilogCodeGenUnit COMMAND test_wiredpanda TestSystemVerilogCodeGenUnit WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestTrashButton COMMAND test_wiredpanda TestTrashButton WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestExerciseTourResources COMMAND test_wiredpanda TestExerciseTourResources WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestUpdateChecker COMMAND test_wiredpanda TestUpdateChecker WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # ============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,11 +249,12 @@ include(CMakeSources.cmake)
 # Find available translation files
 file(GLOB_RECURSE TS_FILES CONFIGURE_DEPENDS App/Resources/Translations/wpanda_*.ts)
 
-# Exercise content and its Weblate-managed translation catalog.
+# Exercise/Tour content and its Weblate-managed translation catalog.
 # CONFIGURE_DEPENDS re-runs CMake's configure step when a file is added/removed here
 # (best-effort per CMake docs; works with the Ninja generator this project requires), so a
 # new .json file is picked up automatically — no CMake or .qrc edits needed.
 file(GLOB EXERCISE_JSON_FILES CONFIGURE_DEPENDS App/Resources/Exercises/*.json)
+file(GLOB TOUR_JSON_FILES CONFIGURE_DEPENDS App/Resources/Tours/*.json)
 file(GLOB EXERCISE_TOUR_CATALOG_JSON_FILES CONFIGURE_DEPENDS App/Resources/Translations/ExerciseTour/*.json)
 
 # Use the COMPONENTS form so cross-compile builds (WASM) consult QT_HOST_PATH
@@ -271,11 +272,13 @@ qt6_add_resources(RESOURCES_RCC ${RESOURCES})
 add_library(wiredpanda_resources OBJECT ${RESOURCES_RCC})
 set_target_properties(wiredpanda_resources PROPERTIES UNITY_BUILD OFF)
 
-# Embed Exercise content JSON and its translation catalog directly onto the
+# Embed Exercise/Tour content JSON and their translation catalog directly onto the
 # wiredpanda_resources target. Deliberately NOT a .qrc file: rcc can't glob, so a .qrc would
 # reintroduce the hardcoded file list this mechanism is meant to eliminate.
 qt6_add_resources(wiredpanda_resources "exercises" PREFIX "/Exercises"
     BASE App/Resources/Exercises FILES ${EXERCISE_JSON_FILES})
+qt6_add_resources(wiredpanda_resources "tours" PREFIX "/Tours"
+    BASE App/Resources/Tours FILES ${TOUR_JSON_FILES})
 qt6_add_resources(wiredpanda_resources "exercise-tour-catalog" PREFIX "/i18n/ExerciseTour"
     BASE App/Resources/Translations/ExerciseTour FILES ${EXERCISE_TOUR_CATALOG_JSON_FILES})
 

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -90,6 +90,10 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/Simulation.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/SimulationBlocker.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/SimulationThrottleDisabler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourBrowserDialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourBrowserDialogUI.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourEngine.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourOverlay.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/CircuitExporter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ClockDialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ClockDialogUI.cpp
@@ -237,6 +241,11 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/Simulation.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/SimulationBlocker.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Simulation/SimulationThrottleDisabler.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourBrowserDialog.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourBrowserDialogUI.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourEngine.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourOverlay.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Tour/TourStep.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/CircuitExporter.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ClockDialog.h
     ${CMAKE_CURRENT_LIST_DIR}/App/UI/ClockDialogUI.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -16,6 +16,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Application.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Common.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Enums.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Core/ExerciseTourResources.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ItemWithId.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Settings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ThemeManager.cpp
@@ -67,6 +68,10 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ICPreviewPopup.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ICRenderer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ICSimulation.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseBrowserDialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseBrowserDialogUI.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseEngine.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseOverlay.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/IO/RecentFiles.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/IO/Serialization.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Scene/ClipboardManager.cpp
@@ -146,6 +151,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Constants.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ContextDirProvider.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Enums.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Core/ExerciseTourResources.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ItemWithId.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/MimeTypes.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Priorities.h
@@ -205,6 +211,11 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ICRenderer.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/ICSimulation.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Element/PropertyDescriptor.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseBrowserDialog.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseBrowserDialogUI.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseEngine.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseOverlay.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Exercise/ExerciseStep.h
     ${CMAKE_CURRENT_LIST_DIR}/App/IO/FileUtils.h
     ${CMAKE_CURRENT_LIST_DIR}/App/IO/RecentFiles.h
     ${CMAKE_CURRENT_LIST_DIR}/App/IO/Serialization.h
@@ -414,6 +425,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestSettings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestThemeManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestApplication.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestExerciseTourResources.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestNotifyCatch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestSettings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestUpdateChecker.cpp
@@ -598,6 +610,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestSettings.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestThemeManager.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestApplication.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestExerciseTourResources.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestNotifyCatch.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestSettings.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestUpdateChecker.h

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ wiRedPanda is a free, open-source digital logic circuit simulator designed to he
 - Create learning materials and tutorials
 - Share classroom experiences and feedback
 - Suggest educational improvements
+- Add a circuit Exercise — see [`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md)
 
 ## Development Setup
 
@@ -248,6 +249,13 @@ wiRedPanda supports multiple languages through our translation system.
 2. Select your language or request a new one
 3. Translate strings using the web interface
 4. Translations are automatically submitted as pull requests
+
+### Translating Exercise Content
+
+Circuit Exercise step text is translated through a separate Weblate "JSON file"
+component (not the `.ts` component above) — the same web UI, no separate process. If you're
+adding new Exercise content rather than translating, see
+[`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md).
 
 ### Manual Translation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ wiRedPanda is a free, open-source digital logic circuit simulator designed to he
 - Create learning materials and tutorials
 - Share classroom experiences and feedback
 - Suggest educational improvements
-- Add a circuit Exercise — see [`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md)
+- Add a circuit Exercise or guided UI Tour — see [`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md) and [`App/Resources/Tours/README.md`](App/Resources/Tours/README.md)
 
 ## Development Setup
 
@@ -250,12 +250,13 @@ wiRedPanda supports multiple languages through our translation system.
 3. Translate strings using the web interface
 4. Translations are automatically submitted as pull requests
 
-### Translating Exercise Content
+### Translating Exercise/Tour Content
 
-Circuit Exercise step text is translated through a separate Weblate "JSON file"
+Circuit Exercise and guided Tour step text is translated through a separate Weblate "JSON file"
 component (not the `.ts` component above) — the same web UI, no separate process. If you're
-adding new Exercise content rather than translating, see
-[`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md).
+adding new Exercise/Tour content rather than translating, see
+[`App/Resources/Exercises/README.md`](App/Resources/Exercises/README.md) or
+[`App/Resources/Tours/README.md`](App/Resources/Tours/README.md).
 
 ### Manual Translation
 

--- a/Scripts/generate_exercise_tour_catalog.py
+++ b/Scripts/generate_exercise_tour_catalog.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2015 - 2026, GIBIS-Unifesp and the wiRedPanda contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Generate the English-source Weblate translation catalog for Exercise/Tour content.
+
+Scans App/Resources/Exercises/*.json and App/Resources/Tours/*.json and extracts every
+translatable field (title, description, and per-step instruction/hint or title/body, keyed by
+each step's "key") into one deterministic JSON catalog consumed by Weblate as
+App/Resources/Translations/ExerciseTour/en.json. Non-English ExerciseTour/<lang>.json files
+are managed by Weblate and never touched by this script.
+
+Usage:
+    python3 Scripts/generate_exercise_tour_catalog.py [--check]
+
+--check: exit 1 if regenerating would change the committed file, without writing it (used by CI
+  to verify the catalog is up to date with the content JSON).
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_repo_root():
+    """Return the git repository root, falling back to the script's grandparent directory."""
+    try:
+        result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True)
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path(__file__).resolve().parent.parent
+
+
+ROOT = find_repo_root()
+EXERCISES_DIR = ROOT / "App" / "Resources" / "Exercises"
+TOURS_DIR = ROOT / "App" / "Resources" / "Tours"
+CATALOG_PATH = ROOT / "App" / "Resources" / "Translations" / "ExerciseTour" / "en.json"
+
+
+def extract_entries(content_dir, is_tour):
+    """Build the {fileId: {...}} catalog fragment for every *.json file in content_dir."""
+    catalog = {}
+    for json_file in sorted(content_dir.glob("*.json")):
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+        file_id = data.get("id")
+        title = data.get("title")
+        if not file_id or not title:
+            raise SystemExit(f"{json_file}: missing required 'id' or 'title'")
+
+        entry = {"title": title}
+        if data.get("description"):
+            entry["description"] = data["description"]
+
+        seen_keys = set()
+        for step in data.get("steps", []):
+            key = step.get("key")
+            if not key:
+                continue
+            if key in seen_keys:
+                raise SystemExit(f"{json_file}: duplicate step key '{key}'")
+            seen_keys.add(key)
+            entry[key] = (
+                {"title": step.get("title", ""), "body": step.get("body", "")}
+                if is_tour
+                else {"instruction": step.get("instruction", ""), "hint": step.get("hint", "")}
+            )
+        catalog[file_id] = entry
+    return catalog
+
+
+def build_catalog():
+    """Merge the Exercises and Tours catalog fragments, rejecting id collisions between them."""
+    exercises = extract_entries(EXERCISES_DIR, is_tour=False)
+    tours = extract_entries(TOURS_DIR, is_tour=True)
+    collisions = set(exercises) & set(tours)
+    if collisions:
+        raise SystemExit(f"Duplicate content id(s) across Exercises/ and Tours/: {sorted(collisions)}")
+    return {**exercises, **tours}
+
+
+def main():
+    """Regenerate (or, with --check, verify) the committed English-source catalog."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="verify catalog is up to date; do not write")
+    args = parser.parse_args()
+
+    rendered = json.dumps(build_catalog(), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+    if args.check:
+        current = CATALOG_PATH.read_text(encoding="utf-8") if CATALOG_PATH.exists() else ""
+        if current != rendered:
+            print(
+                f"{CATALOG_PATH} is out of date; run: python3 Scripts/generate_exercise_tour_catalog.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{CATALOG_PATH} is up to date.")
+        return 0
+
+    CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CATALOG_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {CATALOG_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -123,6 +123,7 @@
 #include "Tests/Unit/Common/TestThemeManager.h"
 // unit/core
 #include "Tests/Unit/Core/TestApplication.h"
+#include "Tests/Unit/Core/TestExerciseTourResources.h"
 #include "Tests/Unit/Core/TestNotifyCatch.h"
 #include "Tests/Unit/Core/TestSettings.h"
 #include "Tests/Unit/Core/TestUpdateChecker.h"
@@ -311,6 +312,7 @@ int main(int argc, char **argv)
         {"TestSettings", []() -> QObject * { return new TestSettings; }},
         {"TestThemeManager", []() -> QObject * { return new TestThemeManager; }},
         {"TestCoreSettings", []() -> QObject * { return new TestCoreSettings; }},
+        {"TestExerciseTourResources", []() -> QObject * { return new TestExerciseTourResources; }},
         {"TestUpdateChecker", []() -> QObject * { return new TestUpdateChecker; }},
         {"TestApplication", []() -> QObject * { return new TestApplication; }},
         {"TestNotifyCatch", []() -> QObject * { return new TestNotifyCatch; }},

--- a/Tests/Unit/Core/TestExerciseTourResources.cpp
+++ b/Tests/Unit/Core/TestExerciseTourResources.cpp
@@ -1,0 +1,242 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/Core/TestExerciseTourResources.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+
+#include "App/Core/ExerciseTourResources.h"
+#include "App/Core/Settings.h"
+
+namespace {
+
+void writeFile(const QString &path, const QString &contents)
+{
+    QFile file(path);
+    QVERIFY(file.open(QIODevice::WriteOnly));
+    file.write(contents.toUtf8());
+}
+
+} // namespace
+
+void TestExerciseTourResources::testScanValidEntries()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    writeFile(dir.filePath("a.json"), R"({"id": "a", "title": "Title A", "description": "Desc A"})");
+    writeFile(dir.filePath("b.json"), R"({"id": "b", "title": "Title B"})");
+
+    const QVector<ExerciseTourResourceEntry> entries = ExerciseTourResources::scan(dir.path());
+
+    QCOMPARE(entries.size(), 2);
+    QCOMPARE(entries.at(0).id, QStringLiteral("a"));
+    QCOMPARE(entries.at(0).title, QStringLiteral("Title A"));
+    QCOMPARE(entries.at(0).description, QStringLiteral("Desc A"));
+    QCOMPARE(entries.at(0).path, dir.path() + QStringLiteral("/a.json"));
+    QCOMPARE(entries.at(1).id, QStringLiteral("b"));
+}
+
+void TestExerciseTourResources::testScanMissingDescriptionDefaultsToEmpty()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    writeFile(dir.filePath("no-description.json"), R"({"id": "x", "title": "Title X"})");
+
+    const QVector<ExerciseTourResourceEntry> entries = ExerciseTourResources::scan(dir.path());
+
+    QCOMPARE(entries.size(), 1);
+    QVERIFY(entries.at(0).description.isEmpty());
+}
+
+void TestExerciseTourResources::testScanSkipsMalformedJson()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    writeFile(dir.filePath("broken.json"), QStringLiteral("{ this is not valid json"));
+    writeFile(dir.filePath("good.json"), R"({"id": "good", "title": "Good"})");
+
+    const QVector<ExerciseTourResourceEntry> entries = ExerciseTourResources::scan(dir.path());
+
+    QCOMPARE(entries.size(), 1);
+    QCOMPARE(entries.at(0).id, QStringLiteral("good"));
+}
+
+void TestExerciseTourResources::testScanSkipsMissingIdOrTitle()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    writeFile(dir.filePath("no-id.json"), R"({"title": "No Id"})");
+    writeFile(dir.filePath("no-title.json"), R"({"id": "no-title"})");
+    writeFile(dir.filePath("good.json"), R"({"id": "good", "title": "Good"})");
+
+    const QVector<ExerciseTourResourceEntry> entries = ExerciseTourResources::scan(dir.path());
+
+    QCOMPARE(entries.size(), 1);
+    QCOMPARE(entries.at(0).id, QStringLiteral("good"));
+}
+
+void TestExerciseTourResources::testScanNonExistentDirectoryReturnsEmpty()
+{
+    const QVector<ExerciseTourResourceEntry> entries = ExerciseTourResources::scan(QStringLiteral("/no/such/directory/at/all"));
+
+    QVERIFY(entries.isEmpty());
+}
+
+void TestExerciseTourResources::testTranslateFromCatalogFoundKey()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString catalogPath = dir.filePath("catalog.json");
+    writeFile(catalogPath, R"({"basic-and-gate": {"title": "Construindo um Circuito com Porta AND"}})");
+
+    const QString result = ExerciseTourResources::translateFromCatalog(catalogPath, QStringLiteral("basic-and-gate.title"),
+                                                                        QStringLiteral("fallback"));
+
+    QCOMPARE(result, QStringLiteral("Construindo um Circuito com Porta AND"));
+}
+
+void TestExerciseTourResources::testTranslateFromCatalogMissingKeyFallsBack()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString catalogPath = dir.filePath("catalog.json");
+    writeFile(catalogPath, R"({"basic-and-gate": {"title": "Some Title"}})");
+
+    const QString result = ExerciseTourResources::translateFromCatalog(catalogPath, QStringLiteral("basic-and-gate.description"),
+                                                                        QStringLiteral("fallback"));
+
+    QCOMPARE(result, QStringLiteral("fallback"));
+}
+
+void TestExerciseTourResources::testTranslateFromCatalogMalformedJsonFallsBack()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString catalogPath = dir.filePath("catalog.json");
+    writeFile(catalogPath, QStringLiteral("not valid json at all"));
+
+    const QString result = ExerciseTourResources::translateFromCatalog(catalogPath, QStringLiteral("basic-and-gate.title"),
+                                                                        QStringLiteral("fallback"));
+
+    QCOMPARE(result, QStringLiteral("fallback"));
+}
+
+void TestExerciseTourResources::testTranslateFromCatalogMissingFileFallsBack()
+{
+    const QString result = ExerciseTourResources::translateFromCatalog(QStringLiteral("/no/such/catalog.json"),
+                                                                        QStringLiteral("basic-and-gate.title"),
+                                                                        QStringLiteral("fallback"));
+
+    QCOMPARE(result, QStringLiteral("fallback"));
+}
+
+void TestExerciseTourResources::testTranslateEnglishNeverTouchesDisk()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("en");
+
+    const QString result = ExerciseTourResources::translate(QStringLiteral("basic-and-gate.title"), QStringLiteral("fallback"));
+
+    Settings::setLanguage(originalLang);
+
+    QCOMPARE(result, QStringLiteral("fallback"));
+}
+
+void TestExerciseTourResources::testTranslateEmptyLanguageNeverTouchesDisk()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("");
+
+    const QString result = ExerciseTourResources::translate(QStringLiteral("basic-and-gate.title"), QStringLiteral("fallback"));
+
+    Settings::setLanguage(originalLang);
+
+    QCOMPARE(result, QStringLiteral("fallback"));
+}
+
+void TestExerciseTourResources::testMergeUniqueMergesNonCollidingEntries()
+{
+    QVector<ExerciseTourResourceEntry> base = {
+        {"/a.json", "a", "Title A", ""},
+    };
+    const QVector<ExerciseTourResourceEntry> additional = {
+        {"/b.json", "b", "Title B", ""},
+    };
+
+    const QVector<ExerciseTourResourceEntry> merged = ExerciseTourResources::mergeUnique(base, additional);
+
+    QCOMPARE(merged.size(), 2);
+    QCOMPARE(merged.at(0).id, QStringLiteral("a"));
+    QCOMPARE(merged.at(1).id, QStringLiteral("b"));
+}
+
+void TestExerciseTourResources::testMergeUniqueSkipsCollidingId()
+{
+    QVector<ExerciseTourResourceEntry> base = {
+        {"/builtin/a.json", "a", "Built-in A", ""},
+    };
+    const QVector<ExerciseTourResourceEntry> additional = {
+        {"/user/a.json", "a", "User A", ""},
+        {"/user/b.json", "b", "User B", ""},
+    };
+
+    const QVector<ExerciseTourResourceEntry> merged = ExerciseTourResources::mergeUnique(base, additional);
+
+    QCOMPARE(merged.size(), 2);
+    QCOMPARE(merged.at(0).id, QStringLiteral("a"));
+    QCOMPARE(merged.at(0).path, QStringLiteral("/builtin/a.json")); // base entry wins, not overwritten
+    QCOMPARE(merged.at(1).id, QStringLiteral("b"));
+}
+
+void TestExerciseTourResources::testManagedContentDirCreatesAndReturnsExistingPath()
+{
+    const QString dir = ExerciseTourResources::managedContentDir(QStringLiteral("ExerciseTourResourcesTestManagedCategory"));
+
+    QVERIFY(!dir.isEmpty());
+    QVERIFY(QDir(dir).exists());
+}
+
+void TestExerciseTourResources::testPreferredContentDirReturnsWritablePathOutsideManagedDir()
+{
+    const QString category = QStringLiteral("ExerciseTourResourcesTestPreferredCategory");
+
+    const QString preferred = ExerciseTourResources::preferredContentDir(category);
+    const QString managed = ExerciseTourResources::managedContentDir(category);
+
+    QVERIFY(!preferred.isEmpty());
+    QVERIFY(QDir(preferred).exists());
+    QVERIFY(QFileInfo(preferred).isWritable());
+    QVERIFY(!preferred.startsWith(managed)); // never resolves into the teacher/IT-managed folder
+}
+
+void TestExerciseTourResources::testResolveWritableDirFallsBackWhenCandidatesUnwritable()
+{
+    QTemporaryDir blockerDir;
+    QVERIFY(blockerDir.isValid());
+    writeFile(blockerDir.filePath("blocker.txt"), QStringLiteral("not a directory"));
+
+    // A path component that's a plain file, not a directory, reliably fails QDir::mkpath()
+    // on every platform - simulates "this candidate can't be created/written to" without
+    // needing real OS permission manipulation.
+    const QString unwritableCandidate = blockerDir.filePath("blocker.txt/subdir");
+
+    QTemporaryDir fallbackParent;
+    QVERIFY(fallbackParent.isValid());
+    const QString fallback = fallbackParent.filePath("fallback-subdir");
+
+    const QString result = ExerciseTourResources::resolveWritableDir({unwritableCandidate}, fallback);
+
+    QCOMPARE(result, fallback);
+    QVERIFY(QDir(fallback).exists());
+    QVERIFY(QFileInfo(fallback).isWritable());
+}

--- a/Tests/Unit/Core/TestExerciseTourResources.h
+++ b/Tests/Unit/Core/TestExerciseTourResources.h
@@ -1,0 +1,35 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestExerciseTourResources : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testScanValidEntries();
+    void testScanMissingDescriptionDefaultsToEmpty();
+    void testScanSkipsMalformedJson();
+    void testScanSkipsMissingIdOrTitle();
+    void testScanNonExistentDirectoryReturnsEmpty();
+
+    void testTranslateFromCatalogFoundKey();
+    void testTranslateFromCatalogMissingKeyFallsBack();
+    void testTranslateFromCatalogMalformedJsonFallsBack();
+    void testTranslateFromCatalogMissingFileFallsBack();
+
+    void testTranslateEnglishNeverTouchesDisk();
+    void testTranslateEmptyLanguageNeverTouchesDisk();
+
+    void testMergeUniqueMergesNonCollidingEntries();
+    void testMergeUniqueSkipsCollidingId();
+
+    void testManagedContentDirCreatesAndReturnsExistingPath();
+    void testPreferredContentDirReturnsWritablePathOutsideManagedDir();
+
+    void testResolveWritableDirFallsBackWhenCandidatesUnwritable();
+};


### PR DESCRIPTION
## Summary
- **`feat(exercise)`**: circuit-building challenges validated against the live scene — `ExerciseEngine`/`ExerciseOverlay`/`ExerciseBrowserDialog`, discovered via directory scan (`App/Core/ExerciseTourResources`) rather than a hardcoded list, with a user-writable content folder plus a teacher/IT managed-install folder.
- **`feat(tour)`**: guided spotlight walkthroughs of the UI — `TourEngine`/`TourOverlay`/`TourBrowserDialog`, sharing the same discovery/translation infrastructure introduced by the Exercise commit.
- Both content types are JSON-driven (`App/Resources/Exercises/*.json`, `App/Resources/Tours/*.json`), translated through a separate Weblate "JSON file" catalog (`App/Resources/Translations/ExerciseTour/`) since step text never passes through `tr()`.
- Includes two use-after-free fixes found and fixed during an adversarial review, folded into their respective commits: a dangling `TourOverlay*` when the BeWavedDolphin window it was reparented onto is closed (now `QPointer`), and a broken "previous tab" tracking bug in tab-switch handling that left a stale `ExerciseOverlay*` on the tab being left.

## Test plan
- [x] `cmake --build --preset debug` succeeds, both commits individually (bisectable) and at the final tip
- [x] `ctest --preset debug` — 177/177 passing
- [x] Manually verified the Exercises and Tours browser dialogs discover and launch their content