### PR TITLE
fix(exercise,tour): retranslate overlay text live on language change

### DIFF
--- a/App/Exercise/ExerciseEngine.cpp
+++ b/App/Exercise/ExerciseEngine.cpp
@@ -28,6 +28,7 @@ bool ExerciseEngine::loadFromResource(const QString &resourcePath)
     m_currentStep = 0;
     m_id.clear();
     m_title.clear();
+    m_resourcePath = resourcePath;
 
     QFile file(resourcePath);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -169,6 +170,22 @@ void ExerciseEngine::advanceStep()
     ++m_currentStep;
     Settings::setExerciseProgress(m_id, m_currentStep);
     emitCurrentStep();
+}
+
+void ExerciseEngine::retranslate()
+{
+    if (m_resourcePath.isEmpty() || !m_active) {
+        return;
+    }
+    const int savedStep = m_currentStep;
+
+    if (!loadFromResource(m_resourcePath)) {
+        return;
+    }
+
+    m_currentStep = qBound(0, savedStep, static_cast<int>(m_steps.size()) - 1);
+    m_active = true;
+    emit retranslated();
 }
 
 void ExerciseEngine::onCircuitChanged()

--- a/App/Exercise/ExerciseEngine.h
+++ b/App/Exercise/ExerciseEngine.h
@@ -43,11 +43,18 @@ public:
     /// Manually advances one step (used by the overlay Next/Finish button for observe steps).
     void advanceStep();
 
+    /// Re-translates the title and all steps' instruction/hint text for the current
+    /// language, preserving currentStep()/isActive(). No-op if never loaded or inactive.
+    /// Emits retranslated() (never stepChanged()) so listeners can't replay step-entry
+    /// side effects like MainWindow's click-target handling.
+    void retranslate();
+
 signals:
     void stepChanged(int step, int total, const ExerciseStep &data);
     void stepCompleted(int step);
     void exerciseCompleted();
     void exerciseStopped();
+    void retranslated();
 
 private slots:
     void onCircuitChanged();
@@ -65,6 +72,7 @@ private:
 
     QString               m_id;
     QString               m_title;
+    QString               m_resourcePath;
     QVector<ExerciseStep> m_steps;
     int                   m_currentStep = 0;
     bool                  m_active = false;

--- a/App/Exercise/ExerciseOverlay.cpp
+++ b/App/Exercise/ExerciseOverlay.cpp
@@ -190,6 +190,26 @@ void ExerciseOverlay::onStepChanged(int step, int total, const ExerciseStep &ste
     repositionToParent();
 }
 
+void ExerciseOverlay::onRetranslated()
+{
+    const ExerciseStep &stepData = m_engine->currentStepData();
+    const int step  = m_engine->currentStep();
+    const int total = m_engine->totalSteps();
+
+    m_stepCounter->setText(tr("Step %1 of %2").arg(step + 1).arg(total));
+    m_instructionLabel->setText(stepData.instruction);
+    m_hintLabel->setText(stepData.hint);
+    updateNextButton(step == total - 1);
+
+    m_closeButton->setText(tr("Exit"));
+    m_closeButton->setToolTip(tr("Close exercise"));
+    m_hintButton->setText(m_hintVisible ? tr("Hide hint") : tr("Hint"));
+    m_prevButton->setText(tr("← Back"));
+
+    adjustSize();
+    repositionToParent();
+}
+
 void ExerciseOverlay::onExerciseCompleted()
 {
     m_stepCounter->setText({});

--- a/App/Exercise/ExerciseOverlay.h
+++ b/App/Exercise/ExerciseOverlay.h
@@ -27,6 +27,7 @@ public:
 public slots:
     void onStepChanged(int step, int total, const ExerciseStep &stepData);
     void onExerciseCompleted();
+    void onRetranslated();
 
 signals:
     void closeRequested();

--- a/App/Tour/TourEngine.cpp
+++ b/App/Tour/TourEngine.cpp
@@ -23,6 +23,7 @@ bool TourEngine::loadFromResource(const QString &resourcePath)
     m_currentStep = 0;
     m_id.clear();
     m_title.clear();
+    m_resourcePath = resourcePath;
 
     QFile file(resourcePath);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -127,6 +128,22 @@ void TourEngine::advanceStep()
     ++m_currentStep;
     Settings::setTourProgress(m_id, m_currentStep);
     emitCurrentStep();
+}
+
+void TourEngine::retranslate()
+{
+    if (m_resourcePath.isEmpty() || !m_active) {
+        return;
+    }
+    const int savedStep = m_currentStep;
+
+    if (!loadFromResource(m_resourcePath)) {
+        return;
+    }
+
+    m_currentStep = qBound(0, savedStep, static_cast<int>(m_steps.size()) - 1);
+    m_active = true;
+    emit retranslated();
 }
 
 void TourEngine::emitCurrentStep()

