### PR TITLE
docs: switch star history chart to sealed-token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ The translations are located in the [App/Resources/Translations](https://github.
 <img src="https://hosted.weblate.org/widget/wiredpanda/wiredpanda/multi-auto.svg" alt="Translation status" />
 </a>
 
-## Stars
+## Star History
 
-<a href="https://www.star-history.com/#GIBIS-UNIFESP/wiRedPanda&Date">
+<a href="https://www.star-history.com/?repos=GIBIS-UNIFESP%2FwiRedPanda&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&theme=dark&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
  </picture>
 </a>
 

--- a/README_es.md
+++ b/README_es.md
@@ -57,13 +57,13 @@ Las traducciones se encuentran en el directorio [App/Resources/Translations](htt
 <img src="https://hosted.weblate.org/widget/wiredpanda/wiredpanda/multi-auto.svg" alt="Estado de la traducción" />
 </a>
 
-## Estrellas
+## Historial de Estrellas
 
-<a href="https://www.star-history.com/#GIBIS-UNIFESP/wiRedPanda&Date">
+<a href="https://www.star-history.com/?repos=GIBIS-UNIFESP%2FwiRedPanda&type=date&legend=top-left">
 <picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date&theme=dark" />
-<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
-<img alt="Gráfico histórico de estrellas" src="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
+<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&theme=dark&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+<img alt="Gráfico histórico de estrellas" src="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
 </picture>
 </a>
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -57,13 +57,13 @@ As traduções estão localizadas no diretório [App/Resources/Translations](htt
 <img src="https://hosted.weblate.org/widget/wiredpanda/wiredpanda/multi-auto.svg" alt="Status da tradução" />
 </a>
 
-## Estrelas
+## Histórico de Estrelas
 
-<a href="https://www.star-history.com/#GIBIS-UNIFESP/wiRedPanda&Date">
+<a href="https://www.star-history.com/?repos=GIBIS-UNIFESP%2FwiRedPanda&type=date&legend=top-left">
 <picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date&theme=dark" />
-<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
-<img alt="Gráfico Histórico Estelar" src="https://api.star-history.com/svg?repos=GIBIS-UNIFESP/wiRedPanda&type=Date" />
+<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&theme=dark&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
+<img alt="Gráfico Histórico Estelar" src="https://api.star-history.com/chart?repos=GIBIS-UNIFESP/wiRedPanda&type=date&legend=top-left&sealed_token=U2xfd63gLfdN7hNXCqP_s6FCeboyNACDWqEoE53Q-AGtfVCOHJMCJ9Ee1sLr5iCKj7j0VPS5PnySLjVDJjCpaL8yfvKVId5e1JSqHf17ByJ1ZoRqqB7dcA" />
 </picture>
 </a>
 


### PR DESCRIPTION
## Summary
- GitHub now restricts the stargazer API star-history.com needs, so their chart now requires a `sealed_token` (a PAT encrypted server-side, not the raw token) appended to the `/chart` endpoint.
- Updates the English, Spanish, and Portuguese READMEs to the new endpoint/token and renames the section to "Star History" / "Historial de Estrellas" / "Histórico de Estrelas" to match star-history.com's current embed snippet.

## Test plan
- [x] Visually diff the three README sections against star-history.com's generated snippet
- [ ] Confirm the chart renders on GitHub after merge (image is fetched live from api.star-history.com)