### PR TITLE
fix(build): eliminate cast-align violations on armhf/riscv64

### DIFF
--- a/App/Element/GraphicElements/Display7.cpp
+++ b/App/Element/GraphicElements/Display7.cpp
@@ -110,17 +110,20 @@ QPixmap Display7::convertColor(const QImage &source, const bool red, const bool 
     QImage target(source);
 
     for (int y = 0; y < target.height(); ++y) {
-        QRgb *line = reinterpret_cast<QRgb *>(target.scanLine(y));
         for (int x = 0; x < target.width(); ++x) {
-            QRgb &rgb = line[x];
             // The source SVG uses grayscale: red channel encodes pixel brightness.
             // Reuse that brightness value for the enabled channels and set alpha
             // equal to brightness so transparent backgrounds remain transparent.
-            const int value = qRed(rgb);
-            rgb = qRgba(red   ? value : 0,
-                        green ? value : 0,
-                        blue  ? value : 0,
-                        value);
+            // Uses the pixel()/setPixel() accessors instead of a raw scanLine()
+            // cast to QRgb* — scanLine() returns uchar*, and reinterpret_cast to
+            // the 4-byte-aligned QRgb is a -Wcast-align violation on armhf/riscv64
+            // (issue #453). Called only a handful of times total (cached), so the
+            // per-pixel accessor cost is irrelevant here.
+            const int value = qRed(target.pixel(x, y));
+            target.setPixel(x, y, qRgba(red   ? value : 0,
+                                         green ? value : 0,
+                                         blue  ? value : 0,
+                                         value));
         }
     }
 

--- a/App/Element/GraphicElements/ToneGenerator.h
+++ b/App/Element/GraphicElements/ToneGenerator.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstring>
 
 #include <QAudioFormat>
 #include <QIODevice>
@@ -62,10 +63,15 @@ protected:
         const double increment = m_frequency / SampleRate;
 
         const qint64 samples = maxSize / BytesPerSample;
-        auto *ptr = reinterpret_cast<qint16 *>(data);
 
         for (qint64 i = 0; i < samples; ++i) {
-            ptr[i] = static_cast<qint16>(Amplitude * std::sin(twoPi * m_phase));
+            // data is Qt's raw QIODevice buffer — no alignment guarantee, so a
+            // reinterpret_cast<qint16*> store is a -Wcast-align violation on
+            // armhf/riscv64 (issue #453). memcpy of a compile-time-constant 2
+            // bytes inlines to a single (possibly unaligned) store at -O2, so
+            // this has no measurable cost in the real-time audio path.
+            const qint16 sample = static_cast<qint16>(Amplitude * std::sin(twoPi * m_phase));
+            std::memcpy(data + i * BytesPerSample, &sample, sizeof(sample));
             m_phase += increment;
             if (m_phase >= 1.0) {
                 m_phase -= 1.0;

--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -4,6 +4,7 @@
 #include "App/IO/Serialization.h"
 
 #include <array>
+#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -18,6 +19,7 @@
 #include <QScopeGuard>
 #include <QSysInfo>
 #include <QtEndian>
+#include <QVarLengthArray>
 #include <QVariant>
 
 #include "App/Core/Common.h"
@@ -422,9 +424,21 @@ void Serialization::readDolphinHeader(QDataStream &stream)
     if (device->peek(strProbeBuf.data(), probeLen) != probeLen) {
         throw PANDACEPTION("Invalid file format.");
     }
-    const QString appName = QString::fromUtf16(
-        reinterpret_cast<const char16_t *>(strProbeBuf.constData() + sizeof(quint32)),
-        static_cast<int>(magicHeader / 2));
+    // strProbeBuf's buffer has no 2-byte alignment guarantee, so the UTF-16 code
+    // units are copied into a properly-aligned scratch buffer instead of being
+    // reinterpret_cast in place — that cast is a strict-aliasing/alignment
+    // violation that -Wcast-align catches on armhf/riscv64 (issue #453).
+    // Plain byte copy, no endian conversion: unlike the QDataStream-framed
+    // "wiRedPanda X.Y" legacy header in readPandaHeader above (which is read
+    // back via stream >> QString), this beWavedDolphin field is a raw
+    // native-order UTF-16 dump — introducing qFromBigEndian/qFromLittleEndian
+    // here, or reusing readPandaHeader's QDataStream-based probe, would change
+    // behaviour, not just alignment.
+    const int codeUnitCount = static_cast<int>(magicHeader / 2);
+    QVarLengthArray<char16_t, 128> appNameBuf(codeUnitCount);
+    std::memcpy(appNameBuf.data(), strProbeBuf.constData() + sizeof(quint32),
+                static_cast<size_t>(magicHeader));
+    const QString appName = QString::fromUtf16(appNameBuf.constData(), codeUnitCount);
     if (!appName.startsWith("beWavedDolphin")) {
         throw PANDACEPTION("Invalid file format.");
     }

--- a/Tests/Unit/Serialization/TestDolphinSerializer.cpp
+++ b/Tests/Unit/Serialization/TestDolphinSerializer.cpp
@@ -221,7 +221,7 @@ void TestDolphinSerializer::testReadDolphinHeaderParsesLegacyAppName()
     // UTF-16 code units (no QDataStream QString framing — this format predates
     // that; see the comment in Serialization::readDolphinHeader).
     const QString appName = QStringLiteral("beWavedDolphin 1.0");
-    const int byteLen = appName.size() * 2;
+    const int byteLen = static_cast<int>(appName.size()) * 2;
 
     QByteArray payload;
     {

--- a/Tests/Unit/Serialization/TestDolphinSerializer.cpp
+++ b/Tests/Unit/Serialization/TestDolphinSerializer.cpp
@@ -212,3 +212,37 @@ void TestDolphinSerializer::testReadDolphinHeaderRejectsLargeAppName()
     QDataStream stream(data);
     QVERIFY_THROWS(std::exception, Serialization::readDolphinHeader(stream));
 }
+
+void TestDolphinSerializer::testReadDolphinHeaderParsesLegacyAppName()
+{
+    // Synthetic legacy ".dolphin" stream: 4-byte length prefix (big-endian,
+    // matching peekU32's qFromBigEndian convention — same as the modern-format
+    // magic-number field), followed by "beWavedDolphin 1.0" as raw *native-order*
+    // UTF-16 code units (no QDataStream QString framing — this format predates
+    // that; see the comment in Serialization::readDolphinHeader).
+    const QString appName = QStringLiteral("beWavedDolphin 1.0");
+    const int byteLen = appName.size() * 2;
+
+    QByteArray payload;
+    {
+        QDataStream out(&payload, QIODevice::WriteOnly);
+        out.setVersion(QDataStream::Qt_5_12);
+        out << static_cast<quint32>(byteLen); // default byte order is BigEndian
+    }
+    payload.append(reinterpret_cast<const char *>(appName.utf16()), byteLen);
+
+    QDataStream stream(payload);
+    stream.setVersion(QDataStream::Qt_5_12);
+
+    bool threw = false;
+    try {
+        Serialization::readDolphinHeader(stream);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY(!threw);
+    QCOMPARE(stream.status(), QDataStream::Ok);
+    // Header fully consumed (4-byte length + byteLen bytes) — next read should
+    // land exactly where the caller (DolphinSerializer::loadBinary) expects it.
+    QCOMPARE(stream.device()->pos(), qint64(4 + byteLen));
+}

--- a/Tests/Unit/Serialization/TestDolphinSerializer.h
+++ b/Tests/Unit/Serialization/TestDolphinSerializer.h
@@ -36,4 +36,8 @@ private slots:
     // libFuzzer regression (Tests/Fuzz/regressions/) — legacy .dolphin header
     // with a fuzz-controlled app-name length must be rejected before allocation.
     void testReadDolphinHeaderRejectsLargeAppName();
+
+    // Regression: issue #453 — legacy beWavedDolphin header's raw UTF-16
+    // app-name probe must still parse correctly after the -Wcast-align fix.
+    void testReadDolphinHeaderParsesLegacyAppName();
 };


### PR DESCRIPTION
## Summary

Fixes #453 — wiRedPanda 5.1.3 failed to build on armhf and riscv64 with `-Werror=cast-align`, because three `reinterpret_cast`s reinterpreted a byte pointer as a wider-aligned type:

- `App/IO/Serialization.cpp` (`readDolphinHeader`): `const char*` → `const char16_t*`
- `App/Element/GraphicElements/Display7.cpp` (`convertColor`): `uchar*` → `QRgb*`
- `App/Element/GraphicElements/ToneGenerator.h` (`readData`): `char*` → `qint16*`

This never surfaced in CI because plain `-Wcast-align` only fires when the compiler knows the target enforces strict alignment (armhf/riscv64) — CI only runs x86_64 and AArch64, neither of which trip it.

- `readDolphinHeader` now `memcpy`s into a properly-aligned `QVarLengthArray<char16_t, 128>` scratch buffer instead of casting in place (with a comment on why the sibling `readPandaHeader`'s `QDataStream >> QString` idiom must not be reused here — it's a different wire format and would silently byte-swap real files).
- `Display7::convertColor` now uses `QImage::pixel()`/`setPixel()` instead of a raw `scanLine()` cast — verified against Qt 6 source that this is a byte-for-byte identical operation, just moved inside Qt's own compiled library.
- `ToneGenerator::readData` now writes each sample via a per-sample `memcpy` instead of a raw pointer store.
- Added a regression test (`testReadDolphinHeaderParsesLegacyAppName`) covering the previously-untested successful legacy-header parse path.

## Test plan

- [x] Full native MSVC build (`cmake --build --preset debug`) succeeds
- [x] Full test suite passes: `ctest --preset debug` → 179/179 passed, including the new test and all `TestDisplay7`/`TestDolphinSerializer` cases
- [x] Cross-compiled a standalone repro of all three cast shapes with the real `arm-linux-gnueabihf-g++` and `riscv64-linux-gnu-g++` toolchains under plain `-Wcast-align -Werror`: the pre-fix pattern reproduces the exact three errors from the issue on both targets, the post-fix pattern compiles clean on both