--- a/App/Tour/TourEngine.h
+++ b/App/Tour/TourEngine.h
@@ -34,10 +34,17 @@ public:
     void goToPreviousStep();
     void advanceStep();
 
+    /// Re-translates the title and all steps' title/body text for the current language,
+    /// preserving currentStep()/isActive(). No-op if never loaded or inactive. Emits
+    /// retranslated() (never stepChanged()) so listeners can't replay step-entry side
+    /// effects like MainWindow's click-target handling.
+    void retranslate();
+
 signals:
     void stepChanged(int step, int total, const TourStep &data);
     void tourCompleted();
     void tourStopped();
+    void retranslated();
 
 private:
     void emitCurrentStep();
@@ -45,6 +52,7 @@ private:
 
     QString           m_id;
     QString           m_title;
+    QString           m_resourcePath;
     QVector<TourStep> m_steps;
     int               m_currentStep = 0;
     bool              m_active = false;

--- a/App/Tour/TourOverlay.cpp
+++ b/App/Tour/TourOverlay.cpp
@@ -207,6 +207,26 @@ void TourOverlay::onStepChanged(int step, int total, const TourStep &stepData)
     m_callout->show();
 }
 
+void TourOverlay::onRetranslated()
+{
+    const TourStep &stepData = m_engine->currentStepData();
+    const int step  = m_engine->currentStep();
+    const int total = m_engine->totalSteps();
+
+    m_stepCounter->setText(tr("Step %1 of %2").arg(step + 1).arg(total));
+    m_titleLabel->setText(stepData.title);
+    m_bodyLabel->setText(stepData.body);
+    m_nextButton->setText(step == total - 1 ? tr("Finish") : tr("Next →"));
+
+    m_closeButton->setText(tr("Exit"));
+    m_closeButton->setToolTip(tr("Stop the tour"));
+    m_prevButton->setText(tr("← Back"));
+
+    m_callout->adjustSize();
+    repositionCallout();
+    update();
+}
+
 void TourOverlay::onTourFinished()
 {
     hide();

--- a/App/Tour/TourOverlay.h
+++ b/App/Tour/TourOverlay.h
@@ -40,6 +40,7 @@ public:
 public slots:
     void onStepChanged(int step, int total, const TourStep &stepData);
     void onTourFinished();
+    void onRetranslated();
 
 signals:
     void closeRequested();

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -101,6 +101,11 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
     connect(m_binder, &SceneUiBinder::openICRequested, m_workspaceManager, &WorkspaceManager::openICInTab);
     connect(m_binder, &SceneUiBinder::loadFileRequested, m_workspaceManager, &WorkspaceManager::loadPandaFile);
 
+    // Must be created before setupLanguage(): loading a translation can synchronously
+    // emit translationChanged(), which retranslateUi() handles by calling isActive() here.
+    m_exerciseEngine = new ExerciseEngine(this);
+    m_tourEngine     = new TourEngine(this);
+
     setupLanguage();
     setupGeometry();
     setupTheme();
@@ -119,9 +124,6 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
 
     qCDebug(zero) << "Setting connections";
     setupConnections();
-
-    m_exerciseEngine = new ExerciseEngine(this);
-    m_tourEngine     = new TourEngine(this);
 
     qCDebug(zero) << "Checking playing simulation.";
     // Start simulation running by default so the circuit is live on open.
@@ -886,6 +888,13 @@ void MainWindow::retranslateUi()
             elm->retranslate();
         }
     }
