### PR TITLE
fix(io): bound embedded-IC blob registry deserialization on file load

### DIFF
--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -695,7 +695,7 @@ QMap<QString, QByteArray> Serialization::deserializeBlobRegistry(const QMap<QStr
         if (VersionInfo::hasVersionedBlobRegistry(fileVersion))
             regStream.setVersion(QDataStream::Qt_5_12);
         // Pre-V_5_0 files: no setVersion — use Qt default matching the build that wrote them.
-        regStream >> result;
+        result = readBoundedBlobMap(regStream);
     }
     return result;
 }

--- a/Tests/Unit/Exercise/TestExerciseEngine.cpp
+++ b/Tests/Unit/Exercise/TestExerciseEngine.cpp
@@ -27,7 +27,9 @@ QString writeExerciseFixture(const QTemporaryDir &dir)
 {
     const QString path = dir.filePath("exercise.json");
     QFile file(path);
-    file.open(QIODevice::WriteOnly);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return {};
+    }
     file.write(kExerciseFixtureJson);
     return path;
 }

--- a/Tests/Unit/Serialization/TestSerialization.cpp
+++ b/Tests/Unit/Serialization/TestSerialization.cpp
@@ -19,6 +19,7 @@
 #include "App/IO/Serialization.h"
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
+#include "App/Versions.h"
 #include "App/Wiring/Connection.h"
 #include "App/Wiring/Port.h"
 #include "Tests/Common/TestUtils.h"
@@ -1222,6 +1223,31 @@ void TestSerialization::testMalformedConnectionData()
         // Acceptable to fail on malformed data
         QVERIFY2(!QString(e.what()).isEmpty(), "Exception should explain the malformed connection issue");
     }
+}
+
+void TestSerialization::testMalformedEmbeddedICsRegistryRejected()
+{
+    // A crafted embeddedICs blob whose leading QMap entry count vastly exceeds what
+    // the buffer could hold. Serialization::deserializeBlobRegistry must reject this
+    // via readBoundedBlobMap before Qt's raw QMap<QString,QByteArray>::operator>> can
+    // spin through an implausible entry count.
+    QByteArray badRegistry;
+    QDataStream writeStream(&badRegistry, QIODevice::WriteOnly);
+    writeStream.setVersion(QDataStream::Qt_5_12);
+    writeStream << 0xFFFFFFFFu; // implausible entry count
+    // No entries follow — nowhere near enough bytes for that many key/value pairs.
+
+    QMap<QString, QVariant> metadata;
+    metadata.insert("embeddedICs", badRegistry);
+
+    bool threw = false;
+    try {
+        Serialization::deserializeBlobRegistry(metadata, FormatRev::current);
+    } catch (const std::exception &e) {
+        threw = true;
+        QVERIFY2(!QString(e.what()).isEmpty(), "Exception should explain the implausible count");
+    }
+    QVERIFY2(threw, "Implausible embeddedICs entry count should be rejected, not allocated");
 }
 
 // ============================================================

--- a/Tests/Unit/Serialization/TestSerialization.h
+++ b/Tests/Unit/Serialization/TestSerialization.h
@@ -74,6 +74,7 @@ private slots:
     void testStreamPositionValidation();
     void testConnectionWithDeletedPorts();
     void testMalformedConnectionData();
+    void testMalformedEmbeddedICsRegistryRejected();
 
     // Wireless node serialization (4 tests)
     void testWirelessTxNodePreservedInScene();

--- a/Tests/Unit/Tour/TestTourEngine.cpp
+++ b/Tests/Unit/Tour/TestTourEngine.cpp
@@ -27,7 +27,9 @@ QString writeTourFixture(const QTemporaryDir &dir)
 {
     const QString path = dir.filePath("tour.json");
     QFile file(path);
-    file.open(QIODevice::WriteOnly);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return {};
+    }
     file.write(kTourFixtureJson);
     return path;
 }


### PR DESCRIPTION
## Summary
- `Serialization::deserializeBlobRegistry` extracted the `embeddedICs`/`blobRegistry` `QByteArray` safely, but then deserialized its contents with a raw `QDataStream >> QMap<QString, QByteArray>`, on every `.panda` file open that contains embedded ICs. A crafted file can set the leading entry count to an implausible value and spin the read loop before any application-level validation.
- `ClipboardManager::paste()` already solves the identical extraction shape correctly, via `Serialization::readBoundedBlobMap`, for the clipboard-paste path — the file-load path never got the same treatment. This swaps in that existing helper.
- Includes a small prerequisite commit fixing an unrelated pre-existing build break (`-Werror=unused-result` on two ignored `QFile::open()` return values in test fixtures) that was blocking the debug preset from building at all.

## Test plan
- [x] `cmake --build --preset debug` succeeds
- [x] `ctest --preset debug` — 181/181 passed
- [x] New regression test `TestSerialization::testMalformedEmbeddedICsRegistryRejected` — crafted oversized entry count is rejected cleanly instead of hanging/allocating

🤖 Generated with [Claude Code](https://claude.com/claude-code)