### PR TITLE
ci: work around flaky packages.microsoft.com apt mirror

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,10 @@ jobs:
         pip install --upgrade pip
         pip install -r MCP/Client/requirements.txt
 
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
     - name: Install Qt
       uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,6 +67,10 @@ jobs:
         build-mode: ${{ matrix.build-mode }}
         config-file: ${{ matrix.config }}
 
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux' && matrix.language == 'cpp'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
     - name: Install Qt
       if: matrix.language == 'cpp'
       uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
@@ -134,6 +138,10 @@ jobs:
         languages: cpp
         build-mode: manual
         config-file: ./.github/codeql/codeql-config-cpp-experimental.yml
+
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
 
     - name: Install Qt
       uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,10 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
     - name: Install Qt
       uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -71,6 +71,10 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
     - name: Install Qt
       uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
       with:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -46,6 +46,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Work around flaky packages.microsoft.com apt mirror
+        if: runner.os == 'Linux'
+        run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
       - name: Install Qt
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
         with:
@@ -113,6 +117,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Work around flaky packages.microsoft.com apt mirror
+        if: runner.os == 'Linux'
+        run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
 
       - name: Install Qt
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
@@ -201,6 +209,10 @@ jobs:
           # For cross-repository PRs (like from Weblate fork), use the PR head repository
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
+
+      - name: Work around flaky packages.microsoft.com apt mirror
+        if: runner.os == 'Linux'
+        run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
 
       - name: Install Qt
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,6 +24,10 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Work around flaky packages.microsoft.com apt mirror
+      if: runner.os == 'Linux'
+      run: sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+
     # Install the host Qt explicitly (with qttools) so qt_add_translations
     # can find Qt6LinguistTools.  --autodesktop on the WASM step installs a
     # base host Qt, but without qttools, lrelease/lupdate aren't available


### PR DESCRIPTION
## Summary
- GitHub's Ubuntu runners preinstall the Azure CLI apt repo, which intermittently serves corrupted signature metadata (`Clearsigned file isn't valid, got 'NOSPLIT'`), failing `apt-get update` before any of our own steps run — hit repeatedly on `build.yml`'s mega-unity job and again on `grid-wires-v2`'s CI run.
- We don't use Azure CLI, dotnet, or PowerShell anywhere in this pipeline, so this removes its `sources.list.d` entries (`azure-cli.list`, `microsoft-prod.list`) right before `jurplel/install-qt-action` triggers its own `apt-get update`, in every Linux job across the six workflows that install Qt (`build.yml`, `sanitizers.yml`, `coverage.yml`, `wasm.yml`, `translate.yml` x3 jobs, `codeql.yml` x2 jobs).
- Non-Linux matrix entries in `build.yml` are unaffected (`if: runner.os == 'Linux'` guards the new step so it's skipped rather than attempted with the wrong shell).

## Test plan
- [x] All 6 modified workflow YAML files parse successfully
- [x] Diff reviewed: each insertion only touches its own job/matrix-entry, preserving existing if conditions (e.g. codeql's matrix.language == 'cpp' gate)
- [ ] Confirm on the actual PR run that the previously-flaky jobs no longer fail on apt-get update

Generated with Claude Code