+
+    if (m_exerciseEngine->isActive()) {
+        m_exerciseEngine->retranslate();
+    }
+    if (m_tourEngine->isActive()) {
+        m_tourEngine->retranslate();
+    }
 }
 
 void MainWindow::loadTranslation(const QString &language)
@@ -1230,6 +1239,8 @@ void MainWindow::startExercise(const QString &resourcePath)
             m_exerciseOverlay, &ExerciseOverlay::onStepChanged);
     connect(m_exerciseEngine, &ExerciseEngine::exerciseCompleted,
             m_exerciseOverlay, &ExerciseOverlay::onExerciseCompleted);
+    connect(m_exerciseEngine, &ExerciseEngine::retranslated,
+            m_exerciseOverlay, &ExerciseOverlay::onRetranslated);
     connect(m_exerciseOverlay, &ExerciseOverlay::closeRequested, this, [this] {
         if (!m_exerciseOverlay) return;
         ExerciseOverlay *overlay = m_exerciseOverlay;
@@ -1309,6 +1320,8 @@ void MainWindow::startTour(const QString &resourcePath)
             m_tourOverlay, &TourOverlay::onTourFinished);
     connect(m_tourEngine, &TourEngine::tourStopped,
             m_tourOverlay, &TourOverlay::onTourFinished);
+    connect(m_tourEngine, &TourEngine::retranslated,
+            m_tourOverlay, &TourOverlay::onRetranslated);
     connect(m_tourOverlay, &TourOverlay::closeRequested, this, [this] {
         if (!m_tourOverlay) return;
         TourOverlay *overlay = m_tourOverlay;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,6 +873,8 @@ add_test(NAME TestDanglingPointer COMMAND test_wiredpanda TestDanglingPointer WO
 add_test(NAME TestSystemVerilogCodeGenUnit COMMAND test_wiredpanda TestSystemVerilogCodeGenUnit WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestTrashButton COMMAND test_wiredpanda TestTrashButton WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestExerciseTourResources COMMAND test_wiredpanda TestExerciseTourResources WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestExerciseEngine COMMAND test_wiredpanda TestExerciseEngine WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestTourEngine COMMAND test_wiredpanda TestTourEngine WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestUpdateChecker COMMAND test_wiredpanda TestUpdateChecker WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # ============================================================================

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -467,6 +467,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestSequentialLogic.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestTruthTable.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestWirelessNode.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Exercise/TestExerciseEngine.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Factory/TestElementFactory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogic.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.cpp
@@ -488,6 +489,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestDanglingPointer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestSimulation.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestSimulationBlocker.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Tour/TestTourEngine.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestCircuitExporter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestDialogs.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestElementContextMenu.cpp
@@ -655,6 +657,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestSequentialLogic.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestTruthTable.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Elements/TestWirelessNode.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Exercise/TestExerciseEngine.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Factory/TestElementFactory.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogic.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.h
@@ -676,6 +679,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestDanglingPointer.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestSimulation.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Simulation/TestSimulationBlocker.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Tour/TestTourEngine.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestCircuitExporter.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestDialogs.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Ui/TestElementContextMenu.h

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -155,6 +155,8 @@
 #include "Tests/Unit/Elements/TestSequentialLogic.h"
 #include "Tests/Unit/Elements/TestTruthTable.h"
 #include "Tests/Unit/Elements/TestWirelessNode.h"
+// unit/exercise
+#include "Tests/Unit/Exercise/TestExerciseEngine.h"
 // unit/factory
 #include "Tests/Unit/Factory/TestElementFactory.h"
 // unit/logic
@@ -181,6 +183,8 @@
 #include "Tests/Unit/Simulation/TestDanglingPointer.h"
 #include "Tests/Unit/Simulation/TestSimulation.h"
 #include "Tests/Unit/Simulation/TestSimulationBlocker.h"
+// unit/tour
+#include "Tests/Unit/Tour/TestTourEngine.h"
 // unit/ui
 #include "Tests/Unit/Ui/TestCircuitExporter.h"
 #include "Tests/Unit/Ui/TestDialogs.h"
@@ -316,6 +320,7 @@ int main(int argc, char **argv)
         {"TestThemeManager", []() -> QObject * { return new TestThemeManager; }},
         {"TestCoreSettings", []() -> QObject * { return new TestCoreSettings; }},
         {"TestExerciseTourResources", []() -> QObject * { return new TestExerciseTourResources; }},
+        {"TestExerciseEngine", []() -> QObject * { return new TestExerciseEngine; }},
         {"TestUpdateChecker", []() -> QObject * { return new TestUpdateChecker; }},
         {"TestApplication", []() -> QObject * { return new TestApplication; }},
         {"TestNotifyCatch", []() -> QObject * { return new TestNotifyCatch; }},
@@ -372,6 +377,7 @@ int main(int argc, char **argv)
         {"TestPort", []() -> QObject * { return new TestPort; }},
         {"TestSimulationUnit", []() -> QObject * { return new TestSimulationUnit; }},
         {"TestSimulationBlocker", []() -> QObject * { return new TestSimulationBlocker; }},
+        {"TestTourEngine", []() -> QObject * { return new TestTourEngine; }},
         {"TestDanglingPointer", []() -> QObject * { return new TestDanglingPointer; }},
         {"TestCircuitExporter", []() -> QObject * { return new TestCircuitExporter; }},
         {"TestDialogs", []() -> QObject * { return new TestDialogs; }},

--- a/Tests/Unit/Exercise/TestExerciseEngine.cpp
+++ b/Tests/Unit/Exercise/TestExerciseEngine.cpp
@@ -1,0 +1,119 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/Exercise/TestExerciseEngine.h"
+
+#include <QFile>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+
+#include "App/Core/Settings.h"
+#include "App/Exercise/ExerciseEngine.h"
+
+namespace {
+
+const char *const kExerciseFixtureId = "test-retranslate-exercise";
+
+const char *const kExerciseFixtureJson = R"({
+    "id": "test-retranslate-exercise",
+    "title": "Test Exercise",
+    "steps": [
+        { "key": "step0", "instruction": "Instruction 0", "hint": "Hint 0" },
+        { "key": "step1", "instruction": "Instruction 1", "hint": "Hint 1" }
+    ]
+})";
+
+QString writeExerciseFixture(const QTemporaryDir &dir)
+{
+    const QString path = dir.filePath("exercise.json");
+    QFile file(path);
+    file.open(QIODevice::WriteOnly);
+    file.write(kExerciseFixtureJson);
+    return path;
+}
+
+} // namespace
+
+void TestExerciseEngine::testRetranslateBeforeLoadIsNoOp()
+{
+    ExerciseEngine engine;
+    QSignalSpy retranslatedSpy(&engine, &ExerciseEngine::retranslated);
+
+    engine.retranslate();
+
+    QVERIFY(!engine.isActive());
+    QCOMPARE(retranslatedSpy.count(), 0);
+}
+
+void TestExerciseEngine::testRetranslateWhileInactiveIsNoOp()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeExerciseFixture(dir);
+
+    ExerciseEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    QVERIFY(!engine.isActive()); // loadFromResource() alone never activates the engine
+
+    QSignalSpy retranslatedSpy(&engine, &ExerciseEngine::retranslated);
+    engine.retranslate();
+
+    QVERIFY(!engine.isActive());
+    QCOMPARE(retranslatedSpy.count(), 0);
+}
+
+void TestExerciseEngine::testRetranslatePreservesProgressAndData()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("en");
+    Settings::setExerciseProgress(QLatin1String(kExerciseFixtureId), 0);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeExerciseFixture(dir);
+
+    ExerciseEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    engine.start();
+    engine.advanceStep();
+
+    QCOMPARE(engine.currentStep(), 1);
+    QVERIFY(engine.isActive());
+
+    engine.retranslate();
+
+    QCOMPARE(engine.currentStep(), 1);
+    QVERIFY(engine.isActive());
+    QCOMPARE(engine.exerciseTitle(), QStringLiteral("Test Exercise"));
+    QCOMPARE(engine.currentStepData().instruction, QStringLiteral("Instruction 1"));
+    QCOMPARE(engine.currentStepData().hint, QStringLiteral("Hint 1"));
+
+    Settings::setLanguage(originalLang);
+}
+
+void TestExerciseEngine::testRetranslateEmitsRetranslatedOnly()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("en");
+    Settings::setExerciseProgress(QLatin1String(kExerciseFixtureId), 0);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeExerciseFixture(dir);
+
+    ExerciseEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    engine.start();
+
+    QSignalSpy retranslatedSpy(&engine, &ExerciseEngine::retranslated);
+    QSignalSpy stepChangedSpy(&engine, &ExerciseEngine::stepChanged);
+    QSignalSpy stepCompletedSpy(&engine, &ExerciseEngine::stepCompleted);
+
+    engine.retranslate();
+
+    QCOMPARE(retranslatedSpy.count(), 1);
+    QCOMPARE(stepChangedSpy.count(), 0);
+    QCOMPARE(stepCompletedSpy.count(), 0);
+
+    Settings::setLanguage(originalLang);
+}

--- a/Tests/Unit/Exercise/TestExerciseEngine.h
+++ b/Tests/Unit/Exercise/TestExerciseEngine.h
@@ -1,0 +1,18 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestExerciseEngine : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testRetranslateBeforeLoadIsNoOp();
+    void testRetranslateWhileInactiveIsNoOp();
+    void testRetranslatePreservesProgressAndData();
+    void testRetranslateEmitsRetranslatedOnly();
+};

--- a/Tests/Unit/Tour/TestTourEngine.cpp
+++ b/Tests/Unit/Tour/TestTourEngine.cpp
@@ -1,0 +1,117 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/Tour/TestTourEngine.h"
+
+#include <QFile>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+
+#include "App/Core/Settings.h"
+#include "App/Tour/TourEngine.h"
+
+namespace {
+
+const char *const kTourFixtureId = "test-retranslate-tour";
+
+const char *const kTourFixtureJson = R"({
+    "id": "test-retranslate-tour",
+    "title": "Test Tour",
+    "steps": [
+        { "key": "step0", "title": "Title 0", "body": "Body 0" },
+        { "key": "step1", "title": "Title 1", "body": "Body 1" }
+    ]
+})";
+
+QString writeTourFixture(const QTemporaryDir &dir)
+{
+    const QString path = dir.filePath("tour.json");
+    QFile file(path);
+    file.open(QIODevice::WriteOnly);
+    file.write(kTourFixtureJson);
+    return path;
+}
+
+} // namespace
+
+void TestTourEngine::testRetranslateBeforeLoadIsNoOp()
+{
+    TourEngine engine;
+    QSignalSpy retranslatedSpy(&engine, &TourEngine::retranslated);
+
+    engine.retranslate();
+
+    QVERIFY(!engine.isActive());
+    QCOMPARE(retranslatedSpy.count(), 0);
+}
+
+void TestTourEngine::testRetranslateWhileInactiveIsNoOp()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeTourFixture(dir);
+
+    TourEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    QVERIFY(!engine.isActive()); // loadFromResource() alone never activates the engine
+
+    QSignalSpy retranslatedSpy(&engine, &TourEngine::retranslated);
+    engine.retranslate();
+
+    QVERIFY(!engine.isActive());
+    QCOMPARE(retranslatedSpy.count(), 0);
+}
+
+void TestTourEngine::testRetranslatePreservesProgressAndData()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("en");
+    Settings::setTourProgress(QLatin1String(kTourFixtureId), 0);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeTourFixture(dir);
+
+    TourEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    engine.start();
+    engine.advanceStep();
+
+    QCOMPARE(engine.currentStep(), 1);
+    QVERIFY(engine.isActive());
+
+    engine.retranslate();
+
+    QCOMPARE(engine.currentStep(), 1);
+    QVERIFY(engine.isActive());
+    QCOMPARE(engine.tourTitle(), QStringLiteral("Test Tour"));
+    QCOMPARE(engine.currentStepData().title, QStringLiteral("Title 1"));
+    QCOMPARE(engine.currentStepData().body, QStringLiteral("Body 1"));
+
+    Settings::setLanguage(originalLang);
+}
+
+void TestTourEngine::testRetranslateEmitsRetranslatedOnly()
+{
+    const QString originalLang = Settings::language();
+    Settings::setLanguage("en");
+    Settings::setTourProgress(QLatin1String(kTourFixtureId), 0);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = writeTourFixture(dir);
+
+    TourEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+    engine.start();
+
+    QSignalSpy retranslatedSpy(&engine, &TourEngine::retranslated);
+    QSignalSpy stepChangedSpy(&engine, &TourEngine::stepChanged);
+
+    engine.retranslate();
+
+    QCOMPARE(retranslatedSpy.count(), 1);
+    QCOMPARE(stepChangedSpy.count(), 0);
+
+    Settings::setLanguage(originalLang);
+}

--- a/Tests/Unit/Tour/TestTourEngine.h
+++ b/Tests/Unit/Tour/TestTourEngine.h
@@ -1,0 +1,18 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestTourEngine : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testRetranslateBeforeLoadIsNoOp();
+    void testRetranslateWhileInactiveIsNoOp();
+    void testRetranslatePreservesProgressAndData();
+    void testRetranslateEmitsRetranslatedOnly();
+};


### PR DESCRIPTION
## Summary
- Exercise/Tour overlay text (title/instruction/hint or title/body) was translated once at load time and cached, so switching the app language while an exercise or tour was open left the overlay stuck in the old language until closed and reopened.
- Adds `retranslate()` + a dedicated `retranslated()` signal on `ExerciseEngine`/`TourEngine`, and `onRetranslated()` slots on `ExerciseOverlay`/`TourOverlay` that refresh all displayed text (including the static "Exit"/"Hint"/"← Back" button labels), wired into `MainWindow::retranslateUi()`.
- Deliberately does **not** reuse the existing `stepChanged` signal to trigger the refresh: that signal is wired to `MainWindow`'s non-idempotent `clickTarget()` handling (some click ids unconditionally add new demo elements to the scene), so reusing it would have duplicated circuit elements into the user's canvas on every language switch.
- Along the way, this exposed a null-pointer crash on startup: `m_exerciseEngine`/`m_tourEngine` were constructed *after* `setupLanguage()` in `MainWindow`'s constructor, but `setupLanguage()` can synchronously trigger `retranslateUi()` before those members exist. Fixed by constructing them earlier, matching the existing precedent for `m_palette`.

## Test plan
- [x] Added `TestExerciseEngine`/`TestTourEngine` covering `retranslate()`: no-op before load, no-op while inactive, preserves `currentStep()`/`isActive()`, emits `retranslated()` only (never `stepChanged()`/`stepCompleted()`).
- [x] Full suite: `ctest --preset debug` — 181/181 passing.
- [x] Manually verified in the running app: started the "Clock and LED" exercise, switched language mid-overlay, confirmed all overlay text (including buttons) updates immediately in place, and no duplicate circuit elements appear on the canvas.