### PR TITLE
Fix appearance-path resolution and harden untrusted-input handling

### DIFF
--- a/App/BeWavedDolphin/BeWavedDolphin.cpp
+++ b/App/BeWavedDolphin/BeWavedDolphin.cpp
@@ -120,9 +120,13 @@ void BewavedDolphin::createWaveform(const QString &fileName)
         setWindowTitle(tr("beWavedDolphin Simulator"));
         run();
     } else {
-        // Resolve the file relative to the main window's working directory so that
-        // relative paths stored inside .panda files resolve correctly
-        QFileInfo fileInfo(m_host->currentDir(), QFileInfo(fileName).fileName());
+        // Try the stored path as-is first (handles an absolute path); if that doesn't
+        // resolve, fall back to just the filename relative to the main window's working
+        // directory so that relative paths stored inside .panda files still resolve.
+        QFileInfo fileInfo(fileName);
+        if (fileInfo.isRelative() || !fileInfo.exists()) {
+            fileInfo.setFile(m_host->currentDir(), QFileInfo(fileName).fileName());
+        }
 
         if (!fileInfo.exists()) {
             m_ui->statusbar->showMessage(tr("File \"%1\" does not exist!").arg(fileName), 4000);

--- a/App/BeWavedDolphin/BeWavedDolphin.cpp
+++ b/App/BeWavedDolphin/BeWavedDolphin.cpp
@@ -38,8 +38,8 @@
 #include "App/UI/FileDialogProvider.h"
 #include "App/UI/LengthDialog.h"
 
-BewavedDolphin::BewavedDolphin(Scene *scene, const bool askConnection, DolphinHost *host)
-    : QMainWindow(nullptr)
+BewavedDolphin::BewavedDolphin(Scene *scene, const bool askConnection, DolphinHost *host, QWidget *parent)
+    : QMainWindow(parent)
     , m_ui(std::make_unique<BewavedDolphinUi>())
     , m_host(host)
     , m_externalScene(scene)
@@ -248,12 +248,36 @@ void BewavedDolphin::on_tableView_selectionChanged()
     m_externalScene->view()->update();
 }
 
+bool BewavedDolphin::elementsStillLive() const
+{
+    const auto sceneElements = m_externalScene->elements();
+    for (auto *elm : std::as_const(m_inputs)) {
+        if (!sceneElements.contains(elm)) {
+            return false;
+        }
+    }
+    for (auto *elm : std::as_const(m_outputs)) {
+        if (!sceneElements.contains(elm)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void BewavedDolphin::run()
 {
     // Guard against a caller invoking run() before prepare()/loadNewTable() has built
     // the sweep driver and table model (every current call site prepares first, but
     // this is a public entry point with no compile-time guarantee of that ordering).
     if (!m_simDriver || !m_model) {
+        return;
+    }
+
+    // An input/output element this waveform was built from may have been deleted from the
+    // live scene since prepare() ran — via the main canvas, or an MCP client, neither of
+    // which this window's modality blocks (MCP mutates the scene directly, bypassing Qt
+    // input routing entirely). Skip the sweep rather than dereferencing freed elements.
+    if (!elementsStillLive()) {
         return;
     }
 
@@ -426,10 +450,22 @@ void BewavedDolphin::saveToTxt(QTextStream &stream)
     if (!m_model) {
         return;
     }
+
+    // Same staleness hazard as run() (see elementsStillLive()); saveToTxt() dereferences
+    // m_inputs/m_outputs via sweep() below too. Throw instead of silently no-op'ing so an
+    // MCP client (the only realistic caller once run() already guards interactive use) gets
+    // a clean error instead of a "successful" empty/truncated export.
+    if (!elementsStillLive()) {
+        throw PANDACEPTION("Cannot export: the circuit this waveform was built from has changed.");
+    }
+
     // Dump the full combinational truth table. Build it in a throwaway model (like
     // renderWaveform() uses a throwaway view) so the live document is never mutated —
     // exporting must not clobber the user's waveform (e.g. an MCP persistent session).
-    const int columns = static_cast<int>(std::pow(2, m_inputPorts));
+    // Clamp to SignalModel::kMaxColumns, exactly like on_actionCombinational_triggered's
+    // identical cap below — otherwise a circuit with ~25+ effective input ports allocates
+    // tens of millions of cells, and m_inputPorts >= 31 overflows the int cast (UB).
+    const int columns = static_cast<int>((std::min)(static_cast<double>(SignalModel::kMaxColumns), std::pow(2, m_inputPorts)));
     SignalModel truthTable(m_model->rowCount(), columns);
 
     // Carry the live model's row labels onto the throwaway model so the exporter, which

--- a/App/BeWavedDolphin/BeWavedDolphin.h
+++ b/App/BeWavedDolphin/BeWavedDolphin.h
@@ -50,8 +50,12 @@ public:
      * \param askConnection If \c true, prompts the user to link to a .dolphin file.
      * \param host          Host application providing the circuit file context (a
      *                      MainWindow in the app; a stub in tests). May be \c nullptr.
+     * \param parent        Widget to parent this window to, so its Qt::WindowModal setting
+     *                      (see the constructor body) actually blocks it — separate from
+     *                      \a host since tests pass a non-QWidget stub host. May be \c nullptr.
      */
-    explicit BewavedDolphin(Scene *scene, const bool askConnection = true, DolphinHost *host = nullptr);
+    explicit BewavedDolphin(Scene *scene, const bool askConnection = true, DolphinHost *host = nullptr,
+                            QWidget *parent = nullptr);
     ~BewavedDolphin() override;
 
     /// Initializes a blank waveform from the current scene's I/O elements.
@@ -175,6 +179,12 @@ private:
     void load(const QString &fileName);
     /// Applies parsed file \a fileData to the model (sets length, fills inputs, re-runs).
     void applyWaveformData(const DolphinSerializer::WaveformData &fileData);
+
+    /// Returns \c false if any element in m_inputs/m_outputs was deleted from the live scene
+    /// since prepare() snapshotted them (e.g. via the main canvas or an MCP client — neither
+    /// path is blocked by this window's modality, which only affects interactive GUI input).
+    /// run()/saveToTxt() must check this before dereferencing those pointers via sweep().
+    bool elementsStillLive() const;
 
     // --- Signal Table Management ---
 

--- a/App/BeWavedDolphin/DolphinClipboard.cpp
+++ b/App/BeWavedDolphin/DolphinClipboard.cpp
@@ -10,6 +10,7 @@
 #include <QMimeData>
 
 #include "App/BeWavedDolphin/SignalModel.h"
+#include "App/Core/Common.h"
 #include "App/IO/Serialization.h"
 
 namespace {
@@ -71,7 +72,20 @@ void paste(SignalModel &model, const QItemSelection &ranges, QDataStream &stream
     const int anchorRow = firstRow(model, ranges);
     quint64 itemListSize; stream >> itemListSize;
 
-    for (int i = 0; i < static_cast<int>(itemListSize); ++i) {
+    // The clipboard is not a trusted source (any process can set MIME data ahead of a
+    // Ctrl+V) — bound the announced item count by what the stream can actually hold
+    // before looping, the same way DolphinSerializer::loadBinary bounds its row count,
+    // so a crafted/corrupt payload can't spin this loop for eons instead of failing fast.
+    constexpr qint64 kBytesPerItem = 3 * static_cast<qint64>(sizeof(quint64));
+    const qint64 available = stream.device() ? stream.device()->bytesAvailable() : 0;
+    const quint64 maxItems = available > 0 ? static_cast<quint64>(available / kBytesPerItem) : 0;
+    if (itemListSize > maxItems) {
+        qCWarning(zero) << "DolphinClipboard: truncating paste from" << itemListSize
+                         << "items to" << maxItems << "(insufficient stream data)";
+        itemListSize = maxItems;
+    }
+
+    for (quint64 i = 0; i < itemListSize; ++i) {
         quint64 row;   stream >> row;
         quint64 col;   stream >> col;
         quint64 value; stream >> value;

--- a/App/CodeGen/ArduinoCodeGen.cpp
+++ b/App/CodeGen/ArduinoCodeGen.cpp
@@ -295,7 +295,7 @@ void ArduinoCodeGen::declareAuxVariablesRec(const QVector<GraphicElement *> &ele
             auto *ic = qobject_cast<IC *>(elm);
             if (!ic) continue;
 
-            m_stream << "// IC: " << ic->label() << Qt::endl;
+            m_stream << "// IC: " << CodeGenUtils::sanitizeComment(ic->label()) << Qt::endl;
 
             // Include the full ancestor path (icPrefix) so names stay globally
             // unique across repeated/nested sub-IC instances (register files, RAM,
@@ -340,7 +340,7 @@ void ArduinoCodeGen::declareAuxVariablesRec(const QVector<GraphicElement *> &ele
                 }
             }
 
-            m_stream << "// End IC: " << ic->label() << Qt::endl;
+            m_stream << "// End IC: " << CodeGenUtils::sanitizeComment(ic->label()) << Qt::endl;
             continue;
         }
 
@@ -671,7 +671,7 @@ void ArduinoCodeGen::assignVariablesRec(const QVector<GraphicElement *> &element
             auto *ic = qobject_cast<IC *>(elm);
             if (!ic) continue;
 
-            m_stream << "    // IC: " << ic->label() << Qt::endl;
+            m_stream << "    // IC: " << CodeGenUtils::sanitizeComment(ic->label()) << Qt::endl;
 
             for (int i = 0; i < ic->inputSize(); ++i) {
                 Port *externalPort = ic->inputPort(i);
@@ -712,7 +712,7 @@ void ArduinoCodeGen::assignVariablesRec(const QVector<GraphicElement *> &element
                 m_stream << "    " << externalVar << " = " << internalValue << ";" << Qt::endl;
             }
 
-            m_stream << "    // End IC: " << ic->label() << Qt::endl;
+            m_stream << "    // End IC: " << CodeGenUtils::sanitizeComment(ic->label()) << Qt::endl;
             continue;
         }
 

--- a/App/CodeGen/CodeGenUtils.h
+++ b/App/CodeGen/CodeGenUtils.h
@@ -49,4 +49,20 @@ inline QString removeForbiddenChars(const QString &input, const bool stripFirst 
     return result;
 }
 
+/**
+ * \brief Makes \a input safe to embed in a single-line "//" comment.
+ *
+ * Neutralizes embedded line breaks. Without this, a label containing "\n" (settable via a
+ * crafted .panda file's label field, or the MCP create_element/set_element_properties "label"
+ * parameter — neither restricts content beyond length) could break out of the comment and
+ * inject an arbitrary line into the generated Arduino/SystemVerilog file.
+ */
+inline QString sanitizeComment(const QString &input)
+{
+    QString result = input;
+    result.replace(QLatin1Char('\r'), QLatin1Char(' '));
+    result.replace(QLatin1Char('\n'), QLatin1Char(' '));
+    return result;
+}
+
 }  // namespace CodeGenUtils

--- a/App/CodeGen/SystemVerilogCodeGen.cpp
+++ b/App/CodeGen/SystemVerilogCodeGen.cpp
@@ -395,7 +395,7 @@ void SystemVerilogCodeGen::generateSingleICModule(ICModuleInfo &info)
 
     // Emit module header
     const QString source = ic->isEmbedded() ? ic->blobName() : QFileInfo(ic->file()).fileName();
-    m_stream << "// Module for " << ic->label() << " (generated from " << source << ")" << Qt::endl;
+    m_stream << "// Module for " << CodeGenUtils::sanitizeComment(ic->label()) << " (generated from " << source << ")" << Qt::endl;
     m_stream << "module " << info.moduleName << " (" << Qt::endl;
 
     // Emit port list
@@ -648,7 +648,7 @@ void SystemVerilogCodeGen::declareAuxVariablesRec(const QVector<GraphicElement *
             QString instanceName = QString("%1_inst_%2").arg(info.moduleName).arg(m_globalCounter++);
             m_instanceNames[ic] = instanceName;
 
-            m_stream << "// IC instance: " << ic->label() << " (" << info.moduleName << ")" << Qt::endl;
+            m_stream << "// IC instance: " << CodeGenUtils::sanitizeComment(ic->label()) << " (" << info.moduleName << ")" << Qt::endl;
 
             // Declare output wires for this IC instance
             for (int i = 0; i < ic->outputSize(); ++i) {

--- a/App/Core/DragDropPayload.cpp
+++ b/App/Core/DragDropPayload.cpp
@@ -1,0 +1,19 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "App/Core/DragDropPayload.h"
+
+#include <QDataStream>
+
+#include "App/IO/Serialization.h"
+
+DragDropPayload readDragDropPayload(QDataStream &stream)
+{
+    DragDropPayload payload;
+    stream >> payload.offset;
+    stream >> payload.type;
+    payload.icFileName = Serialization::readBoundedString(stream);
+    if (!stream.atEnd()) { stream >> payload.isEmbedded; }
+    if (!stream.atEnd()) { payload.blobName = Serialization::readBoundedString(stream); }
+    return payload;
+}

--- a/App/Core/DragDropPayload.h
+++ b/App/Core/DragDropPayload.h
@@ -1,0 +1,44 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** \file
+ * \brief Shared reader for wiRedPanda's drag-and-drop MIME payload format.
+ */
+
+#pragma once
+
+#include <QPoint>
+#include <QString>
+
+#include "App/Core/Enums.h"
+
+class QDataStream;
+
+/**
+ * \struct DragDropPayload
+ * \brief Decoded contents of a wiRedPanda drag-and-drop MIME payload.
+ *
+ * \details Carries either a file-based IC reference (\c icFileName) or an embedded IC
+ * reference (\c isEmbedded + \c blobName), never both — populated by
+ * \c readDragDropPayload().
+ */
+struct DragDropPayload {
+    QPoint offset;                                ///< Drag-start offset from the dragged item's origin.
+    ElementType type = ElementType::Unknown;       ///< Element type being dragged.
+    QString icFileName;                           ///< File-based IC path (empty if embedded).
+    bool isEmbedded = false;                       ///< True if this references an embedded IC blob.
+    QString blobName;                              ///< Embedded IC blob name (empty if file-based).
+};
+
+/**
+ * \brief Reads a drag-and-drop payload from \a stream.
+ * \param stream Stream positioned just past \c Serialization::readPandaHeader().
+ * \return The decoded payload.
+ *
+ * \details Bounds \c icFileName and \c blobName via \c Serialization::readBoundedString() —
+ * the drag source is not a trusted process (any application can offer wiRedPanda's public MIME
+ * type with a crafted payload), so these must not use Qt's raw, unbounded
+ * \c QDataStream::operator>>(QString&). The optional trailing \c isEmbedded/\c blobName fields
+ * are read only if present, preserving compatibility with payloads that predate them.
+ */
+DragDropPayload readDragDropPayload(QDataStream &stream);

--- a/App/Core/UpdateChecker.cpp
+++ b/App/Core/UpdateChecker.cpp
@@ -60,6 +60,11 @@ bool shouldOfferUpdate(const QString &tagName, const QVersionNumber &currentVers
     return latest.toString() != skippedVersion;
 }
 
+bool isSafeGitHubUrl(const QUrl &url)
+{
+    return url.isValid() && url.scheme() == QLatin1String("https") && url.host() == QLatin1String("github.com");
+}
+
 UpdateChecker::UpdateChecker(QObject *parent)
     : QObject(parent)
 {
@@ -137,5 +142,14 @@ void UpdateChecker::onReplyFinished(QNetworkReply *reply)
     }
 
     const QUrl releaseUrl = QUrl(doc.object().value("html_url").toString());
+    if (!isSafeGitHubUrl(releaseUrl)) {
+        qWarning() << "UpdateChecker: release URL has unexpected scheme/host, ignoring update notification:" << releaseUrl;
+        return;
+    }
+    if (!downloadUrl.isEmpty() && !isSafeGitHubUrl(downloadUrl)) {
+        qWarning() << "UpdateChecker: download URL has unexpected scheme/host, falling back to release page:" << downloadUrl;
+        downloadUrl.clear();
+    }
+
     emit updateAvailable(latest.toString(), downloadUrl, releaseUrl);
 }

--- a/App/Core/UpdateChecker.h
+++ b/App/Core/UpdateChecker.h
@@ -67,3 +67,13 @@ bool isMatchingReleaseAsset(const QString &name, const QString &platform, const 
 /// to a valid version that is strictly newer than the running application and
 /// whose normalized string does not match the user's per-version suppression.
 bool shouldOfferUpdate(const QString &tagName, const QVersionNumber &currentVersion, const QString &skippedVersion);
+
+/// \brief True when \a url is safe to download from or hand to the OS's URL handler.
+///
+/// \details Exposed for testing. Requires scheme https and host github.com — the only shape
+/// GitHub's release JSON ever populates \c browser_download_url / \c html_url with (the CDN
+/// redirect for the actual asset happens only after fetching this URL, so the field itself
+/// never contains the CDN's host). Guards against a compromised/future-relaxed API response
+/// smuggling a \c file:// path (silently copies a local file into the Downloads folder) or an
+/// unexpected scheme/UNC-style URL into QDesktopServices::openUrl.
+bool isSafeGitHubUrl(const QUrl &url);

--- a/App/Element/ElementAppearance.cpp
+++ b/App/Element/ElementAppearance.cpp
@@ -12,6 +12,7 @@
 #include <QFileInfo>
 #include <QPainter>
 #include <QPen>
+#include <QPixmapCache>
 #include <QRegularExpression>
 #include <QSvgRenderer>
 
@@ -20,23 +21,6 @@
 #include "App/Element/GraphicElement.h"
 
 namespace {
-
-/// Cache decoded pixmaps by resolved path so each image is loaded from disk only once.
-QHash<QString, QPixmap> &pixmapCache()
-{
-    static QHash<QString, QPixmap> cache;
-    return cache;
-}
-
-/// Cache of orientation-variant pixmaps keyed by "<resolvedPath>|<canonicalAngle>|<flipX><flipY>"
-/// so the SVG text correction is rendered only once per appearance and rotation/flip state.
-/// Both this and pixmapCache() are plain static QHashes with no locking: GraphicElement pixmaps are
-/// only built and read on the GUI thread, so concurrent access does not occur.
-QHash<QString, QPixmap> &orientedPixmapCache()
-{
-    static QHash<QString, QPixmap> cache;
-    return cache;
-}
 
 /// Rewrites \a svgBytes so every <text> element is counter-oriented about its own centre for the
 /// element's current rotation \a angle and \a flipX / \a flipY. Pre-applying the inverse of the
@@ -124,7 +108,8 @@ QByteArray orientSvgTextNodes(const QByteArray &svgBytes, const qreal angle, con
 
 /// Renders an orientation-variant pixmap for the SVG at \a resolvedPath with its <text> labels
 /// counter-oriented for the current rotation \a angle and flip, cached per path + angle + flip
-/// state. Returns a null pixmap on failure so callers can fall back to the plain base pixmap
+/// state via the shared QPixmapCache (see MainWindow's setCacheLimit() call for the app-wide
+/// budget). Returns a null pixmap on failure so callers can fall back to the plain base pixmap
 /// (which the item transform then rotates/flips).
 QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const bool flipX, const bool flipY)
 {
@@ -132,15 +117,17 @@ QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const 
     // share one cache entry instead of growing the key space without bound — MCP can request any
     // angle and rotate-left produces negatives.
     const qreal canonAngle = std::fmod(std::fmod(angle, 360.0) + 360.0, 360.0);
-    const QString key = resolvedPath + QLatin1Char('|')
+    // Namespaced so this can never collide with Qt's own internal QPixmapCache keys (which are
+    // always prefixed "qt_pixmap") or anything else the app might insert into the same shared,
+    // process-wide cache.
+    const QString key = QLatin1String("wp_oriented_svg:") + resolvedPath + QLatin1Char('|')
         + QString::number(canonAngle) + QLatin1Char('|')
         + (flipX ? QLatin1Char('1') : QLatin1Char('0'))
         + (flipY ? QLatin1Char('1') : QLatin1Char('0'));
 
-    auto &cache = orientedPixmapCache();
-    const auto it = cache.constFind(key);
-    if (it != cache.constEnd()) {
-        return *it;
+    QPixmap cached;
+    if (QPixmapCache::find(key, &cached)) {
+        return cached;
     }
 
     QFile file(resolvedPath);
@@ -167,7 +154,7 @@ QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const 
     renderer.render(&painter);
     painter.end();
 
-    cache.insert(key, pixmap);
+    QPixmapCache::insert(key, pixmap);
     return pixmap;
 }
 
@@ -237,13 +224,11 @@ void ElementAppearance::setPixmap(const QString &pixmapPath)
         }
     }
 
-    auto &cache = pixmapCache();
-    auto it = cache.constFind(path);
-    if (it != cache.constEnd()) {
-        m_basePixmap = *it;
-    } else if (m_basePixmap.load(path)) {
-        cache.insert(path, m_basePixmap);
-    } else {
+    // QPixmap::load() already caches internally via the shared QPixmapCache, keyed on
+    // path + mtime + size (see MainWindow's setCacheLimit() call for the app-wide budget) — a
+    // wrapper cache of our own here would be both redundant and, keyed on the bare path alone,
+    // staler than what load() already gives us for free.
+    if (!m_basePixmap.load(path)) {
         const QFileInfo info(path);
         const QString reason = !info.exists()
                                    ? tr("File does not exist")

--- a/App/Element/ElementAppearance.cpp
+++ b/App/Element/ElementAppearance.cpp
@@ -217,22 +217,23 @@ void ElementAppearance::setPixmap(const QString &pixmapPath)
 
     QString path = pixmapPath;
 
-    // Qt resource paths start with ":/"; anything else is a filesystem path
-    // relative to the project's working directory (where the .panda file lives).
-    // Try the path as-is against contextDir first; if not found, fall back to
-    // just the filename — handles cross-platform absolute paths from old files.
-    if (!path.startsWith(":/")) {
+    // Qt resource paths start with ":/"; a path that already resolves as given (e.g. a real,
+    // existing absolute path freshly chosen via the file dialog) needs no further resolution and
+    // loads directly, even before the project has ever been saved. Gate on existence rather than
+    // QFileInfo::isRelative(): a Windows-style "C:/..." path is absolute per QFileInfo when
+    // running on Windows, but a project saved on a different OS means that exact path usually
+    // doesn't exist there either, so it still needs to fall through to the contextDir/filename
+    // fallback below — the same case BeWavedDolphin::createWaveform() already guards with an
+    // isRelative() || !exists() check.
+    if (!path.startsWith(":/") && !QFileInfo::exists(path)) {
         const QString contextDir = GraphicElement::resolveContextDir(m_owner);
-        if (contextDir.isEmpty()) {
-            return;
-        }
-        const QDir dir(contextDir);
-        const QString resolved = dir.filePath(path);
+        if (!contextDir.isEmpty()) {
+            const QDir dir(contextDir);
+            const QString resolved = dir.filePath(path);
 
-        if (!QFileInfo::exists(resolved)) {
-            path = dir.filePath(QFileInfo(QString(path).replace('\\', '/')).fileName());
-        } else {
-            path = resolved;
+            path = QFileInfo::exists(resolved)
+                       ? resolved
+                       : dir.filePath(QFileInfo(QString(path).replace('\\', '/')).fileName());
         }
     }
 
@@ -253,6 +254,10 @@ void ElementAppearance::setPixmap(const QString &pixmapPath)
         // Load the default appearance so the element remains renderable before the exception unwinds
         m_basePixmap.load(m_defaultAppearances.constFirst());
         m_pixmap = m_basePixmap;
+        // Remember this exact request failed so a later call with the same broken path (e.g.
+        // every simulation tick's refresh()) is skipped by the guard above instead of
+        // re-attempting the load and re-throwing — each distinct failure surfaces once.
+        m_currentPixmapPath = pixmapPath;
         qCDebug(zero) << "Problem loading pixmapPath: " << path;
         throw PANDACEPTION("Couldn't load pixmap: %1 (%2)", path, reason);
     }

--- a/App/Element/GraphicElementSerializer.cpp
+++ b/App/Element/GraphicElementSerializer.cpp
@@ -467,7 +467,7 @@ void GraphicElementSerializer::loadPortsSize(QDataStream &stream, const QVersion
 void GraphicElementSerializer::loadTrigger(GraphicElement &element, QDataStream &stream, const QVersionNumber &version)
 {
     if (VersionInfo::hasTrigger(version)) {
-        QKeySequence trigger; stream >> trigger;
+        const QKeySequence trigger = Serialization::readBoundedKeySequence(stream);
         element.setTrigger(trigger);
     }
 }

--- a/App/Element/GraphicElementSerializer.cpp
+++ b/App/Element/GraphicElementSerializer.cpp
@@ -146,9 +146,25 @@ void GraphicElementSerializer::save(const GraphicElement &element, QDataStream &
 
     QList<QMap<QString, QVariant>> appearancesMap;
 
+    const QString contextDir = GraphicElement::resolveContextDir(&element);
+
     for (const auto &appearance : element.m_appearance.alternativeAppearances()) {
         QMap<QString, QVariant> tempMap;
-        tempMap.insert("skinName", appearance.startsWith(":/") ? appearance : QFileInfo(appearance).fileName());
+        QString skinName = appearance;
+        if (!appearance.startsWith(":/")) {
+            // Truncating to a bare filename is only lossless if that name already resolves
+            // next to the project (WorkSpace::save() copies external dependencies there
+            // before this runs); otherwise this is an in-memory-only snapshot (e.g. an
+            // UpdateCommand undo/redo round-trip) or an unsaved project, and shortening the
+            // path now would make it permanently unresolvable — keep the full path instead.
+            const QString basename = QFileInfo(appearance).fileName();
+            const bool alreadyResolvable = !contextDir.isEmpty()
+                && QFileInfo(QDir(contextDir).filePath(basename)).exists();
+            if (alreadyResolvable) {
+                skinName = basename;
+            }
+        }
+        tempMap.insert("skinName", skinName);
         appearancesMap << tempMap;
     }
 

--- a/App/Element/GraphicElements/AudioBox.cpp
+++ b/App/Element/GraphicElements/AudioBox.cpp
@@ -156,7 +156,21 @@ void AudioBox::save(QDataStream &stream) const
     GraphicElement::save(stream);
 
     const QString &path = m_audio.filePath();
-    const QString audioPath = path.startsWith(":/") ? path : m_audio.fileName();
+    QString audioPath = path;
+    if (!path.startsWith(":/")) {
+        // Truncating to a bare filename is only lossless if that name already resolves
+        // next to the project; otherwise this is an in-memory-only snapshot (e.g. an
+        // UpdateCommand undo/redo round-trip triggered by an unrelated property edit) or
+        // an unsaved project, and shortening the path now would make it permanently
+        // unresolvable — keep the full path instead.
+        const QString contextDir = GraphicElement::resolveContextDir(this);
+        const QString basename = m_audio.fileName();
+        const bool alreadyResolvable = !contextDir.isEmpty()
+            && QFileInfo(QDir(contextDir).filePath(basename)).exists();
+        if (alreadyResolvable) {
+            audioPath = basename;
+        }
+    }
 
     QMap<QString, QVariant> map;
     map.insert("audiobox", audioPath);

--- a/App/Element/GraphicElements/Buzzer.cpp
+++ b/App/Element/GraphicElements/Buzzer.cpp
@@ -3,6 +3,8 @@
 
 #include "App/Element/GraphicElements/Buzzer.h"
 
+#include <cmath>
+
 #include <QAudioSink>
 
 #include "App/Element/ElementFactory.h"
@@ -69,6 +71,15 @@ double Buzzer::frequency() const
 
 void Buzzer::setFrequency(double freq)
 {
+    // A .panda file (or any other caller) can supply a non-finite or non-positive value;
+    // ToneGenerator::readData() casts a NaN-derived sample to qint16, which is undefined
+    // behaviour, and a non-positive frequency has no physical meaning for a buzzer. Reject
+    // it here — the one setter every caller (file load, GUI, MCP, undo/redo) goes through —
+    // mirroring Clock::setFrequency()'s identical guard for the same untrusted-value class.
+    if (!std::isfinite(freq) || freq <= 0.0) {
+        return;
+    }
+
     m_frequency = freq;
 
     if (!m_hasOutputDevice) {

--- a/App/Element/GraphicElements/Clock.cpp
+++ b/App/Element/GraphicElements/Clock.cpp
@@ -69,6 +69,23 @@ void Clock::updateClock(std::chrono::steady_clock::time_point globalTime)
 
     const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(globalTime - m_startTime);
 
+    // A gap this large means the wall clock jumped far ahead without an intervening
+    // Simulation::stop()/start() cycle (which already resyncs via resetClock() — see its call
+    // site) — e.g. the OS suspended the process while the simulation's QTimer stayed "active".
+    // Left to the single-step path below, replaying the backlog would toggle once per
+    // subsequent 1 ms tick until caught up: for a long gap, a burst of thousands of rapid,
+    // unrealistic toggles feeding into any connected sequential logic. Resync immediately
+    // instead, on this very first tick after the gap, so the burst never starts. The threshold
+    // is a fixed wall-clock duration, not a multiple of m_interval — scaling it to the
+    // half-period would fire this path on entirely ordinary jitter for high-frequency clocks
+    // (e.g. a 100 Hz clock's 5 ms interval means even a benign 20+ ms hiccup would look like a
+    // "large" multiple), which is not the gap this guards against.
+    constexpr auto kMaxCatchUpGap = std::chrono::seconds(5);
+    if (elapsed > kMaxCatchUpGap) {
+        resetClock(globalTime);
+        return;
+    }
+
     // m_interval is the half-period (time per HIGH or LOW phase).
     // Rather than resetting to globalTime we advance by exactly one interval so
     // that accumulated drift doesn't skew the clock frequency over time.

--- a/App/Element/IC.cpp
+++ b/App/Element/IC.cpp
@@ -161,8 +161,12 @@ void IC::load(QDataStream &stream, SerializationContext &context)
             m_blobName = baseName;
             loadFromBlob(context.blobRegistry->value(baseName), context.contextDir);
         } else {
-            m_file = name;
-            loadFile(m_file, context.contextDir);
+            // Don't assign m_file until loadFile() has confirmed name actually resolves to a
+            // real file — ICLoader::loadFile() itself sets ic.m_file, but only once validated,
+            // so a name that resolves to neither a blob nor a file (e.g. an unrelated rename
+            // elsewhere in the registry) throws cleanly without leaving m_file holding a
+            // bogus non-path string.
+            loadFile(name, context.contextDir);
         }
     }
 

--- a/App/Element/ICLoader.cpp
+++ b/App/Element/ICLoader.cpp
@@ -140,6 +140,20 @@ void ICLoader::loadFile(IC &ic, const QString &fileName, const QString &contextD
 
 void ICLoader::loadFileDirectly(IC &ic, const QFileInfo &fileInfo)
 {
+    // Depth cap: shares s_icLoadDepth/kMaxICNestingDepth with deserializeAndLoad() rather than
+    // using a separate counter, so a chain that mixes file-backed and embedded-blob hops can't
+    // bypass the limit by crossing between the two loading paths — depth bounds the overall
+    // recursion, not "how many hops happened to go through this particular function." Cycle
+    // detection (below) alone isn't enough: a long, non-cyclic chain of distinct legitimate
+    // files (A embeds B embeds C embeds ... , no repeats) would otherwise recurse unbounded here
+    // and exhaust the call stack.
+    if (s_icLoadDepth >= kMaxICNestingDepth) {
+        throw PANDACEPTION("IC nesting depth limit (%1) exceeded while loading %2",
+                           QString::number(kMaxICNestingDepth), fileInfo.absoluteFilePath());
+    }
+    ++s_icLoadDepth;
+    const auto depthGuard = qScopeGuard([] { --s_icLoadDepth; });
+
     // Cycle detection: if this file is already being loaded up the call stack,
     // a circular IC reference exists (A→B→A→…). Throw instead of stack-overflowing.
     static QSet<QString> s_loadingFiles;

--- a/App/Exercise/ExerciseEngine.cpp
+++ b/App/Exercise/ExerciseEngine.cpp
@@ -76,7 +76,7 @@ bool ExerciseEngine::loadFromResource(const QString &resourcePath)
             const QJsonObject elemObj = elemVal.toObject();
             ExerciseElementRequirement req;
             req.typeName  = elemObj.value("type").toString();
-            req.minCount  = elemObj.value("minCount").toInt(1);
+            req.minCount  = qMax(0, elemObj.value("minCount").toInt(1));
             step.requiredElements.append(req);
         }
 
@@ -85,7 +85,7 @@ bool ExerciseEngine::loadFromResource(const QString &resourcePath)
             ExerciseConnectionRequirement req;
             req.fromTypeName = connObj.value("fromType").toString();
             req.toTypeName   = connObj.value("toType").toString();
-            req.minCount     = connObj.value("minCount").toInt(1);
+            req.minCount     = qMax(0, connObj.value("minCount").toInt(1));
             step.requiredConnections.append(req);
         }
 

--- a/App/IO/FileUtils.h
+++ b/App/IO/FileUtils.h
@@ -3,18 +3,12 @@
 
 #pragma once
 
-#include <QDataStream>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QSet>
 #include <QString>
-#include <QStringList>
-#include <QtEndian>
 
 #include "App/Core/Common.h"
-#include "App/IO/Serialization.h"
-#include "App/IO/VersionInfo.h"
 
 namespace FileUtils {
 
@@ -41,91 +35,6 @@ inline void copyToDir(const QString &srcPath, const QString &destDir)
         if (!srcFile.copy(dest)) {
             throw PANDACEPTION_WITH_CONTEXT("FileUtils", "Could not copy %1 to %2: %3",
                                             srcPath, dest, srcFile.errorString());
-        }
-    }
-}
-
-/// Recursively copies .panda IC dependencies from \a srcDir to \a destDir
-/// by reading the fileBackedICs metadata key from the given \a pandaPath.
-/// \a visited tracks already-processed canonical paths to break circular
-/// fileBackedICs metadata (A→B→A); the root caller passes nothing.
-inline void copyPandaDeps(const QString &pandaPath, const QString &srcDir, const QString &destDir,
-                          QSet<QString> *visited = nullptr)
-{
-    QSet<QString> ownedVisited;
-    if (!visited) {
-        visited = &ownedVisited;
-    }
-    const QString canonical = QFileInfo(pandaPath).canonicalFilePath();
-    if (canonical.isEmpty() || visited->contains(canonical)) {
-        return;
-    }
-    visited->insert(canonical);
-
-    QFile file(pandaPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        return;
-    }
-
-    // Quick peek-based plausibility check before attempting a full parse, so
-    // a non-panda file encountered while walking IC dependency blobs is
-    // quietly skipped without relying on readPreamble()'s exception path.
-    // Peek only — never touch the stream readPreamble() constructs next.
-    {
-        char magicBuf[sizeof(quint32)];
-        if (file.peek(magicBuf, sizeof(magicBuf)) != static_cast<qint64>(sizeof(magicBuf))) {
-            return;
-        }
-        const quint32 magicHeader = qFromBigEndian<quint32>(magicBuf);
-        if (magicHeader != Serialization::MAGIC_HEADER_CIRCUIT) {
-            constexpr quint32 NullStringMarker = 0xFFFFFFFFu;
-            constexpr qint64 MaxLegacyHeaderBytes = 128;
-            if (magicHeader == NullStringMarker || magicHeader > MaxLegacyHeaderBytes) {
-                return;
-            }
-            const qint64 probeLen = sizeof(quint32) + magicHeader;
-            QByteArray strProbeBuf(static_cast<int>(probeLen), '\0');
-            if (file.peek(strProbeBuf.data(), probeLen) != probeLen) {
-                return;
-            }
-            QDataStream strProbe(strProbeBuf);
-            strProbe.setVersion(QDataStream::Qt_5_12);
-            QString appName;
-            strProbe >> appName;
-            if (strProbe.status() != QDataStream::Ok || !appName.startsWith("wiRedPanda", Qt::CaseInsensitive)) {
-                return;
-            }
-        }
-    }
-
-    QDataStream stream(&file);
-    Serialization::Preamble preamble;
-    try {
-        preamble = Serialization::readPreamble(stream);
-    } catch (...) {
-        return; // Corrupt or non-panda file — nothing to recurse into
-    }
-    if (!VersionInfo::hasMetadata(preamble.version)) {
-        return;
-    }
-
-    const QStringList icFiles = preamble.metadata.value("fileBackedICs").toStringList();
-    for (const QString &icFile : icFiles) {
-        const QFileInfo icSrc(QDir(srcDir), icFile);
-        const QFileInfo icDest(QDir(destDir), icFile);
-
-        if (icSrc.exists() && !QFile::exists(icDest.absoluteFilePath())) {
-            QFile srcFile(icSrc.absoluteFilePath());
-            if (!srcFile.copy(icDest.absoluteFilePath())) {
-                throw PANDACEPTION_WITH_CONTEXT("FileUtils",
-                                                "Could not copy %1 to %2: %3",
-                                                icSrc.absoluteFilePath(), icDest.absoluteFilePath(),
-                                                srcFile.errorString());
-            }
-        }
-
-        if (icSrc.exists()) {
-            copyPandaDeps(icSrc.absoluteFilePath(), srcDir, destDir, visited);
         }
     }
 }

--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -752,6 +752,37 @@ void Serialization::copyPandaFile(const QFileInfo &srcPath, const QFileInfo &des
         return;
     }
 
+    // Quick peek-based plausibility check before attempting a full parse, so a
+    // non-panda file encountered while walking IC dependency blobs is quietly
+    // skipped without paying for readPreamble()'s exception path.
+    // Peek only — never touch the stream readPreamble() constructs next.
+    {
+        char magicBuf[sizeof(quint32)];
+        if (file.peek(magicBuf, sizeof(magicBuf)) != static_cast<qint64>(sizeof(magicBuf))) {
+            return;
+        }
+        const quint32 magicHeader = qFromBigEndian<quint32>(magicBuf);
+        if (magicHeader != MAGIC_HEADER_CIRCUIT) {
+            constexpr quint32 NullStringMarker = 0xFFFFFFFFu;
+            constexpr qint64 MaxLegacyHeaderBytes = 128;
+            if (magicHeader == NullStringMarker || magicHeader > MaxLegacyHeaderBytes) {
+                return;
+            }
+            const qint64 probeLen = sizeof(quint32) + magicHeader;
+            QByteArray strProbeBuf(static_cast<int>(probeLen), '\0');
+            if (file.peek(strProbeBuf.data(), probeLen) != probeLen) {
+                return;
+            }
+            QDataStream strProbe(strProbeBuf);
+            strProbe.setVersion(QDataStream::Qt_5_12);
+            QString appName;
+            strProbe >> appName;
+            if (strProbe.status() != QDataStream::Ok || !appName.startsWith("wiRedPanda", Qt::CaseInsensitive)) {
+                return;
+            }
+        }
+    }
+
     QDataStream stream(&file);
     Preamble preamble;
     try {

--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -19,8 +19,8 @@
 #include <QScopeGuard>
 #include <QSysInfo>
 #include <QtEndian>
-#include <QVarLengthArray>
 #include <QVariant>
+#include <QVarLengthArray>
 
 #include "App/Core/Common.h"
 #include "App/Element/ElementFactory.h"
@@ -267,6 +267,11 @@ QVariant readBoundedVariant(QDataStream &stream)
 QString Serialization::readBoundedString(QDataStream &stream)
 {
     return ::readBoundedString(stream); // delegate to the file-local free function
+}
+
+QKeySequence Serialization::readBoundedKeySequence(QDataStream &stream)
+{
+    return ::readBoundedKeySequence(stream); // delegate to the file-local free function
 }
 
 QMap<QString, QVariant> Serialization::readBoundedMetadata(QDataStream &stream)

--- a/App/IO/Serialization.cpp
+++ b/App/IO/Serialization.cpp
@@ -729,8 +729,17 @@ QString Serialization::typeName(const int type) {
 }
 
 void Serialization::copyPandaFile(const QFileInfo &srcPath, const QFileInfo &destPath,
-                                  QSet<QString> *visited)
+                                  QSet<QString> *visited, int depth)
 {
+    // Cycle detection (visited) alone doesn't bound a long, non-cyclic chain of distinct
+    // dependency files (A references B references C references ..., no repeats) — mirrors
+    // ICLoader's kMaxICNestingDepth for the identical failure mode on the IC-load path.
+    constexpr int kMaxPandaFileCopyDepth = 16;
+    if (depth >= kMaxPandaFileCopyDepth) {
+        throw PANDACEPTION("Panda file dependency chain exceeds the maximum nesting depth (%1) while copying '%2'",
+                           QString::number(kMaxPandaFileCopyDepth), srcPath.filePath());
+    }
+
     QSet<QString> ownedVisited;
     if (!visited) {
         visited = &ownedVisited;
@@ -804,7 +813,7 @@ void Serialization::copyPandaFile(const QFileInfo &srcPath, const QFileInfo &des
         const QFileInfo icSrc(QDir(srcPath.absolutePath()), icFile);
         const QFileInfo icDest(QDir(destPath.absolutePath()), icFile);
         if (icSrc.exists()) {
-            copyPandaFile(icSrc, icDest, visited);
+            copyPandaFile(icSrc, icDest, visited, depth + 1);
         }
     }
 }

--- a/App/IO/Serialization.h
+++ b/App/IO/Serialization.h
@@ -172,9 +172,12 @@ public:
      * \param srcPath  Source .panda file info.
      * \param destPath Destination .panda file info.
      * \param visited  Internal recursion guard; root callers leave this null.
+     * \param depth    Internal recursion depth; root callers leave this at 0. Throws once a
+     *                 chain of distinct dependency files would recurse past a fixed limit —
+     *                 the \a visited cycle guard alone doesn't bound a long, non-cyclic chain.
      */
     static void copyPandaFile(const QFileInfo &srcPath, const QFileInfo &destPath,
-                              QSet<QString> *visited = nullptr);
+                              QSet<QString> *visited = nullptr, int depth = 0);
 
     // --- Magic Headers ---
 

--- a/App/IO/Serialization.h
+++ b/App/IO/Serialization.h
@@ -9,6 +9,7 @@
 
 #include <QCoreApplication>
 #include <QFileInfo>
+#include <QKeySequence>
 #include <QMap>
 #include <QSet>
 #include <QString>
@@ -87,6 +88,14 @@ public:
      *        remain in the stream (prevents OOM on fuzz-controlled length fields).
      */
     static QString readBoundedString(QDataStream &stream);
+
+    /**
+     * \brief Reads a QKeySequence from \a stream, rejecting an implausible/oversized
+     *        internal key-combination count before QDataStream's default QKeySequence
+     *        deserialization would reserve() it (a QKeySequence holds at most 4 key
+     *        combinations, so a larger count can only be a corrupt/crafted stream).
+     */
+    static QKeySequence readBoundedKeySequence(QDataStream &stream);
 
     /**
      * \brief Reads a \c QMap<QString,QByteArray> from \a stream with bounds checking.

--- a/App/Scene/ClipboardManager.cpp
+++ b/App/Scene/ClipboardManager.cpp
@@ -186,6 +186,31 @@ bool ClipboardManager::canPaste(const QMimeData *mimeData)
            && (mimeData->hasFormat(MimeType::Clipboard) || mimeData->hasFormat(MimeType::ClipboardLegacy));
 }
 
+QImage ClipboardManager::buildDragImage(Scene *scene, const QTransform &viewTransform, const QRectF &sourceRect)
+{
+    QSize mappedSize = viewTransform.mapRect(sourceRect).size().toSize();
+
+    // Cap the ghost image at a sane maximum dimension. sourceRect derives from selected
+    // elements' scene positions (a crafted/corrupted file, or a large paste offset, can place
+    // one at an extreme-but-finite coordinate — the same gap CircuitExporter::renderToImage
+    // hit), so mappedSize would otherwise be sized proportionally to that distance. Scale down
+    // to fit instead of failing outright; the ghost is a transient visual aid, not saved output.
+    if (mappedSize.width() > kMaxDragImageDimension || mappedSize.height() > kMaxDragImageDimension) {
+        mappedSize.scale(kMaxDragImageDimension, kMaxDragImageDimension, Qt::KeepAspectRatio);
+    }
+
+    QImage image(mappedSize, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+
+    QPainter painter(&image);
+    // Opacity 0 makes the ghost transparent; the drag cursor shape still appears
+    painter.setOpacity(0.0);
+    scene->render(&painter, QRectF(QPointF(), mappedSize), sourceRect);
+    painter.end();
+
+    return image;
+}
+
 void ClipboardManager::cloneDrag(const QPointF &mousePos)
 {
     auto *view = m_scene->view();
@@ -217,16 +242,7 @@ void ClipboardManager::cloneDrag(const QPointF &mousePos)
     // 8px padding avoids clipping port handles at the bounding-rect edges
     rect = rect.adjusted(-8, -8, 8, 8);
 
-    auto mappedSize = view->transform().mapRect(rect).size().toSize();
-    QImage image(mappedSize, QImage::Format_ARGB32_Premultiplied);
-    image.fill(Qt::transparent);
-
-    QPainter painter(&image);
-    // Opacity 0 makes the ghost transparent; the drag cursor shape still appears
-    painter.setOpacity(0.0);
-    QRectF target = image.rect();
-    QRectF source = rect;
-    m_scene->render(&painter, target, source);
+    const QImage image = buildDragImage(m_scene, view->transform(), rect);
 
     // Restore hidden items before the drag begins so the scene looks normal
     for (auto *item : items) {

--- a/App/Scene/ClipboardManager.cpp
+++ b/App/Scene/ClipboardManager.cpp
@@ -140,15 +140,6 @@ void ClipboardManager::paste()
         QDataStream regStream(&regBytes, QIODevice::ReadOnly);
         try { clipboardBlobs = Serialization::readBoundedBlobMap(regStream); } catch (...) {}
     }
-    if (!clipboardBlobs.isEmpty()) {
-        auto *registry = m_scene->icRegistry();
-        for (auto it = clipboardBlobs.cbegin(); it != clipboardBlobs.cend(); ++it) {
-            if (!registry->hasBlob(it.key())) {
-                registry->setBlob(it.key(), it.value());
-            }
-        }
-    }
-
     QByteArray itemData;
 
     if (mimeData->hasFormat(MimeType::ClipboardLegacy)) {
@@ -159,10 +150,31 @@ void ClipboardManager::paste()
         itemData = mimeData->data(MimeType::Clipboard);
     }
 
+    // Register any new embedded-IC blobs and add the pasted items as a single undo step —
+    // registering the blobs untracked would leave them orphaned in the registry forever after
+    // an undo, since AddItemsCommand only knows about scene items, not the blob registry.
+    const bool needsMacro = !clipboardBlobs.isEmpty() && !itemData.isEmpty();
+    if (needsMacro) {
+        m_scene->undoStack()->beginMacro(tr("Paste"));
+    }
+
+    if (!clipboardBlobs.isEmpty()) {
+        auto *registry = m_scene->icRegistry();
+        for (auto it = clipboardBlobs.cbegin(); it != clipboardBlobs.cend(); ++it) {
+            if (!registry->hasBlob(it.key())) {
+                m_scene->receiveCommand(new RegisterBlobCommand(it.key(), it.value(), m_scene));
+            }
+        }
+    }
+
     if (!itemData.isEmpty()) {
         QDataStream stream(&itemData, QIODevice::ReadOnly);
         QVersionNumber version = Serialization::readPandaHeader(stream);
         deserializeAndAdd(stream, version);
+    }
+
+    if (needsMacro) {
+        m_scene->undoStack()->endMacro();
     }
 }
 

--- a/App/Scene/ClipboardManager.h
+++ b/App/Scene/ClipboardManager.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <QCoreApplication>
 #include <QDataStream>
 #include <QList>
 #include <QPointF>
@@ -26,6 +27,8 @@ class Scene;
  */
 class ClipboardManager
 {
+    Q_DECLARE_TR_FUNCTIONS(ClipboardManager)
+
 public:
     explicit ClipboardManager(Scene *scene);
 

--- a/App/Scene/ClipboardManager.h
+++ b/App/Scene/ClipboardManager.h
@@ -14,7 +14,10 @@
 #include <QVersionNumber>
 
 class QGraphicsItem;
+class QImage;
 class QMimeData;
+class QRectF;
+class QTransform;
 class Scene;
 
 /**
@@ -51,6 +54,20 @@ public:
 
     /// Initiates a clone-drag (Ctrl+drag) of the current selection.
     void cloneDrag(const QPointF &mousePos);
+
+    /// Maximum width/height (in device pixels) buildDragImage() will allocate. A drag ghost is
+    /// a transient visual aid, not saved output, so a modest cap is enough — selection extent
+    /// beyond this is scaled down to fit rather than sized proportionally.
+    static constexpr int kMaxDragImageDimension = 1024;
+
+    /**
+     * \brief Renders \a sourceRect of \a scene, mapped through \a viewTransform, into a
+     * transparent-filled QImage bounded by kMaxDragImageDimension.
+     * \details \a sourceRect is a union of selected elements' scene bounding rects — unbounded
+     * magnitude, since position validation on load only rejects non-finite coordinates, never
+     * bounds them. Scaled down to fit rather than allocated proportionally. Exposed for testing.
+     */
+    static QImage buildDragImage(Scene *scene, const QTransform &viewTransform, const QRectF &sourceRect);
 
 private:
     /// Serializes \a items into \a stream (centroid + element data).

--- a/App/Scene/Commands.cpp
+++ b/App/Scene/Commands.cpp
@@ -705,26 +705,11 @@ MorphCommand::MorphCommand(const QList<GraphicElement *> &elements, ElementType 
     setText(tr("Morph %1 elements to %2").arg(elements.size()).arg(elements.constFirst()->objectName()));
 }
 
-void MorphCommand::undo()
+void MorphCommand::restoreDeletedConnections(const QList<DeletedConnectionInfo> &deleted)
 {
-    // transferConnections() deletes the current elements; a sim tick on
-    // the torn state between delete and setCircuitUpdateRequired() faults.
-    SimulationBlocker blocker(m_scene->simulation());
-
-    auto newElms = elements();
-    decltype(newElms) oldElms;
-    oldElms.reserve(m_ids.size());
-
-    for (int i = 0; i < m_ids.size(); ++i) {
-        oldElms << ElementFactory::buildElement(m_types.at(i));
-    }
-
-    transferConnections(newElms, oldElms);
-
-    // Restore connections that were deleted when redo() morphed to a smaller element.
     // By this point transferConnections has already placed the restored elements in the
     // scene under their original IDs, so itemById() resolves correctly.
-    for (const auto &info : std::as_const(m_deletedConnections)) {
+    for (const auto &info : deleted) {
         auto *morphedElm = dynamic_cast<GraphicElement *>(m_scene->itemById(info.morphedElementId));
         auto *otherElm   = dynamic_cast<GraphicElement *>(m_scene->itemById(info.otherElementId));
         if (!morphedElm || !otherElm) {
@@ -744,6 +729,27 @@ void MorphCommand::undo()
         m_scene->updateItemId(conn, info.connectionId);
         m_scene->addItem(conn);
     }
+}
+
+void MorphCommand::undo()
+{
+    // transferConnections() deletes the current elements; a sim tick on
+    // the torn state between delete and setCircuitUpdateRequired() faults.
+    SimulationBlocker blocker(m_scene->simulation());
+
+    auto newElms = elements();
+    decltype(newElms) oldElms;
+    oldElms.reserve(m_ids.size());
+
+    for (int i = 0; i < m_ids.size(); ++i) {
+        oldElms << ElementFactory::buildElement(m_types.at(i));
+    }
+
+    m_deletedConnectionsOnUndo.clear();
+    transferConnections(newElms, oldElms, &m_deletedConnectionsOnUndo);
+
+    // Restore connections that were deleted when the last redo() morphed to a smaller element.
+    restoreDeletedConnections(m_deletedConnections);
 
     m_scene->setCircuitUpdateRequired();
 }
@@ -762,6 +768,12 @@ void MorphCommand::redo()
 
     m_deletedConnections.clear();
     transferConnections(oldElms, newElms, &m_deletedConnections);
+
+    // Restore connections that were deleted when the last undo() reverted to a smaller
+    // original type — symmetric with undo()'s restoration above, so a connection added
+    // while morphed and later dropped by undo() isn't lost permanently.
+    restoreDeletedConnections(m_deletedConnectionsOnUndo);
+
     m_scene->setCircuitUpdateRequired();
 }
 

--- a/App/Scene/Commands.cpp
+++ b/App/Scene/Commands.cpp
@@ -1147,6 +1147,27 @@ void RemoveBlobCommand::undo()
     m_scene->icRegistry()->setBlob(m_blobName, m_data);
 }
 
+// --- RenameBlobCommand ---
+
+RenameBlobCommand::RenameBlobCommand(const QString &oldName, const QString &newName, Scene *scene, QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , m_oldName(oldName)
+    , m_newName(newName)
+    , m_scene(scene)
+{
+    setText(tr("Rename IC \"%1\" to \"%2\"").arg(oldName, newName));
+}
+
+void RenameBlobCommand::redo()
+{
+    m_scene->icRegistry()->renameBlob(m_oldName, m_newName);
+}
+
+void RenameBlobCommand::undo()
+{
+    m_scene->icRegistry()->renameBlob(m_newName, m_oldName);
+}
+
 // --- UpdateBlobCommand ---
 
 UpdateBlobCommand::UpdateBlobCommand(const QList<GraphicElement *> &elements, const QByteArray &oldData,

--- a/App/Scene/Commands.h
+++ b/App/Scene/Commands.h
@@ -332,10 +332,16 @@ private:
     void transferPortConnections(GraphicElement *oldElm, GraphicElement *newElm,
                                  bool isInput, QList<DeletedConnectionInfo> *deleted);
 
+    /// Recreates each connection recorded in \a deleted, restoring its original scene ID.
+    /// Shared by redo() and undo() so both directions restore a connection that couldn't
+    /// survive the *other* direction's port-count change.
+    void restoreDeletedConnections(const QList<DeletedConnectionInfo> &deleted);
+
     // --- Members ---
     ElementType m_newType;
     QList<ElementType> m_types;
-    QList<DeletedConnectionInfo> m_deletedConnections; ///< Connections deleted during the last redo(); restored on undo().
+    QList<DeletedConnectionInfo> m_deletedConnections; ///< Connections deleted during the last redo(); restored on the next undo().
+    QList<DeletedConnectionInfo> m_deletedConnectionsOnUndo; ///< Connections deleted during the last undo(); restored on the next redo().
 };
 
 /**

--- a/App/Scene/Commands.h
+++ b/App/Scene/Commands.h
@@ -481,6 +481,30 @@ private:
 };
 
 /**
+ * \class RenameBlobCommand
+ * \brief Undo command that renames a blob in the IC registry.
+ *
+ * \details Pushed standalone (never sharing a transaction with an UpdateCommand)
+ * so a rename is its own independent undo step — see ElementEditor's
+ * lineEditBlobName editingFinished handler.
+ */
+class RenameBlobCommand : public QUndoCommand
+{
+    Q_DECLARE_TR_FUNCTIONS(RenameBlobCommand)
+
+public:
+    RenameBlobCommand(const QString &oldName, const QString &newName, Scene *scene, QUndoCommand *parent = nullptr);
+
+    void redo() override;
+    void undo() override;
+
+private:
+    QString m_oldName;
+    QString m_newName;
+    Scene *m_scene;
+};
+
+/**
  * \class UpdateBlobCommand
  * \brief Undo command for embedded IC blob changes that may alter port counts.
  *

--- a/App/Scene/ICRegistry.cpp
+++ b/App/Scene/ICRegistry.cpp
@@ -334,8 +334,13 @@ void ICRegistry::reloadTargetsAtomically(const QList<GraphicElement *> &targets,
 }
 
 void ICRegistry::makeBlobSelfContained(const QString &name, QSet<QString> &visited,
-                                       QMap<QString, QByteArray> &blobs)
+                                       QMap<QString, QByteArray> &blobs, int depth)
 {
+    if (depth >= kMaxBlobNestingDepth) {
+        throw PANDACEPTION("Embedded IC dependency chain exceeds the maximum nesting depth (%1) while resolving '%2'",
+                           QString::number(kMaxBlobNestingDepth), name);
+    }
+
     if (visited.contains(name)) {
         qCWarning(zero) << "Circular blob reference detected:" << name << "— skipping.";
         return;
@@ -358,7 +363,7 @@ void ICRegistry::makeBlobSelfContained(const QString &name, QSet<QString> &visit
     for (auto it = embeddedICs.begin(); it != embeddedICs.end(); ++it) {
         const QString &depName = it.key();
         blobs[depName] = it.value();
-        makeBlobSelfContained(depName, visited, blobs);
+        makeBlobSelfContained(depName, visited, blobs, depth + 1);
         it.value() = blobs[depName];
     }
 
@@ -391,7 +396,7 @@ void ICRegistry::makeBlobSelfContained(const QString &name, QSet<QString> &visit
 
             // Recursively make the dep self-contained before embedding
             blobs[baseName] = fileBytes;
-            makeBlobSelfContained(baseName, visited, blobs);
+            makeBlobSelfContained(baseName, visited, blobs, depth + 1);
             embeddedICs[baseName] = blobs[baseName];
         }
 

--- a/App/Scene/ICRegistry.cpp
+++ b/App/Scene/ICRegistry.cpp
@@ -103,27 +103,14 @@ void ICRegistry::onFileChanged(const QString &filePath)
     const auto connections = UpdateBlobCommand::captureConnections(targets);
     const QByteArray oldData = captureSnapshot(targets);
 
-    // Stop the simulation for the entire reload. Between freeing each IC's
-    // old internal graph and rebuilding it, the scene's sorted vectors hold
-    // dangling pointers; ticking on that state would fault. Roll back any
-    // partial mutation if loadFile throws so we don't push a half-applied
-    // undo command.
-    QList<GraphicElement *> updated;
-    {
-        SimulationBlocker blocker(m_scene->simulation());
-        try {
-            for (auto *elm : targets) {
-                static_cast<IC *>(elm)->loadFile(filePath);
-                updated.append(elm);
-            }
-        } catch (...) {
-            rollbackElements(updated, oldData, m_scene);
-            m_scene->setCircuitUpdateRequired();
-            emit definitionChanged(filePath);
-            throw;
-        }
+    try {
+        reloadTargetsAtomically(targets, oldData, [&](IC *ic) { ic->loadFile(filePath); });
+    } catch (...) {
         m_scene->setCircuitUpdateRequired();
+        emit definitionChanged(filePath);
+        throw;
     }
+    m_scene->setCircuitUpdateRequired();
 
     auto *cmd = new UpdateBlobCommand(targets, oldData, connections, m_scene);
     m_scene->undoStack()->push(cmd);
@@ -258,18 +245,12 @@ int ICRegistry::embedICsByFile(const QString &fileName, const QByteArray &fileBy
 
     registerBlob(blobName, fileBytes);
 
-    // Mutate all targets atomically: if any loadFromBlob throws, roll back
-    // every element that was already updated so we don't push a partial undo command.
-    QList<GraphicElement *> updated;
     try {
-        for (auto *elm : targets) {
-            auto *ic = static_cast<IC *>(elm);
+        reloadTargetsAtomically(targets, oldData, [&](IC *ic) {
             ic->setBlobName(blobName);
             ic->loadFromBlob(m_blobs[blobName], m_scene->contextDir());
-            updated.append(elm);
-        }
+        });
     } catch (...) {
-        rollbackElements(updated, oldData, m_scene);
         removeBlob(blobName);
         throw;
     }
@@ -306,20 +287,8 @@ int ICRegistry::extractToFile(const QString &blobName, const QString &filePath)
     const QByteArray oldData = captureSnapshot(targets);
     const QByteArray oldBlob = blob(blobName);
 
-    // Mutate all targets atomically: if any loadFile throws, roll back
-    // every element that was already updated so we don't push a partial undo command.
     const QString fileDir = QFileInfo(filePath).absolutePath();
-    QList<GraphicElement *> updated;
-    try {
-        for (auto *elm : targets) {
-            auto *ic = static_cast<IC *>(elm);
-            ic->loadFile(filePath, fileDir);
-            updated.append(elm);
-        }
-    } catch (...) {
-        rollbackElements(updated, oldData, m_scene);
-        throw;
-    }
+    reloadTargetsAtomically(targets, oldData, [&](IC *ic) { ic->loadFile(filePath, fileDir); });
 
     removeBlob(blobName);
 
@@ -340,6 +309,27 @@ void ICRegistry::rollbackElements(const QList<GraphicElement *> &elements, const
     auto ctx = scene->deserializationContext(portMap, version);
     for (auto *elm : elements) {
         elm->load(stream, ctx);
+    }
+}
+
+void ICRegistry::reloadTargetsAtomically(const QList<GraphicElement *> &targets, const QByteArray &oldData,
+                                          const std::function<void(IC *)> &mutate)
+{
+    // Stop the simulation for the entire loop, not just each individual mutation. Between
+    // freeing one IC's old internal graph and rebuilding it, the scene's sorted vectors hold
+    // dangling pointers; ticking on that state would fault — and that stale state persists
+    // across the whole loop, since setCircuitUpdateRequired() only runs once, after every
+    // target has been reloaded, not after each one.
+    QList<GraphicElement *> updated;
+    SimulationBlocker blocker(m_scene->simulation());
+    try {
+        for (auto *elm : targets) {
+            mutate(static_cast<IC *>(elm));
+            updated.append(elm);
+        }
+    } catch (...) {
+        rollbackElements(updated, oldData, m_scene);
+        throw;
     }
 }
 

--- a/App/Scene/ICRegistry.cpp
+++ b/App/Scene/ICRegistry.cpp
@@ -164,7 +164,11 @@ void ICRegistry::removeBlob(const QString &name)
 
 void ICRegistry::renameBlob(const QString &oldName, const QString &newName)
 {
-    if (!m_blobs.contains(oldName) || oldName == newName) {
+    // Defense in depth: the primary guard is at the caller (ElementEditor rejects a colliding
+    // rename before ever constructing a command), but no-op here too rather than silently
+    // overwriting an unrelated blob's bytes, so any future/other caller can't corrupt one IC's
+    // data by renaming a different one onto it.
+    if (!m_blobs.contains(oldName) || oldName == newName || m_blobs.contains(newName)) {
         return;
     }
 
@@ -271,6 +275,11 @@ int ICRegistry::embedICsByFile(const QString &fileName, const QByteArray &fileBy
     }
 
     auto *cmd = new UpdateBlobCommand(targets, oldData, connections, m_scene);
+    // This blob is newly registered above (registerBlob() at a name these targets weren't
+    // already using), not replacing prior content — leave m_oldBlob at its default-empty so
+    // undo() removes it rather than restoring bytes that never existed. Explicit rather than
+    // relying on the constructor default, unlike every other UpdateBlobCommand call site.
+    cmd->setOldBlob(QByteArray());
     m_scene->undoStack()->push(cmd);
     return static_cast<int>(targets.size());
 }

--- a/App/Scene/ICRegistry.h
+++ b/App/Scene/ICRegistry.h
@@ -108,10 +108,18 @@ private slots:
     void onFileChanged(const QString &filePath);
 
 private:
+    /// Maximum recursion depth for makeBlobSelfContained()'s dependency walk. Cycle detection via
+    /// its \c visited set alone doesn't bound a long, non-cyclic chain of distinct legitimate
+    /// files (A embeds B embeds C embeds ..., no repeats) — mirrors ICLoader's
+    /// kMaxICNestingDepth, which exists for the identical failure mode on the file-load path.
+    static constexpr int kMaxBlobNestingDepth = 16;
+
     /// Recursively inlines all IC dependencies of blob \a name so it has no external file references.
     /// Uses \a blobs as working storage instead of m_blobs to avoid corrupting state on failure.
+    /// \a depth counts recursion levels from the initial call (0) and throws once it would exceed
+    /// kMaxBlobNestingDepth, so a long chain of distinct dependency files can't exhaust the stack.
     void makeBlobSelfContained(const QString &name, QSet<QString> &visited,
-                               QMap<QString, QByteArray> &blobs);
+                               QMap<QString, QByteArray> &blobs, int depth = 0);
 
     /// Renames a nested blob reference from \a oldName to \a newName inside \a blobData's metadata.
     static void renameBlobReference(QByteArray &blobData, const QString &oldName, const QString &newName);

--- a/App/Scene/ICRegistry.h
+++ b/App/Scene/ICRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <QFileSystemWatcher>
 #include <QMap>
 #include <QObject>
@@ -113,6 +115,15 @@ private:
 
     /// Renames a nested blob reference from \a oldName to \a newName inside \a blobData's metadata.
     static void renameBlobReference(QByteArray &blobData, const QString &oldName, const QString &newName);
+
+    /// Runs \a mutate on each of \a targets, atomically: if any call throws, every target already
+    /// mutated is rolled back to \a oldData before the exception propagates. The whole loop runs
+    /// under one SimulationBlocker — each mutation frees and rebuilds an IC's internal graph, and a
+    /// tick observing that between iterations (not just within one) would still dereference freed
+    /// memory via Simulation's cached vectors, so the guard must span the entire loop, not each
+    /// iteration.
+    void reloadTargetsAtomically(const QList<GraphicElement *> &targets, const QByteArray &oldData,
+                                 const std::function<void(IC *)> &mutate);
 
     Scene *m_scene;                          ///< Owning scene.
     QMap<QString, QByteArray> m_fileCache;   ///< Cached file reads for file-backed ICs (path → bytes).

--- a/App/Scene/PropertyShortcutHandler.cpp
+++ b/App/Scene/PropertyShortcutHandler.cpp
@@ -4,7 +4,6 @@
 #include "App/Scene/PropertyShortcutHandler.h"
 
 #include <algorithm>
-#include <functional>
 
 #include "App/Core/Enums.h"
 #include "App/Element/GraphicElement.h"
@@ -17,27 +16,34 @@ PropertyShortcutHandler::PropertyShortcutHandler(Scene *scene)
 {
 }
 
-void PropertyShortcutHandler::adjustMainProperty(int dir)
+void PropertyShortcutHandler::applyWithUndo(GraphicElement *element, const std::function<void()> &mutate)
 {
     // Wraps a direct property mutation in an UpdateCommand (F37) so the
     // [ / ] shortcuts are undoable and mark the circuit dirty, exactly like
     // the port-size path below and the property editor.
-    const auto applyWithUndo = [this](GraphicElement *element, const std::function<void()> &mutate) {
-        QByteArray oldData;
-        {
-            QDataStream stream(&oldData, QIODevice::WriteOnly);
-            Serialization::writePandaHeader(stream);
-            element->save(stream);
-        }
-        mutate();
-        m_scene->receiveCommand(new UpdateCommand({element}, oldData, m_scene));
-    };
+    QByteArray oldData;
+    {
+        QDataStream stream(&oldData, QIODevice::WriteOnly);
+        Serialization::writePandaHeader(stream);
+        element->save(stream);
+    }
+    mutate();
+    m_scene->receiveCommand(new UpdateCommand({element}, oldData, m_scene));
+}
 
+void PropertyShortcutHandler::adjustMainProperty(int dir)
+{
     // dir = -1 for prev, +1 for next
     // Cycles the "primary" configurable property of each selected element:
     // input count for logic gates, output count for rotary inputs,
     // clock frequency (0.5 Hz step), buzzer frequency (100 Hz step), or display color.
-    for (auto *element : m_scene->selectedElements()) {
+    const auto selected = m_scene->selectedElements();
+    const bool needsMacro = selected.size() > 1;
+    if (needsMacro) {
+        m_scene->undoStack()->beginMacro(tr("Cycle element properties"));
+    }
+
+    for (auto *element : selected) {
         switch (element->elementType()) {
         // Logic Elements
         case ElementType::And:
@@ -113,6 +119,10 @@ void PropertyShortcutHandler::adjustMainProperty(int dir)
         element->setSelected(false);
         element->setSelected(true);
     }
+
+    if (needsMacro) {
+        m_scene->undoStack()->endMacro();
+    }
 }
 
 void PropertyShortcutHandler::prevMainProperty()
@@ -128,7 +138,13 @@ void PropertyShortcutHandler::nextMainProperty()
 void PropertyShortcutHandler::adjustSecondaryProperty(int dir)
 {
     // dir = -1 for prev, +1 for next
-    for (auto *element : m_scene->selectedElements()) {
+    const auto selected = m_scene->selectedElements();
+    const bool needsMacro = selected.size() > 1;
+    if (needsMacro) {
+        m_scene->undoStack()->beginMacro(tr("Cycle element properties"));
+    }
+
+    for (auto *element : selected) {
         switch (element->elementType()) {
         case ElementType::TruthTable: {
             const int newSize = element->outputSize() + dir;
@@ -139,7 +155,7 @@ void PropertyShortcutHandler::adjustSecondaryProperty(int dir)
         }
         case ElementType::Led:
             if (element->hasColors())
-                element->setColor(dir < 0 ? element->previousColor() : element->nextColor());
+                applyWithUndo(element, [element, dir] { element->setColor(dir < 0 ? element->previousColor() : element->nextColor()); });
             break;
 
         case ElementType::And:
@@ -180,6 +196,10 @@ void PropertyShortcutHandler::adjustSecondaryProperty(int dir)
         element->setSelected(false);
         element->setSelected(true);
     }
+
+    if (needsMacro) {
+        m_scene->undoStack()->endMacro();
+    }
 }
 
 void PropertyShortcutHandler::prevSecondaryProperty()
@@ -194,7 +214,13 @@ void PropertyShortcutHandler::nextSecondaryProperty()
 
 void PropertyShortcutHandler::nextElement()
 {
-    for (auto *element : m_scene->selectedElements()) {
+    const auto selected = m_scene->selectedElements();
+    const bool needsMacro = selected.size() > 1;
+    if (needsMacro) {
+        m_scene->undoStack()->beginMacro(tr("Morph elements"));
+    }
+
+    for (auto *element : selected) {
         const QPointF elmPosition = element->scenePos();
         auto nextType = Enums::nextElmType(element->elementType());
 
@@ -211,11 +237,21 @@ void PropertyShortcutHandler::nextElement()
             item->setSelected(true);
         }
     }
+
+    if (needsMacro) {
+        m_scene->undoStack()->endMacro();
+    }
 }
 
 void PropertyShortcutHandler::prevElement()
 {
-    for (auto *element : m_scene->selectedElements()) {
+    const auto selected = m_scene->selectedElements();
+    const bool needsMacro = selected.size() > 1;
+    if (needsMacro) {
+        m_scene->undoStack()->beginMacro(tr("Morph elements"));
+    }
+
+    for (auto *element : selected) {
         const QPointF elmPosition = element->scenePos();
         auto prevType = Enums::prevElmType(element->elementType());
 
@@ -228,5 +264,9 @@ void PropertyShortcutHandler::prevElement()
         if (item) {
             item->setSelected(true);
         }
+    }
+
+    if (needsMacro) {
+        m_scene->undoStack()->endMacro();
     }
 }

--- a/App/Scene/PropertyShortcutHandler.h
+++ b/App/Scene/PropertyShortcutHandler.h
@@ -7,6 +7,11 @@
 
 #pragma once
 
+#include <functional>
+
+#include <QCoreApplication>
+
+class GraphicElement;
 class Scene;
 
 /**
@@ -18,6 +23,8 @@ class Scene;
  */
 class PropertyShortcutHandler
 {
+    Q_DECLARE_TR_FUNCTIONS(PropertyShortcutHandler)
+
 public:
     explicit PropertyShortcutHandler(Scene *scene);
 
@@ -41,4 +48,7 @@ private:
     void adjustMainProperty(int dir);
     /// Shared implementation for prev/nextSecondaryProperty(); \a dir is -1 or +1.
     void adjustSecondaryProperty(int dir);
+    /// Snapshots \a element, applies \a mutate, then pushes an UpdateCommand so the
+    /// change is undoable. Shared by adjustMainProperty() and adjustSecondaryProperty().
+    void applyWithUndo(GraphicElement *element, const std::function<void()> &mutate);
 };

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -194,10 +194,30 @@ void Scene::drawBackground(QPainter *painter, const QRectF &rect)
     const int right = static_cast<int>(std::ceil(rect.right() / gridSize)) * gridSize;
     const int bottom = static_cast<int>(std::ceil(rect.bottom() / gridSize)) * gridSize;
 
+    // Bound the grid regardless of view zoom: \a rect isn't necessarily clipped to the
+    // interactive view's viewport — a headless scene->render() call (CircuitExporter's
+    // PDF/image export) passes the *entire* scene bounding rect as the exposed area, which
+    // for a scene containing one element at an extreme-but-finite position (the only check
+    // on load rejects non-finite, not large, coordinates) can span millions of grid cells.
+    // Left unchecked, the loop below builds a point list with billions of entries — hanging
+    // and exhausting memory well before drawPoints() ever runs. Compute in 64-bit: the naive
+    // int product overflows for exactly this scenario, wrapping to a small/negative value
+    // that would pass a small reserve() through to an unbounded loop anyway.
+    const qint64 columns = (static_cast<qint64>(right) - left) / gridSize + 1;
+    const qint64 rows = (static_cast<qint64>(bottom) - top) / gridSize + 1;
+    constexpr qint64 kMaxGridPoints = 1'000'000;
+    if (columns * rows > kMaxGridPoints) {
+        return;
+    }
+
     painter->setPen(m_dots);
 
     QPolygon points;
-    points.reserve(((right - left) / gridSize + 1) * ((bottom - top) / gridSize + 1));
+    // kMaxGridPoints (checked above) comfortably fits in int on every supported platform;
+    // cast explicitly rather than relying on the implicit qint64->qsizetype narrowing, since
+    // qsizetype is 32-bit on i386 (would warn under -Wconversion) but the same width as qint64
+    // on 64-bit platforms (a same-width static_cast there would instead warn -Wuseless-cast).
+    points.reserve(static_cast<int>(columns * rows));
 
     for (int x = left; x <= right; x += gridSize) {
         for (int y = top; y <= bottom; y += gridSize) {

--- a/App/Scene/SceneDropHandler.cpp
+++ b/App/Scene/SceneDropHandler.cpp
@@ -10,6 +10,7 @@
 #include <QtGlobal>
 
 #include "App/Core/Common.h"
+#include "App/Core/DragDropPayload.h"
 #include "App/Core/Enums.h"
 #include "App/Core/MimeTypes.h"
 #include "App/Element/ElementFactory.h"
@@ -50,30 +51,23 @@ void SceneDropHandler::handleNewElementDrop(QGraphicsSceneDragDropEvent *event)
     QDataStream stream(&itemData, QIODevice::ReadOnly);
     Serialization::readPandaHeader(stream);
 
-    QPoint offset;      stream >> offset;
-    ElementType type;   stream >> type;
-    QString icFileName; stream >> icFileName;
-
-    bool isEmbedded = false;
-    QString blobName;
-    if (!stream.atEnd()) { stream >> isEmbedded; }
-    if (!stream.atEnd()) { stream >> blobName; }
+    const auto payload = readDragDropPayload(stream);
 
     // Subtract the drag offset so the element lands under the original grab point
-    QPointF pos = event->scenePos() - offset;
-    qCDebug(zero) << type << " at position: " << pos.x() << ", " << pos.y() << ", label: " << icFileName;
+    QPointF pos = event->scenePos() - payload.offset;
+    qCDebug(zero) << payload.type << " at position: " << pos.x() << ", " << pos.y() << ", label: " << payload.icFileName;
 
-    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
+    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(payload.type));
     qCDebug(zero) << "Valid element.";
 
-    if (isEmbedded && type == ElementType::IC) {
-        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
+    if (payload.isEmbedded && payload.type == ElementType::IC) {
+        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), payload.blobName)) {
             return;
         }
     } else {
         // loadFromDrop can throw on malformed files; unique_ptr keeps the
         // freshly-allocated element from leaking when it does.
-        element->loadFromDrop(icFileName, m_scene->contextDir());
+        element->loadFromDrop(payload.icFileName, m_scene->contextDir());
     }
 
     qCDebug(zero) << "Adding the element to the scene.";
@@ -135,16 +129,9 @@ void SceneDropHandler::addFromMimeData(QMimeData *mimeData)
     QDataStream stream(&itemData, QIODevice::ReadOnly);
     Serialization::readPandaHeader(stream);
 
-    QPoint offset;      stream >> offset;
-    ElementType type;   stream >> type;
-    QString icFileName; stream >> icFileName;
+    const auto payload = readDragDropPayload(stream);
 
-    bool isEmbedded = false;
-    QString blobName;
-    if (!stream.atEnd()) { stream >> isEmbedded; }
-    if (!stream.atEnd()) { stream >> blobName; }
-
-    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(type));
+    std::unique_ptr<GraphicElement> element(ElementFactory::buildElement(payload.type));
     qCDebug(zero) << "Valid element.";
 
     // RAII for mimeData too — the original deleteLater at the bottom is
@@ -152,12 +139,12 @@ void SceneDropHandler::addFromMimeData(QMimeData *mimeData)
     // the half-built element.
     auto mimeGuard = qScopeGuard([mimeData]() { mimeData->deleteLater(); });
 
-    if (isEmbedded && type == ElementType::IC) {
-        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), blobName)) {
+    if (payload.isEmbedded && payload.type == ElementType::IC) {
+        if (!m_scene->icRegistry()->initEmbeddedIC(static_cast<IC *>(element.get()), payload.blobName)) {
             return;
         }
     } else {
-        element->loadFromDrop(icFileName, m_scene->contextDir());
+        element->loadFromDrop(payload.icFileName, m_scene->contextDir());
     }
 
     qCDebug(zero) << "Adding the element to the scene.";

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -282,9 +282,13 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
 
     // Copy external file dependencies (appearances, audio, IC sub-circuits, waveform)
     // to the new directory before updating contextDir, so save() can store bare filenames.
+    // This also runs on a project's very first save (oldContextDir empty): without it, a
+    // custom appearance/audio file picked before ever saving would never get copied
+    // alongside the .panda file, leaving the bare filename GraphicElementSerializer::save()
+    // stores unresolvable on the next reload.
     const QString oldContextDir = m_scene.contextDir();
     const QString newContextDir = QFileInfo(fileName_).absolutePath();
-    if (!oldContextDir.isEmpty() && oldContextDir != newContextDir) {
+    if (oldContextDir != newContextDir) {
         for (auto *elm : m_scene.elements()) {
             for (const QString &file : elm->externalFiles()) {
                 FileUtils::copyToDir(file, newContextDir);

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -291,9 +291,13 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
     if (oldContextDir != newContextDir) {
         for (auto *elm : m_scene.elements()) {
             for (const QString &file : elm->externalFiles()) {
-                FileUtils::copyToDir(file, newContextDir);
                 if (file.endsWith(".panda")) {
-                    FileUtils::copyPandaDeps(file, oldContextDir, newContextDir);
+                    // copyPandaFile copies the file itself and recursively copies any
+                    // fileBackedICs it references, in one pass.
+                    const QFileInfo srcInfo(file);
+                    Serialization::copyPandaFile(srcInfo, QFileInfo(newContextDir + "/" + srcInfo.fileName()));
+                } else {
+                    FileUtils::copyToDir(file, newContextDir);
                 }
             }
         }

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -241,12 +241,17 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
                 const QString baseName = QFileInfo(icFile).baseName();
                 if (!m_scene.icRegistry()->hasBlob(baseName)) {
                     QFileInfo fi(QDir(contextDir), icFile);
-                    if (fi.exists()) {
-                        QFile f(fi.absoluteFilePath());
-                        if (f.open(QIODevice::ReadOnly)) {
-                            m_scene.icRegistry()->registerBlob(baseName, f.readAll());
-                        }
+                    QFile f(fi.absoluteFilePath());
+                    // setBlobName() below marks the IC embedded unconditionally; if the
+                    // dependency can't actually be read, embedding it anyway would leave the
+                    // blob metadata pointing at a name never registered in the IC registry —
+                    // and, since isEmbedded() would then always be true, this block would never
+                    // retry on any later save either. Fail loudly now instead of producing a
+                    // blob that throws "not found" only when someone tries to reload it.
+                    if (!fi.exists() || !f.open(QIODevice::ReadOnly)) {
+                        throw PANDACEPTION("Cannot save: sub-circuit \"%1\" could not be read to embed it.", icFile);
                     }
+                    m_scene.icRegistry()->registerBlob(baseName, f.readAll());
                 }
                 // Switch the IC to blob-backed for serialization; do NOT call
                 // loadFromBlob. The IC already has its internal state loaded
@@ -309,8 +314,6 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
         }
     }
 
-    setCurrentFile(fileName_);
-
     // QSaveFile writes to a temp file and commits atomically, preventing data loss
     // if the process is interrupted during a write
     QSaveFile saveFile(fileName_);
@@ -357,6 +360,12 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
         }
         throw PANDACEPTION("Could not save file: %1", saveFile.errorString());
     }
+
+    // Only adopt the new file/context identity once it's actually on disk — setting it earlier
+    // left the workspace believing its current file was a path that was never written whenever
+    // the open/commit above failed (interactive ReadOnlyTarget with the retry cancelled, or a
+    // throw in non-interactive/MCP callers), with nothing to roll it back afterward.
+    setCurrentFile(fileName_);
 
     // Mark the undo stack as clean so the title bar no longer shows unsaved-change indicator
     m_scene.undoStack()->setClean();

--- a/App/UI/CircuitExporter.cpp
+++ b/App/UI/CircuitExporter.cpp
@@ -43,19 +43,18 @@ void renderToPdf(Scene *scene, const QString &filePath)
     painter.end();
 }
 
-void renderToImage(Scene *scene, const QString &filePath)
+QImage renderScaledImage(Scene *scene, const QRectF &paddedRect)
 {
-    const QRectF rect = paddedBoundingRect(scene);
-
-    // Cap the output at a sane maximum dimension. rect derives from element positions
-    // loaded from a .panda file; the only check on load (GraphicElementSerializer's position
+    // Cap the output at a sane maximum dimension. paddedRect derives from element positions
+    // loaded from a .panda file (or set via the MCP create_element/move_element commands, which
+    // accept any finite coordinate); the only check on load (GraphicElementSerializer's position
     // validation) rejects non-finite coordinates but never bounds magnitude, so a crafted or
-    // corrupted file with one element at a large-but-finite position would otherwise size
-    // this pixmap proportionally — potentially tens of gigabytes. Scale into the capped size
-    // instead of failing outright, the same "fit scene content to a fixed target" technique
-    // renderToPdf already uses via its fixed-size printer page. Below the cap (every
-    // realistic circuit), output resolution is unchanged.
-    QSizeF targetSize = rect.size();
+    // corrupted file — or a scripted MCP client — with one element at a large-but-finite
+    // position would otherwise size this image proportionally — potentially tens of gigabytes.
+    // Scale into the capped size instead of failing outright, the same "fit scene content to a
+    // fixed target" technique renderToPdf already uses via its fixed-size printer page. Below
+    // the cap (every realistic circuit), output resolution is unchanged.
+    QSizeF targetSize = paddedRect.size();
     const qreal scale = (std::min)({1.0, kMaxImageDimension / targetSize.width(), kMaxImageDimension / targetSize.height()});
     if (scale < 1.0) {
         targetSize *= scale;
@@ -77,8 +76,15 @@ void renderToImage(Scene *scene, const QString &filePath)
     }
     // Antialiasing enabled here; the PDF path relies on the printer's high DPI instead.
     painter.setRenderHint(QPainter::Antialiasing);
-    scene->render(&painter, QRectF(QPointF(), targetSize), rect);
+    scene->render(&painter, QRectF(QPointF(), targetSize), paddedRect);
     painter.end();
+
+    return image;
+}
+
+void renderToImage(Scene *scene, const QString &filePath)
+{
+    const QImage image = renderScaledImage(scene, paddedBoundingRect(scene));
 
     if (!image.save(filePath)) {
         throw PANDACEPTION_WITH_CONTEXT("CircuitExporter", "Could not save image to %1.", filePath);

--- a/App/UI/CircuitExporter.cpp
+++ b/App/UI/CircuitExporter.cpp
@@ -3,12 +3,15 @@
 
 #include "App/UI/CircuitExporter.h"
 
+#include <algorithm>
+
+#include <QImage>
 #include <QPageLayout>
 #include <QPageSize>
 #include <QPainter>
-#include <QPixmap>
 #include <QPrinter>
 #include <QRectF>
+#include <QSizeF>
 
 #include "App/Core/Common.h"
 #include "App/Scene/Scene.h"
@@ -43,18 +46,41 @@ void renderToPdf(Scene *scene, const QString &filePath)
 void renderToImage(Scene *scene, const QString &filePath)
 {
     const QRectF rect = paddedBoundingRect(scene);
-    QPixmap pixmap(rect.size().toSize());
+
+    // Cap the output at a sane maximum dimension. rect derives from element positions
+    // loaded from a .panda file; the only check on load (GraphicElementSerializer's position
+    // validation) rejects non-finite coordinates but never bounds magnitude, so a crafted or
+    // corrupted file with one element at a large-but-finite position would otherwise size
+    // this pixmap proportionally — potentially tens of gigabytes. Scale into the capped size
+    // instead of failing outright, the same "fit scene content to a fixed target" technique
+    // renderToPdf already uses via its fixed-size printer page. Below the cap (every
+    // realistic circuit), output resolution is unchanged.
+    QSizeF targetSize = rect.size();
+    const qreal scale = (std::min)({1.0, kMaxImageDimension / targetSize.width(), kMaxImageDimension / targetSize.height()});
+    if (scale < 1.0) {
+        targetSize *= scale;
+    }
+
+    // QImage with an explicit alpha format, not QPixmap — QPixmap(size) defaults to an
+    // opaque platform format on this build, so filling it with Qt::transparent silently
+    // flattens to opaque instead of storing real alpha. Without an explicit fill at all it's
+    // uninitialized (Qt's documented QPixmap/QImage(size) contract): Scene only paints its
+    // background opaquely once Scene::updateTheme() has run, which production always does
+    // first, masking this everywhere else; a caller that doesn't would export genuine
+    // garbage/uninitialized pixels in the padding margin.
+    QImage image(targetSize.toSize(), QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
 
     QPainter painter;
-    if (!painter.begin(&pixmap)) {
+    if (!painter.begin(&image)) {
         throw PANDACEPTION_WITH_CONTEXT("CircuitExporter", "Could not begin painting circuit image.");
     }
     // Antialiasing enabled here; the PDF path relies on the printer's high DPI instead.
     painter.setRenderHint(QPainter::Antialiasing);
-    scene->render(&painter, QRectF(), rect);
+    scene->render(&painter, QRectF(QPointF(), targetSize), rect);
     painter.end();
 
-    if (!pixmap.save(filePath)) {
+    if (!image.save(filePath)) {
         throw PANDACEPTION_WITH_CONTEXT("CircuitExporter", "Could not save image to %1.", filePath);
     }
 }

--- a/App/UI/CircuitExporter.h
+++ b/App/UI/CircuitExporter.h
@@ -9,6 +9,8 @@
 
 class Scene;
 class QString;
+class QImage;
+class QRectF;
 
 /**
  * \namespace CircuitExporter
@@ -40,5 +42,15 @@ void renderToPdf(Scene *scene, const QString &filePath);
  * larger scenes are scaled down to fit rather than allocating proportionally.
  */
 void renderToImage(Scene *scene, const QString &filePath);
+
+/**
+ * \brief Renders \a scene into a transparent-filled QImage bounded by kMaxImageDimension.
+ * \details \a paddedRect is scene-coordinate content to render (caller applies its own
+ * padding policy). Content is scaled down to fit within kMaxImageDimension per side rather
+ * than allocated proportionally to \a paddedRect. Shared by renderToImage() and the MCP
+ * export_image handler so this bounding logic has exactly one implementation.
+ * \throws Pandaception if the QPainter cannot begin painting to the image.
+ */
+QImage renderScaledImage(Scene *scene, const QRectF &paddedRect);
 
 } // namespace CircuitExporter

--- a/App/UI/CircuitExporter.h
+++ b/App/UI/CircuitExporter.h
@@ -20,6 +20,14 @@ class QString;
  */
 namespace CircuitExporter {
 
+/// Maximum width/height (in pixels) renderToImage() will allocate. Scene extent beyond this
+/// is scaled down to fit rather than sized proportionally — see renderToImage()'s details.
+/// Bounded well under 8192 (where width*height*4 bytes hits Qt's own default 256 MB
+/// QImageIOHandler allocation limit — confirmed via debugger inspection: a 16384 cap produced
+/// an image QImage's own reader then refused to load back), so the exported file stays usable
+/// by any default-configured Qt image consumer, not just by this process's writer.
+inline constexpr double kMaxImageDimension = 4096;
+
 /**
  * \brief Renders \a scene to a PDF file at \a filePath.
  * \throws Pandaception if the QPainter cannot begin painting to the printer.
@@ -28,6 +36,8 @@ void renderToPdf(Scene *scene, const QString &filePath);
 
 /**
  * \brief Renders \a scene to a PNG image file at \a filePath.
+ * \details Output resolution matches the scene extent 1:1 up to kMaxImageDimension;
+ * larger scenes are scaled down to fit rather than allocating proportionally.
  */
 void renderToImage(Scene *scene, const QString &filePath);
 

--- a/App/UI/ElementEditor.cpp
+++ b/App/UI/ElementEditor.cpp
@@ -86,6 +86,7 @@ ElementEditor::ElementEditor(QWidget *parent)
     connect(m_ui->comboBoxWirelessMode,   qOverload<int>(&QComboBox::currentIndexChanged),  this, &ElementEditor::apply);
     connect(m_ui->lineEditElementLabel,   &QLineEdit::textChanged,                          this, &ElementEditor::apply);
     connect(m_ui->lineEditTrigger,        &QLineEdit::textChanged,                          this, &ElementEditor::triggerChanged);
+    connect(m_ui->lineEditBlobName,       &QLineEdit::editingFinished,                      this, &ElementEditor::blobNameEditingFinished);
     connect(m_ui->pushButtonAudioBox,     &QPushButton::clicked,                            this, &ElementEditor::audioBox);
     connect(m_ui->pushButtonChangeAppearance,   &QPushButton::clicked,                            this, &ElementEditor::updateElementAppearance);
     connect(m_ui->pushButtonDefaultAppearance,  &QPushButton::clicked,                            this, &ElementEditor::defaultAppearance);
@@ -642,15 +643,6 @@ void ElementEditor::apply()
         }
     }
 
-    // Apply blob name rename via ICRegistry (updates registry key + all instances)
-    if (m_caps.isEmbedded && !m_elements.isEmpty()) {
-        const QString newBlobName = m_ui->lineEditBlobName->text().trimmed();
-        const QString oldBlobName = m_elements.first()->blobName();
-        if (!newBlobName.isEmpty() && newBlobName != oldBlobName) {
-            m_scene->icRegistry()->renameBlob(oldBlobName, newBlobName);
-        }
-    }
-
     // Reset the one-shot appearance update flag after applying to all elements.
     if (m_isUpdatingAppearance) {
         m_isUpdatingAppearance = false;
@@ -669,6 +661,28 @@ void ElementEditor::apply()
         m_scene->receiveCommand(new DeleteItemsCommand(wirelessConnsToDelete, m_scene));
         m_scene->undoStack()->endMacro();
     }
+}
+
+void ElementEditor::blobNameEditingFinished()
+{
+    if (m_elements.isEmpty() || !m_caps.isEmbedded) {
+        return;
+    }
+
+    const QString newBlobName = m_ui->lineEditBlobName->text().trimmed();
+    const QString oldBlobName = m_elements.first()->blobName();
+
+    // editingFinished fires on plain focus-out too, not just on an actual edit — guard against
+    // the multi-selection placeholder as well as an empty/unchanged field so clicking into and
+    // out of the field without typing anything never renames.
+    if (newBlobName.isEmpty() || newBlobName == oldBlobName || newBlobName == m_manyLabels) {
+        return;
+    }
+
+    // Renaming is its own independent, immediately-applied action — pushed standalone rather
+    // than folded into apply()'s UpdateCommand, so undo/redo never has to reconcile a generic
+    // property snapshot against the IC registry's shared blob-name state.
+    m_scene->receiveCommand(new RenameBlobCommand(oldBlobName, newBlobName, m_scene));
 }
 
 void ElementEditor::inputIndexChanged(const int index)

--- a/App/UI/ElementEditor.cpp
+++ b/App/UI/ElementEditor.cpp
@@ -184,6 +184,10 @@ void ElementEditor::updateElementAppearance()
         const int appearanceIndex = m_ui->comboBoxAppearanceState->currentData().toInt();
 
         // Snapshot and apply via undo command
+        const bool needsMacro = m_scene && m_elements.size() > 1;
+        if (needsMacro) {
+            m_scene->undoStack()->beginMacro(tr("Change appearance"));
+        }
         for (auto *elm : std::as_const(m_elements)) {
             QByteArray oldData;
             {
@@ -195,6 +199,9 @@ void ElementEditor::updateElementAppearance()
             if (m_scene) {
                 m_scene->receiveCommand(new UpdateCommand({elm}, oldData, m_scene));
             }
+        }
+        if (needsMacro) {
+            m_scene->undoStack()->endMacro();
         }
         return;
     }

--- a/App/UI/ElementEditor.cpp
+++ b/App/UI/ElementEditor.cpp
@@ -679,6 +679,18 @@ void ElementEditor::blobNameEditingFinished()
         return;
     }
 
+    // Reject a rename that collides with a different, already-registered blob: ICRegistry::
+    // renameBlob() would silently overwrite that other blob's bytes with this IC's circuit,
+    // permanently destroying it with no undo path back. Refuse before pushing anything, mirroring
+    // the duplicate-wireless-Tx-channel guard above.
+    if (m_scene->icRegistry()->hasBlob(newBlobName)) {
+        QMessageBox::warning(this,
+            tr("Duplicate IC Name"),
+            tr("An embedded IC named \"%1\" already exists.\n"
+               "Choose a different name.").arg(newBlobName));
+        return;
+    }
+
     // Renaming is its own independent, immediately-applied action — pushed standalone rather
     // than folded into apply()'s UpdateCommand, so undo/redo never has to reconcile a generic
     // property snapshot against the IC registry's shared blob-name state.

--- a/App/UI/ElementEditor.h
+++ b/App/UI/ElementEditor.h
@@ -125,6 +125,8 @@ private:
     void setTruthTableProposition(const int row, const int column);
     /// Slot: the user changed the keyboard trigger via the key-sequence editor.
     void triggerChanged(const QString &cmd);
+    /// Slot: the user finished editing the embedded IC's blob name field.
+    void blobNameEditingFinished();
 
     // --- Members ---
 

--- a/App/UI/ICDropZone.cpp
+++ b/App/UI/ICDropZone.cpp
@@ -9,21 +9,14 @@
 #include <QDragMoveEvent>
 #include <QMimeData>
 
+#include "App/Core/DragDropPayload.h"
 #include "App/Core/Enums.h"
 #include "App/Core/MimeTypes.h"
 #include "App/IO/Serialization.h"
 
 namespace {
 
-struct DragPayload {
-    QPoint offset;
-    ElementType type;
-    QString icFileName;
-    bool isEmbedded = false;
-    QString blobName;
-};
-
-std::optional<DragPayload> extractDragPayload(const QMimeData *mimeData)
+std::optional<DragDropPayload> extractDragPayload(const QMimeData *mimeData)
 {
     QByteArray itemData;
     if (mimeData->hasFormat(MimeType::DragDrop)) {
@@ -37,11 +30,7 @@ std::optional<DragPayload> extractDragPayload(const QMimeData *mimeData)
     QDataStream stream(&itemData, QIODevice::ReadOnly);
     Serialization::readPandaHeader(stream);
 
-    DragPayload payload;
-    stream >> payload.offset >> payload.type >> payload.icFileName;
-    if (!stream.atEnd()) { stream >> payload.isEmbedded; }
-    if (!stream.atEnd()) { stream >> payload.blobName; }
-    return payload;
+    return readDragDropPayload(stream);
 }
 
 } // namespace

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -973,7 +973,7 @@ void MainWindow::on_actionWaveform_triggered()
 
         sentryBreadcrumb("ui", QStringLiteral("Waveform dialog opened"));
         qCDebug(zero) << "BD fileName: " << currentTab()->dolphinFileName();
-        auto *bwd = new BewavedDolphin(currentTab()->scene(), true, this);
+        auto *bwd = new BewavedDolphin(currentTab()->scene(), true, this, this);
         bwd->createWaveform(currentTab()->dolphinFileName());
         m_bwd = bwd;
         connect(bwd, &QObject::destroyed, this, [this] {

--- a/App/UI/TrashButton.cpp
+++ b/App/UI/TrashButton.cpp
@@ -8,6 +8,7 @@
 #include <QMimeData>
 #include <QVersionNumber>
 
+#include "App/Core/DragDropPayload.h"
 #include "App/Core/Enums.h"
 #include "App/Core/MimeTypes.h"
 #include "App/IO/Serialization.h"
@@ -46,14 +47,7 @@ void TrashButton::dropEvent(QDropEvent *event)
         QDataStream stream(&itemData, QIODevice::ReadOnly);
         Serialization::readPandaHeader(stream);
 
-        QPoint offset;      stream >> offset;
-        ElementType type;   stream >> type;
-        QString icFileName; stream >> icFileName;
-
-        bool isEmbedded = false;
-        QString blobName;
-        if (!stream.atEnd()) { stream >> isEmbedded; }
-        if (!stream.atEnd()) { stream >> blobName; }
+        const auto payload = readDragDropPayload(stream);
 
         QMessageBox msgBox;
         msgBox.setParent(this);
@@ -61,8 +55,8 @@ void TrashButton::dropEvent(QDropEvent *event)
         msgBox.setWindowModality(Qt::WindowModal);
         msgBox.setDefaultButton(QMessageBox::No);
 
-        if (isEmbedded) {
-            msgBox.setText(tr("Remove all \"%1\" instances from the circuit?").arg(blobName));
+        if (payload.isEmbedded) {
+            msgBox.setText(tr("Remove all \"%1\" instances from the circuit?").arg(payload.blobName));
         } else {
             msgBox.setText(tr("File will be deleted. Are you sure?"));
         }
@@ -72,10 +66,10 @@ void TrashButton::dropEvent(QDropEvent *event)
             return;
         }
 
-        if (isEmbedded) {
-            emit removeEmbeddedIC(blobName);
+        if (payload.isEmbedded) {
+            emit removeEmbeddedIC(payload.blobName);
         } else {
-            emit removeICFile(icFileName);
+            emit removeICFile(payload.icFileName);
         }
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,6 +895,7 @@ add_test(NAME TestWorkspaceUnit COMMAND test_wiredpanda TestWorkspaceUnit WORKIN
 add_test(NAME TestApplication COMMAND test_wiredpanda TestApplication WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestArduinoCodeGenUnit COMMAND test_wiredpanda TestArduinoCodeGenUnit WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestCircuitExporter COMMAND test_wiredpanda TestCircuitExporter WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestCodeGenUtils COMMAND test_wiredpanda TestCodeGenUtils WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestConnection COMMAND test_wiredpanda TestConnection WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestConnectionManager COMMAND test_wiredpanda TestConnectionManager WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestCoreSettings COMMAND test_wiredpanda TestCoreSettings WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,6 +904,7 @@ add_test(NAME TestDisplay COMMAND test_wiredpanda TestDisplay WORKING_DIRECTORY 
 add_test(NAME TestDisplay7 COMMAND test_wiredpanda TestDisplay7 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestDolphinClipboard COMMAND test_wiredpanda TestDolphinClipboard WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestDolphinSerializer COMMAND test_wiredpanda TestDolphinSerializer WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestDragDropPayload COMMAND test_wiredpanda TestDragDropPayload WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestElementContextMenu COMMAND test_wiredpanda TestElementContextMenu WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestElementEditor COMMAND test_wiredpanda TestElementEditor WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestElementPalette COMMAND test_wiredpanda TestElementPalette WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ add_test(NAME TestEnums COMMAND test_wiredpanda TestEnums WORKING_DIRECTORY ${CM
 add_test(NAME TestFeatures COMMAND test_wiredpanda TestFeatures WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestFeedback COMMAND test_wiredpanda TestFeedback WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestFileDialogProvider COMMAND test_wiredpanda TestFileDialogProvider WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestFileHandlerSecurity COMMAND test_wiredpanda TestFileHandlerSecurity WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestFiles COMMAND test_wiredpanda TestFiles WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestGeometry COMMAND test_wiredpanda TestGeometry WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestGraphicelementAdvanced COMMAND test_wiredpanda TestGraphicelementAdvanced WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,7 @@ add_test(NAME TestGeometry COMMAND test_wiredpanda TestGeometry WORKING_DIRECTOR
 add_test(NAME TestGraphicelementAdvanced COMMAND test_wiredpanda TestGraphicelementAdvanced WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestIC COMMAND test_wiredpanda TestIC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestICFixtureLayout COMMAND test_wiredpanda TestICFixtureLayout WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestICHandlerSecurity COMMAND test_wiredpanda TestICHandlerSecurity WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestICInline COMMAND test_wiredpanda TestICInline WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestIcons COMMAND test_wiredpanda TestIcons WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestInputElements COMMAND test_wiredpanda TestInputElements WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,6 +902,7 @@ add_test(NAME TestCoreSettings COMMAND test_wiredpanda TestCoreSettings WORKING_
 add_test(NAME TestDemux COMMAND test_wiredpanda TestDemux WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestDisplay COMMAND test_wiredpanda TestDisplay WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestDisplay7 COMMAND test_wiredpanda TestDisplay7 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestDolphinClipboard COMMAND test_wiredpanda TestDolphinClipboard WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestDolphinSerializer COMMAND test_wiredpanda TestDolphinSerializer WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestElementContextMenu COMMAND test_wiredpanda TestElementContextMenu WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestElementEditor COMMAND test_wiredpanda TestElementEditor WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,6 +783,7 @@ add_test(NAME TestGraphicelementAdvanced COMMAND test_wiredpanda TestGraphicelem
 add_test(NAME TestIC COMMAND test_wiredpanda TestIC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestICFixtureLayout COMMAND test_wiredpanda TestICFixtureLayout WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestICHandlerSecurity COMMAND test_wiredpanda TestICHandlerSecurity WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_test(NAME TestMCPProcessor COMMAND test_wiredpanda TestMCPProcessor WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestICInline COMMAND test_wiredpanda TestICInline WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestIcons COMMAND test_wiredpanda TestIcons WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME TestInputElements COMMAND test_wiredpanda TestInputElements WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -15,6 +15,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App/CodeGen/SystemVerilogCodeGen.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Application.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Common.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/App/Core/DragDropPayload.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Enums.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ExerciseTourResources.cpp
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/InstallRelativePaths.cpp
@@ -156,6 +157,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Common.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Constants.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ContextDirProvider.h
+    ${CMAKE_CURRENT_LIST_DIR}/App/Core/DragDropPayload.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/Enums.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/ExerciseTourResources.h
     ${CMAKE_CURRENT_LIST_DIR}/App/Core/InstallRelativePaths.h
@@ -443,6 +445,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestSettings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestThemeManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestApplication.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestDragDropPayload.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestExerciseTourResources.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestInstallRelativePaths.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestNotifyCatch.cpp
@@ -640,6 +643,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestSettings.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestThemeManager.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestApplication.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestDragDropPayload.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestExerciseTourResources.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestInstallRelativePaths.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Core/TestNotifyCatch.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -485,6 +485,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestFileHandlerSecurity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestMCPProcessor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestGraphicsView.cpp
@@ -684,6 +685,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestFileHandlerSecurity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestMCPProcessor.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestGraphicsView.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -479,6 +479,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestNodeLogic.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestFileHandlerSecurity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.cpp
@@ -674,6 +675,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestNodeLogic.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestFileHandlerSecurity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -479,6 +479,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestNodeLogic.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestGraphicsView.cpp
@@ -673,6 +674,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestElementLogicErrors.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestNodeLogic.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Logic/TestStatusOps.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/MCP/TestICHandlerSecurity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionManager.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestConnectionValidity.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestGraphicsView.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -433,6 +433,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/System/TestBewavedDolphinGui.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/System/TestWaveform.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestArduinoCodeGenUnit.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestCodeGenUtils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestSystemVerilogCodeGenUnit.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Commands/TestCommands.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestCommon.cpp
@@ -628,6 +629,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/System/TestBewavedDolphinGui.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/System/TestWaveform.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestArduinoCodeGenUnit.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestCodeGenUtils.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/CodeGen/TestSystemVerilogCodeGenUnit.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Commands/TestCommands.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Common/TestCommon.h

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -491,6 +491,7 @@ set(TEST_WIREDPANDA_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestSceneState.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestSceneUndoredo.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestWorkspace.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestDolphinClipboard.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestDolphinSerializer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestFileUtils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestRecentFiles.cpp
@@ -688,6 +689,7 @@ set(TEST_WIREDPANDA_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestSceneState.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestSceneUndoredo.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Scene/TestWorkspace.h
+    ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestDolphinClipboard.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestDolphinSerializer.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestFileUtils.h
     ${CMAKE_CURRENT_LIST_DIR}/Tests/Unit/Serialization/TestRecentFiles.h

--- a/MCP/Server/Core/MCPProcessor.cpp
+++ b/MCP/Server/Core/MCPProcessor.cpp
@@ -49,12 +49,40 @@ void StdinReader::requestStop()
 
 void StdinReader::run()
 {
-    // Blocks in getline; MCPProcessor::stopProcessing closes the stdin handle
-    // to unblock it, so the loop exits on EOF without QThread::terminate().
+    // Blocks reading one character at a time; MCPProcessor::stopProcessing closes the
+    // stdin handle to unblock it, so the loop exits on EOF without QThread::terminate().
+    // A manual char loop (rather than std::getline, which has no length bound) lets a
+    // line past MCPProcessor::kMaxStdinLineBytes be dropped instead of growing std::string without limit.
     std::string line;
-    while (!m_stopRequested && std::getline(std::cin, line)) {
-        if (!line.empty()) {
+    while (!m_stopRequested) {
+        line.clear();
+        bool overflowed = false;
+        int ch = std::char_traits<char>::eof();
+
+        while (!m_stopRequested) {
+            ch = std::cin.get();
+            if (ch == std::char_traits<char>::eof() || ch == '\n') {
+                break;
+            }
+            if (static_cast<qint64>(line.size()) < MCPProcessor::kMaxStdinLineBytes) {
+                line.push_back(static_cast<char>(ch));
+            } else {
+                overflowed = true; // keep draining this line without growing it further
+            }
+        }
+
+        if (std::cin.eof() && line.empty() && !overflowed) {
+            break; // clean EOF, nothing pending
+        }
+
+        if (overflowed) {
+            qWarning() << "MCPProcessor: stdin line exceeds" << MCPProcessor::kMaxStdinLineBytes << "bytes with no newline — dropping it";
+        } else if (!line.empty()) {
             emit dataReceived(QString::fromStdString(line));
+        }
+
+        if (ch == std::char_traits<char>::eof()) {
+            break;
         }
     }
 }
@@ -169,12 +197,10 @@ void MCPProcessor::onStdinReadable()
         const ssize_t bytesRead = ::read(::fileno(stdin), buffer, sizeof(buffer));
 
         if (bytesRead > 0) {
-            m_stdinBuffer.append(buffer, static_cast<qsizetype>(bytesRead));
-            qsizetype newline;
-            while ((newline = m_stdinBuffer.indexOf('\n')) != -1) {
-                const QByteArray lineBytes = m_stdinBuffer.left(newline);
-                m_stdinBuffer.remove(0, newline + 1);
-                processIncomingData(QString::fromUtf8(lineBytes));
+            const QByteArray chunk(buffer, static_cast<qsizetype>(bytesRead));
+            const QStringList lines = extractStdinLines(m_stdinBuffer, chunk);
+            for (const QString &line : lines) {
+                processIncomingData(line);
             }
             continue; // drain whatever else is buffered before yielding
         }
@@ -204,6 +230,27 @@ void MCPProcessor::onStdinReadable()
     }
 }
 #endif
+
+QStringList MCPProcessor::extractStdinLines(QByteArray &buffer, const QByteArray &data)
+{
+    buffer.append(data);
+
+    QStringList lines;
+    qsizetype newline;
+    while ((newline = buffer.indexOf('\n')) != -1) {
+        lines.append(QString::fromUtf8(buffer.left(newline)));
+        buffer.remove(0, newline + 1);
+    }
+
+    // A client that never sends '\n' would otherwise grow the buffer without bound —
+    // stdin is not a trusted channel in --mcp/--mcp-gui mode.
+    if (buffer.size() > kMaxStdinLineBytes) {
+        qWarning() << "MCPProcessor: stdin line exceeds" << kMaxStdinLineBytes << "bytes with no newline — dropping it";
+        buffer.clear();
+    }
+
+    return lines;
+}
 
 void MCPProcessor::processIncomingData(const QString &line)
 {

--- a/MCP/Server/Core/MCPProcessor.h
+++ b/MCP/Server/Core/MCPProcessor.h
@@ -7,10 +7,12 @@
 #include <memory>
 
 #include <QBuffer>
+#include <QByteArray>
 #include <QHash>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QObject>
+#include <QStringList>
 #include <QTextStream>
 #include <QThread>
 #include <QTimer>
@@ -77,6 +79,19 @@ public:
 
     void startProcessing();
     void stopProcessing();
+
+    /// Maximum bytes buffered while waiting for a newline-terminated JSON-RPC command — see
+    /// extractStdinLines(). Public so tests can reference the real limit instead of a
+    /// duplicated magic number.
+    static constexpr qint64 kMaxStdinLineBytes = 16 * 1024 * 1024; // 16 MB
+
+    /// Appends \a data to \a buffer and returns every complete ('\n'-terminated) line found,
+    /// removing them from \a buffer. If more than kMaxStdinLineBytes accumulates with no
+    /// newline, clears \a buffer instead of growing it without bound — stdin is not a trusted
+    /// channel in --mcp/--mcp-gui mode (any local process that can pipe into wiRedPanda's
+    /// stdin can write it). A pure static method, independent of any live file descriptor, so
+    /// the buffering/cap logic is directly unit-testable.
+    static QStringList extractStdinLines(QByteArray &buffer, const QByteArray &data);
 
 private slots:
     void processIncomingData(const QString &line);

--- a/MCP/Server/Handlers/FileHandler.cpp
+++ b/MCP/Server/Handlers/FileHandler.cpp
@@ -3,19 +3,31 @@
 
 #include "MCP/Server/Handlers/FileHandler.h"
 
+#include <algorithm>
+
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QImage>
 #include <QPageSize>
 #include <QPainter>
 #include <QPdfWriter>
-#include <QPixmap>
 #include <QSvgGenerator>
 #include <QTabWidget>
 
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
+#include "App/UI/CircuitExporter.h"
 #include "App/UI/MainWindow.h"
+
+namespace {
+
+/// Maximum padding (in scene pixels) export_image will apply around the circuit before
+/// rendering. The schema only enforces a minimum of 0 (MCP/schema-mcp.json); an MCP client
+/// requesting an absurd padding could otherwise blow up the render regardless of scene size.
+constexpr int kMaxExportPadding = 2000;
+
+} // namespace
 
 FileHandler::FileHandler(MainWindow *mainWindow, const MCPValidator *validator)
     : BaseHandler(mainWindow, validator)
@@ -183,7 +195,7 @@ QJsonObject FileHandler::handleExportImage(const QJsonObject &params, const QJso
 
     QString filename = params.value("filename").toString();
     QString format = params.value("format").toString().toLower();
-    int padding = params.value("padding").toInt(20);
+    const int padding = std::clamp(params.value("padding").toInt(20), 0, kMaxExportPadding);
 
     Scene *scene = currentScene();
     if (!scene) {
@@ -240,17 +252,22 @@ QJsonObject FileHandler::handleExportImage(const QJsonObject &params, const QJso
             scene->render(&painter, QRectF(), sceneRect);
             painter.end();
         } else {  // png
-            QPixmap pixmap(sceneRect.size().toSize());
-            pixmap.fill(Qt::white);
+            // Delegates to CircuitExporter's already-hardened renderer instead of sizing an
+            // image directly from sceneRect: that bounding/scale-to-fit logic (capped at
+            // CircuitExporter::kMaxImageDimension) exists in exactly one place so it can't drift
+            // out of sync between the GUI's "Export to Image" action and this MCP command.
+            const QImage image = CircuitExporter::renderScaledImage(scene, sceneRect);
 
-            QPainter painter(&pixmap);
-            painter.setRenderHint(QPainter::Antialiasing);
-            scene->render(&painter, QRectF(), sceneRect);
-            painter.end();
-
-            if (!pixmap.save(filename, "PNG")) {
+            if (!image.save(filename, "PNG")) {
                 return createErrorResponse("Failed to save PNG file", requestId, JsonRpcError::FileError);
             }
+
+            QJsonObject result;
+            result["exported_file"] = filename;
+            result["format"] = format;
+            result["size"] = QString("%1x%2").arg(image.width()).arg(image.height());
+
+            return createSuccessResponse(result, requestId);
         }
 
         QJsonObject result;

--- a/MCP/Server/Handlers/ICHandler.cpp
+++ b/MCP/Server/Handlers/ICHandler.cpp
@@ -17,6 +17,20 @@
 #include "App/Scene/Workspace.h"
 #include "App/UI/MainWindow.h"
 
+namespace {
+
+/// Returns \c true if \a name is a single path component with no directory traversal —
+/// safe to use as-is inside a filesystem path built from MCP-client-supplied input, which
+/// (unlike the GUI's getSaveFileName()/getOpenFileName() dialogs) has no human confirming
+/// the resulting location before a file gets read or written.
+bool isBareFileName(const QString &name)
+{
+    return name != "." && name != ".." && QFileInfo(name).fileName() == name
+        && !name.contains('/') && !name.contains('\\');
+}
+
+} // namespace
+
 ICHandler::ICHandler(MainWindow *mainWindow, const MCPValidator *validator)
     : BaseHandler(mainWindow, validator)
 {
@@ -58,8 +72,7 @@ QJsonObject ICHandler::handleCreateIC(const QJsonObject &params, const QJsonValu
         return createErrorResponse("IC name cannot be empty", requestId, JsonRpcError::InvalidParams);
     }
 
-    if (name == "." || name == ".." || QFileInfo(name).fileName() != name
-        || name.contains('/') || name.contains('\\')) {
+    if (!isBareFileName(name)) {
         return createErrorResponse("IC name must not contain path separators or directory components",
                                    requestId, JsonRpcError::InvalidParams);
     }
@@ -127,8 +140,7 @@ QJsonObject ICHandler::handleInstantiateIC(const QJsonObject &params, const QJso
             return createErrorResponse("IC path must not contain '..' components",
                                        requestId, JsonRpcError::InvalidParams);
         }
-    } else if (icName == "." || icName == ".." || QFileInfo(icName).fileName() != icName
-        || icName.contains('/') || icName.contains('\\')) {
+    } else if (!isBareFileName(icName)) {
         return createErrorResponse("IC name must not contain path separators or directory components",
                                    requestId, JsonRpcError::InvalidParams);
     }
@@ -166,6 +178,11 @@ QJsonObject ICHandler::handleInstantiateIC(const QJsonObject &params, const QJso
             QString blobName = params.value("blob_name").toString();
             if (blobName.isEmpty()) {
                 blobName = QFileInfo(fullPath).baseName();
+            } else if (!isBareFileName(blobName)) {
+                // Same reasoning as handleEmbedIC: this blob_name is stored verbatim as a
+                // registry key and can later be used as a file-name fallback by extract_ic.
+                return createErrorResponse("blob_name must not contain path separators or directory components",
+                                           requestId, JsonRpcError::InvalidParams);
             }
 
             auto *reg = scene->icRegistry();
@@ -177,8 +194,11 @@ QJsonObject ICHandler::handleInstantiateIC(const QJsonObject &params, const QJso
 
             icPtr = reg->createEmbeddedIC(blobName, fileBytes, icDirectory);
         } else {
+            // loadFile() can throw (nesting depth, circular reference, bad file); release()
+            // only after it succeeds so the unique_ptr cleans up on the throwing path instead
+            // of leaking, mirroring SceneDropHandler.cpp's identical loadFromDrop() sequencing.
+            ic->loadFile(fullPath, icDirectory);
             icPtr = ic.release();
-            icPtr->loadFile(fullPath, icDirectory);
             scene->receiveCommand(new AddItemsCommand({icPtr}, scene));
         }
 
@@ -322,6 +342,12 @@ QJsonObject ICHandler::handleEmbedIC(const QJsonObject &params, const QJsonValue
         QString blobName = params.value("blob_name").toString();
         if (blobName.isEmpty()) {
             blobName = QFileInfo(resolvedPath).baseName();
+        } else if (!isBareFileName(blobName)) {
+            // blob_name is later used verbatim as a file-name fallback by extract_ic
+            // (ICHandler::handleExtractIC) — reject path traversal here too, not just there,
+            // so a malicious name can't ride through the registry as a stored blob key.
+            return createErrorResponse("blob_name must not contain path separators or directory components",
+                                       requestId, JsonRpcError::InvalidParams);
         }
 
         auto *reg = scene->icRegistry();
@@ -381,6 +407,21 @@ QJsonObject ICHandler::handleExtractIC(const QJsonObject &params, const QJsonVal
         if (!fileName.endsWith(".panda")) {
             fileName.append(".panda");
         }
+
+        // file_name is an MCP-client-supplied identifier, not a GUI-picked path (unlike
+        // ICController::extractSelectedIC, which always routes through an interactive
+        // getSaveFileName dialog a human must approve) — an absolute file_name or one with
+        // ".." components would otherwise let the write above land anywhere on disk. Validate
+        // the final resolved path rather than the individual inputs that built it, so this
+        // can't be bypassed by some other future parameter combination; subdirectories of
+        // contextDir remain allowed, only escapes are rejected.
+        const QString cleanContextDir = QDir::cleanPath(QDir(contextDir).absolutePath());
+        const QString cleanFileName = QDir::cleanPath(fileName);
+        if (cleanFileName != cleanContextDir && !cleanFileName.startsWith(cleanContextDir + '/')) {
+            return createErrorResponse("file_name must resolve to a location inside the project directory",
+                                       requestId, JsonRpcError::InvalidParams);
+        }
+        fileName = cleanFileName;
 
         if (QFile::exists(fileName) && !params.value("overwrite").toBool()) {
             return createErrorResponse(QString("File '%1' already exists. Set overwrite=true to replace it.").arg(fileName),

--- a/MCP/Server/Handlers/SimulationHandler.cpp
+++ b/MCP/Server/Handlers/SimulationHandler.cpp
@@ -100,7 +100,7 @@ QJsonObject SimulationHandler::handleCreateWaveform(const QJsonObject &params, c
             m_persistentDolphin->deleteLater();
             m_persistentDolphin = nullptr;
         }
-        m_persistentDolphin = new BewavedDolphin(scene, false, m_mainWindow);
+        m_persistentDolphin = new BewavedDolphin(scene, false, m_mainWindow, m_mainWindow);
         BewavedDolphin *bewavedDolphin = m_persistentDolphin;
 
         bewavedDolphin->prepare("");

--- a/MCP/schema-mcp.json
+++ b/MCP/schema-mcp.json
@@ -1140,6 +1140,7 @@
                 "padding": {
                   "type": "integer",
                   "minimum": 0,
+                  "maximum": 2000,
                   "default": 20
                 }
               },

--- a/Tests/Fuzz/FuzzCopyPanda.cpp
+++ b/Tests/Fuzz/FuzzCopyPanda.cpp
@@ -14,8 +14,11 @@
  *     copyPandaFile is distinct.
  *
  *   - copyPandaFile(): recursively copies a .panda file and its file-backed IC
- *     dependencies.  The recursion guard (QSet<QString>) and the "fileBackedICs"
- *     metadata key parsing are completely dark without an explicit caller.
+ *     dependencies (also copying the file itself and the peek-based
+ *     plausibility pre-check, both formerly duplicated in the now-removed
+ *     FileUtils::copyPandaDeps()).  The recursion guard (QSet<QString>) and
+ *     the "fileBackedICs" metadata key parsing are completely dark without an
+ *     explicit caller.
  *
  * Strategy:
  *   1. Write fuzz bytes to a QTemporaryFile — this is the "source" panda.
@@ -33,7 +36,6 @@
 #include <QByteArray>
 #include <QCoreApplication>
 #include <QDataStream>
-#include <QDir>
 #include <QEvent>
 #include <QFileInfo>
 #include <QIODevice>
@@ -48,7 +50,6 @@
 
 #include "App/Core/Application.h"
 #include "App/Core/Common.h"
-#include "App/IO/FileUtils.h"
 #include "App/IO/Serialization.h"
 
 namespace {
@@ -161,15 +162,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             Serialization::copyPandaFile(outerSrcInfo, outerDestInfo);
         } catch (...) {}
     }
-
-    // --- Phase 3: FileUtils::copyPandaDeps --- exercises a different code path
-    // in the same "copy panda + IC dependencies" flow (inline header-only implementation
-    // with a visited-set cycle guard, distinct from Serialization::copyPandaFile).
-    try {
-        FileUtils::copyPandaDeps(srcFile.fileName(),
-                                 srcInfo.absolutePath(),
-                                 srcInfo.absolutePath()); // src == dest: no-op copy
-    } catch (...) {}
 
     return 0;
 }

--- a/Tests/Integration/TestArduino.cpp
+++ b/Tests/Integration/TestArduino.cpp
@@ -1787,6 +1787,49 @@ void TestArduino::testEmbeddedICGeneration()
              "Generated code must contain computeLogic()");
 }
 
+void TestArduino::testEmbeddedICLabelWithNewlineDoesNotInjectCode()
+{
+    // Regression: an IC's label was written raw into a "// IC: <label>" comment. A label
+    // containing an embedded newline (settable via a crafted .panda file's label field, or
+    // MCP's create_element/set_element_properties "label" param — neither restricts content
+    // beyond length) could break out of the comment and inject a real line of Arduino code.
+    std::unique_ptr<WorkSpace> ws = TestUtils::createWorkspace();
+
+    const QString fixtureDir = QString(QUOTE(CURRENTDIR)) + "/../Tests/Integration/IC/Components/";
+    ws->scene()->setContextDir(fixtureDir);
+    auto *reg = ws->scene()->icRegistry();
+
+    auto *ic = new IC();
+    auto *sw1 = new InputSwitch();
+    auto *sw2 = new InputSwitch();
+    auto *led = new Led();
+
+    CircuitBuilder builder(ws->scene());
+    builder.add(sw1, sw2, ic, led);
+
+    const QByteArray pandaBytes = ICTestHelpers::readFile(fixtureDir + "level2_half_adder.panda");
+    QVERIFY2(!pandaBytes.isEmpty(), "Fixture file level2_half_adder.panda must exist");
+    ICTestHelpers::embedIC(ic, pandaBytes, "embedded_adder", fixtureDir, reg);
+
+    ic->setLabel("Evil\nvoid injected() { /* pwned */ }");
+
+    builder.connect(sw1, 0, ic, 0);
+    builder.connect(sw2, 0, ic, 1);
+    builder.connect(ic, 0, led, 0);
+    builder.initSimulation();
+
+    QVector<GraphicElement *> allElements;
+    for (auto *item : ws->scene()->items()) {
+        if (auto *elm = qgraphicsitem_cast<GraphicElement *>(item))
+            allElements.append(elm);
+    }
+
+    auto code = generateFromElements(allElements);
+    QVERIFY2(code.success, "Embedded IC Arduino generation should succeed");
+    QVERIFY2(!code.content.contains("\nvoid injected()"),
+             "Label newline must not inject a bare line of code into the generated sketch");
+}
+
 void TestArduino::testMuxDemuxIntegration()
 {
     // Test Mux element generates correct if/else select logic

--- a/Tests/Integration/TestArduino.h
+++ b/Tests/Integration/TestArduino.h
@@ -143,6 +143,7 @@ private slots:
     void testWirelessNodeGeneration();
     void testWirelessOrphanedRxCodegen();
     void testEmbeddedICGeneration();
+    void testEmbeddedICLabelWithNewlineDoesNotInjectCode();
     void testMuxDemuxIntegration();
 
     void testMultipleClocksInCircuit();

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -4972,6 +4972,103 @@ void TestICInline::testUpdateBlobCommandUndoRestoresOldBlob()
     QCOMPARE(reg->blob("undo_blob"), blobB);
 }
 
+void TestICInline::testRenameBlobCommandUndoRedo()
+{
+    // RenameBlobCommand undo reverses the rename, redo re-applies it — mirroring
+    // testRegisterBlobCommandUndoRedo()'s shape for the sibling command.
+    QByteArray blob = readFile(m_fixtureDir + "/simple_and.panda");
+
+    Scene scene;
+    scene.setContextDir(m_fixtureDir);
+    auto *reg = scene.icRegistry();
+
+    auto *ic = new IC();
+    embedIC(ic, blob, "rename_cmd_old", m_fixtureDir, reg);
+    scene.addItem(ic);
+
+    scene.undoStack()->push(new RenameBlobCommand("rename_cmd_old", "rename_cmd_new", &scene));
+    QVERIFY(!reg->hasBlob("rename_cmd_old"));
+    QVERIFY(reg->hasBlob("rename_cmd_new"));
+    QCOMPARE(ic->blobName(), QString("rename_cmd_new"));
+
+    scene.undoStack()->undo();
+    QVERIFY(reg->hasBlob("rename_cmd_old"));
+    QVERIFY(!reg->hasBlob("rename_cmd_new"));
+    QCOMPARE(ic->blobName(), QString("rename_cmd_old"));
+
+    scene.undoStack()->redo();
+    QVERIFY(!reg->hasBlob("rename_cmd_old"));
+    QVERIFY(reg->hasBlob("rename_cmd_new"));
+    QCOMPARE(ic->blobName(), QString("rename_cmd_new"));
+}
+
+void TestICInline::testRenameBlobCommandThenUnrelatedUpdateBothUndoIndependently()
+{
+    // Regression: before the fix, renaming an embedded IC's blob was applied directly
+    // inside ElementEditor::apply(), untracked, sharing the same UpdateCommand transaction
+    // as whatever unrelated property also changed. Undoing that UpdateCommand tried to
+    // resolve the pre-rename blob name against a registry that only had the new name
+    // anymore, throwing and corrupting the IC (App/Element/IC.cpp's no-match fallback set
+    // m_file to the bogus name before ICLoader::loadFile() threw "not found").
+    //
+    // With the fix, a rename is its own independent RenameBlobCommand, so a plain property
+    // UpdateCommand never touches m_blobName, and each undo reverses exactly one action.
+    QByteArray blob = readFile(m_fixtureDir + "/simple_and.panda");
+
+    WorkSpace ws;
+    ws.scene()->setContextDir(m_fixtureDir);
+    auto *reg = ws.scene()->icRegistry();
+
+    auto *ic = new IC();
+    embedIC(ic, blob, "regress_old", m_fixtureDir, reg);
+    ic->setPos(100, 100);
+    ws.scene()->addItem(ic);
+
+    // Step 1: rename, exactly as the lineEditBlobName editingFinished handler does.
+    ws.scene()->undoStack()->push(new RenameBlobCommand("regress_old", "regress_new", ws.scene()));
+    QCOMPARE(ic->blobName(), QString("regress_new"));
+
+    // Step 2: an unrelated property edit (label), exactly as apply() pushes.
+    const QList<GraphicElement *> targets{ic};
+    const QByteArray oldData = ICRegistry::captureSnapshot(targets);
+    ic->setLabel("renamed label");
+
+    bool threw = false;
+    try {
+        ws.scene()->undoStack()->push(new UpdateCommand(targets, oldData, ws.scene()));
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+    QVERIFY2(!threw, "pushing the property UpdateCommand must not throw");
+    QCOMPARE(ic->label(), QString("renamed label"));
+    QCOMPARE(ic->blobName(), QString("regress_new"));
+
+    // Undo #1: reverts the label only. Must not throw, and blobName/embedded state must
+    // stay untouched — this is exactly the step that used to corrupt the IC.
+    threw = false;
+    try {
+        ws.scene()->undoStack()->undo();
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+    QVERIFY2(!threw, "undoing the unrelated property edit must not throw");
+    QCOMPARE(ic->blobName(), QString("regress_new"));
+    QVERIFY(ic->isEmbedded());
+    QVERIFY(ic->file().isEmpty());
+
+    // Undo #2: reverts the rename, independently.
+    threw = false;
+    try {
+        ws.scene()->undoStack()->undo();
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+    QVERIFY2(!threw, "undoing the rename must not throw");
+    QCOMPARE(ic->blobName(), QString("regress_old"));
+    QVERIFY(reg->hasBlob("regress_old"));
+    QVERIFY(!reg->hasBlob("regress_new"));
+}
+
 // ============================================================================
 // Edge cases: isEmbedded, port names, RegisterBlobCommand, IC::load
 // ============================================================================

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -366,6 +366,39 @@ void TestICInline::testChildBlobPropagation()
     QCOMPARE(spy.size(), 1);
 }
 
+void TestICInline::testInlineTabSaveThrowsWhenFileBackedIcMissingOnDisk()
+{
+    // chain_b.panda contains chain_c as a file-backed (non-embedded) nested IC (see
+    // testFlattenBlobMissingFile). Load chain_b's content as an inline-IC editing tab, then
+    // delete chain_c.panda from disk before saving: WorkSpace::save()'s dependency-embedding
+    // loop must throw rather than silently mark chain_c "embedded" with nothing registered in
+    // the IC registry (which would otherwise leave the saved blob referencing a blob name that
+    // was never registered — unloadable on a later reload).
+    QByteArray blob = readFile(m_fixtureDir + "/chain_b.panda");
+    QVERIFY(!blob.isEmpty());
+
+    WorkSpace parent;
+    SimulationBlocker parentBlocker(parent.simulation());
+    parent.scene()->setContextDir(m_fixtureDir);
+    parent.scene()->icRegistry()->setBlob("chain_b_test", blob);
+
+    auto *ic = new IC();
+    ic->setBlobName("chain_b_test");
+    ic->loadFromBlob(blob, m_fixtureDir);
+    parent.scene()->addItem(ic);
+
+    int icId = ic->id();
+
+    WorkSpace child;
+    SimulationBlocker childBlocker(child.simulation());
+    child.loadFromBlob(blob, &parent, icId, m_fixtureDir);
+
+    QFile::remove(m_fixtureDir + "/chain_c.panda");
+    auto restoreFixture = qScopeGuard([this] { copyFixture("chain_c.panda"); });
+
+    QVERIFY_THROWS(std::exception, child.save(QString()));
+}
+
 void TestICInline::testUndoRedoEmbedExtract()
 {
     const QString filePath = m_fixtureDir + "/simple_and.panda";

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -5,12 +5,15 @@
 
 #include <memory>
 
+#include <QApplication>
 #include <QDataStream>
 #include <QDir>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QFile>
 #include <QGraphicsSceneDragDropEvent>
+#include <QLineEdit>
+#include <QMessageBox>
 #include <QMimeData>
 #include <QRegularExpression>
 #include <QSaveFile>
@@ -18,6 +21,7 @@
 #include <QSignalSpy>
 #include <QTemporaryFile>
 #include <QTest>
+#include <QTimer>
 
 #include "App/CodeGen/SystemVerilogCodeGen.h"
 #include "App/Core/Common.h"
@@ -34,6 +38,7 @@
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "App/Simulation/SimulationBlocker.h"
+#include "App/UI/ElementEditor.h"
 #include "App/UI/ElementPalette.h"
 #include "App/UI/ICDropZone.h"
 #include "App/UI/MainWindowUI.h"
@@ -46,6 +51,24 @@
 
 using ICTestHelpers::readFile;
 using ICTestHelpers::embedIC;
+
+// Named (not plain "static") to avoid colliding with same-named helpers from other test
+// files under the project's Unity build, which merges multiple .cpp files per translation unit.
+namespace TestICInlineHelpers {
+
+/// Schedules auto-close of the next visible QMessageBox that appears.
+void autoCloseNextMessageBox()
+{
+    QTimer::singleShot(0, [] {
+        if (auto *w = QApplication::activeModalWidget()) {
+            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
+                msgBox->accept();
+            }
+        }
+    });
+}
+
+} // namespace TestICInlineHelpers
 
 // ---------------------------------------------------------------------------
 // Test Harness
@@ -1137,9 +1160,10 @@ void TestICInline::testBlobNameRenamePropagation()
 
 void TestICInline::testBlobNameCollisionDuringRename()
 {
-    // Verify collision detection logic: renaming to an existing blobName
-    // should be detected.
-
+    // Regression: renaming an embedded IC's blob name to a name that already names a
+    // different blob must be rejected by the ElementEditor UI path (the field the user
+    // actually types into) — not silently applied, which would destroy the colliding IC's
+    // data. testRenameBlobCollisionRejected covers the ICRegistry-level guard this backs up.
     WorkSpace ws;
     ws.scene()->setContextDir(m_fixtureDir);
     auto *reg = ws.scene()->icRegistry();
@@ -1154,29 +1178,38 @@ void TestICInline::testBlobNameCollisionDuringRename()
     ic2->setPos(200, 200);
     ws.scene()->addItem(ic2);
 
-    // Renaming "type_alpha" → "type_beta" should detect collision
-    bool collisionDetected = false;
-    for (auto *elm : ws.scene()->elements()) {
-        if (elm->isEmbedded() && elm->blobName() == "type_beta") {
-            collisionDetected = true;
-            break;
-        }
-    }
-    QVERIFY2(collisionDetected, "Collision should be detected when renaming to existing blobName");
+    ElementEditor editor(&ws);
+    editor.setScene(ws.scene());
 
-    // Renaming to a fresh name should NOT detect collision
-    bool noCollision = true;
-    for (auto *elm : ws.scene()->elements()) {
-        if (elm->isEmbedded() && elm->blobName() == "fresh_name") {
-            noCollision = false;
-            break;
-        }
-    }
-    QVERIFY2(noCollision, "No collision should be detected for unused name");
+    ws.scene()->clearSelection();
+    ic1->setSelected(true);
 
-    // Verify both ICs are unchanged
+    auto *lineEdit = editor.findChild<QLineEdit *>("lineEditBlobName");
+    QVERIFY(lineEdit);
+    QCOMPARE(lineEdit->text(), QString("type_alpha"));
+
+    const int countBefore = ws.scene()->undoStack()->count();
+
+    // Try to rename "type_alpha" to the already-taken "type_beta"
+    lineEdit->setText("type_beta");
+    TestICInlineHelpers::autoCloseNextMessageBox();
+    emit lineEdit->editingFinished();
+
+    // Rejected: no command pushed, both ICs and both blobs unchanged
+    QCOMPARE(ws.scene()->undoStack()->count(), countBefore);
     QCOMPARE(ic1->blobName(), QString("type_alpha"));
     QCOMPARE(ic2->blobName(), QString("type_beta"));
+    QVERIFY(reg->hasBlob("type_alpha"));
+    QVERIFY(reg->hasBlob("type_beta"));
+
+    // Renaming to a fresh, non-colliding name must still succeed
+    lineEdit->setText("fresh_name");
+    emit lineEdit->editingFinished();
+
+    QCOMPARE(ws.scene()->undoStack()->count(), countBefore + 1);
+    QCOMPARE(ic1->blobName(), QString("fresh_name"));
+    QVERIFY(reg->hasBlob("fresh_name"));
+    QVERIFY(!reg->hasBlob("type_alpha"));
 }
 
 void TestICInline::testBlobNameSpecialCharacters()
@@ -4569,10 +4602,12 @@ void TestICInline::testRenameBlobSameNameNoOp()
     QCOMPARE(reg->blob("same"), blob);
 }
 
-void TestICInline::testRenameBlobCollisionOverwrites()
+void TestICInline::testRenameBlobCollisionRejected()
 {
-    // Renaming "A" to "B" when "B" already exists overwrites "B"'s data.
-    // ICs that referenced "B" keep the name "B" but now have "A"'s data.
+    // Regression: ICRegistry::renameBlob() used to overwrite an existing, different blob
+    // unconditionally, permanently destroying it (and silently making every IC instance
+    // that already referenced that name start behaving like the renamed-in circuit) with
+    // no undo path back. Renaming "A" to "B" when "B" already exists must now be a no-op.
     QByteArray blobA = readFile(m_fixtureDir + "/simple_and.panda");
     QByteArray blobB = QByteArray("dummy_data_for_B");
 
@@ -4588,13 +4623,14 @@ void TestICInline::testRenameBlobCollisionOverwrites()
     icA->loadFromBlob(blobA, m_fixtureDir);
     scene.addItem(icA);
 
-    // Rename A → B: "A" disappears, "B" now has A's data
+    // Rename A → B: rejected — both blobs and icA's identity are unchanged
     reg->renameBlob("A", "B");
 
-    QVERIFY(!reg->hasBlob("A"));
+    QVERIFY(reg->hasBlob("A"));
     QVERIFY(reg->hasBlob("B"));
-    QCOMPARE(reg->blob("B"), blobA);
-    QCOMPARE(icA->blobName(), QString("B"));
+    QCOMPARE(reg->blob("A"), blobA);
+    QCOMPARE(reg->blob("B"), blobB);
+    QCOMPARE(icA->blobName(), QString("A"));
 }
 
 void TestICInline::testRenameBlobNonExistentNoOp()
@@ -5143,6 +5179,29 @@ void TestICInline::testRegisterBlobCommandRedoAfterExternalRemove()
     // registerBlob calls makeBlobSelfContained, so the stored data might differ
     // from the raw blob bytes, but the blob must exist
     QVERIFY(!reg->blob("ext_rm").isEmpty());
+}
+
+void TestICInline::testRemoveBlobCommandUndoRedo()
+{
+    // RemoveBlobCommand undo restores the blob's original bytes, redo re-removes it —
+    // mirroring testRegisterBlobCommandUndoRedo()'s shape for the sibling command. Previously
+    // this command was only exercised indirectly, inside WorkSpace::removeEmbeddedIC()'s macro.
+    QByteArray blob = readFile(m_fixtureDir + "/simple_and.panda");
+
+    Scene scene;
+    scene.setContextDir(m_fixtureDir);
+    auto *reg = scene.icRegistry();
+    reg->setBlob("remove_cmd_test", blob);
+
+    scene.undoStack()->push(new RemoveBlobCommand("remove_cmd_test", &scene));
+    QVERIFY(!reg->hasBlob("remove_cmd_test"));
+
+    scene.undoStack()->undo();
+    QVERIFY(reg->hasBlob("remove_cmd_test"));
+    QCOMPARE(reg->blob("remove_cmd_test"), blob);
+
+    scene.undoStack()->redo();
+    QVERIFY(!reg->hasBlob("remove_cmd_test"));
 }
 
 void TestICInline::testLoadICMissingAllNameFieldsThrows()
@@ -5946,4 +6005,43 @@ void TestICInline::testOnFileChangedPushesUndoCommandC5()
     QCOMPARE(static_cast<int>(ws.scene()->elements().size()), 1);
 
     QFile::remove(icPath);
+}
+
+void TestICInline::testPasteEmbeddedICBlobUndoRemovesOrphan()
+{
+    // Regression: ClipboardManager::paste() previously registered clipboard blobs directly
+    // into the target registry, outside the undo system, while the paste itself only pushed
+    // an AddItemsCommand (which knows nothing about the blob registry). Undoing the paste
+    // removed the pasted element but left the blob permanently orphaned in the registry —
+    // unreachable by any further undo/redo action.
+    Scene sourceScene;
+    sourceScene.setContextDir(m_fixtureDir);
+    auto *sourceReg = sourceScene.icRegistry();
+
+    auto *ic = new IC();
+    embedIC(ic, readFile(m_fixtureDir + "/simple_and.panda"), "paste_orphan_test", m_fixtureDir, sourceReg);
+    sourceScene.addItem(ic);
+    ic->setSelected(true);
+    sourceScene.copyAction();
+
+    // Paste into a different scene that doesn't already know this blob — mirrors the
+    // cross-tab paste scenario the blob-registry import code exists for.
+    Scene targetScene;
+    targetScene.setContextDir(m_fixtureDir);
+    auto *targetReg = targetScene.icRegistry();
+    QVERIFY(!targetReg->hasBlob("paste_orphan_test"));
+
+    targetScene.pasteAction();
+    QVERIFY(targetReg->hasBlob("paste_orphan_test"));
+    QCOMPARE(static_cast<int>(targetScene.elements().size()), 1);
+
+    // A single undo must reverse both the element addition and the blob registration —
+    // they were pushed as one macro.
+    targetScene.undoStack()->undo();
+    QCOMPARE(static_cast<int>(targetScene.elements().size()), 0);
+    QVERIFY(!targetReg->hasBlob("paste_orphan_test"));
+
+    targetScene.undoStack()->redo();
+    QCOMPARE(static_cast<int>(targetScene.elements().size()), 1);
+    QVERIFY(targetReg->hasBlob("paste_orphan_test"));
 }

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -6045,3 +6045,92 @@ void TestICInline::testPasteEmbeddedICBlobUndoRemovesOrphan()
     QCOMPARE(static_cast<int>(targetScene.elements().size()), 1);
     QVERIFY(targetReg->hasBlob("paste_orphan_test"));
 }
+
+void TestICInline::testEmbedICsByFileWithSequentialElementWhileSimulationRunning()
+{
+    // Regression: embedICsByFile() previously mutated a live, already-in-scene IC with no
+    // SimulationBlocker at all, unlike sibling onFileChanged(). If the embedded sub-circuit
+    // contains a sequential element, resetInternalState() frees exactly the objects
+    // Simulation::m_sequentialElements points to while the simulation timer could still be
+    // running. This can't reproduce the real UAF deterministically in single-threaded QtTest
+    // (see TestDanglingPointer's bug6/bug7 for the same limitation) — this test instead
+    // exercises the guarded path end to end with the simulation actively started, and confirms
+    // the embed completes correctly and the simulation still ticks afterward.
+    const QString filePath = TestUtils::examplesDir() + "jkflipflop.panda";
+    QVERIFY2(QFile::exists(filePath), "jkflipflop.panda fixture not found");
+    QByteArray rawFileBytes = readFile(filePath);
+
+    WorkSpace ws;
+    ws.scene()->setContextDir(QFileInfo(filePath).absolutePath());
+
+    auto *ic = new IC();
+    ic->loadFile(filePath, QFileInfo(filePath).absolutePath());
+    ws.scene()->addItem(ic);
+    QVERIFY(!ic->isEmbedded());
+
+    ws.scene()->simulation()->start();
+
+    auto *reg = ws.scene()->icRegistry();
+    const int count = reg->embedICsByFile(filePath, rawFileBytes, "flipflop_embedded");
+    QCOMPARE(count, 1);
+    QVERIFY(ic->isEmbedded());
+    QCOMPARE(ic->blobName(), QString("flipflop_embedded"));
+
+    // The simulation must still tick correctly post-embed — proves the internal graph was
+    // rebuilt cleanly, not left torn.
+    ws.scene()->simulation()->update();
+
+    ws.scene()->simulation()->stop();
+}
+
+void TestICInline::testLoadFileDirectlyEnforcesNestingDepthLimit()
+{
+    // Regression: ICLoader::loadFileDirectly() (used when an IC isn't yet in a scene, e.g.
+    // during deserialization) previously only had cycle detection — no depth cap, unlike its
+    // sibling deserializeAndLoad() (the blob-cache path), which is bounded by
+    // kMaxICNestingDepth. A long, non-cyclic chain of distinct legitimate files (no repeats, so
+    // the cycle guard never fires) recursed unbounded through loadFileDirectly() and could
+    // exhaust the call stack. Build a chain deeper than the shared limit and confirm it throws
+    // cleanly instead of crashing.
+    QTemporaryDir tmp;
+    QVERIFY(tmp.isValid());
+
+    // Leaf: reuse the simple_and.panda fixture (a plain 2-input AND gate, no IC references).
+    QVERIFY(QFile::copy(m_fixtureDir + "/simple_and.panda", tmp.filePath("level0.panda")));
+
+    // Build a chain of file-backed ICs, each wrapping the previous level. None of these levels
+    // are ever added to a Scene, so loading them back always takes the loadFileDirectly()
+    // fallback, not the blob-cache path. Each level's loadFile() call fully re-resolves the
+    // whole chain accumulated so far (an IC needs its complete internal structure to determine
+    // port counts, not just a lazy filename reference), so the depth limit fires partway
+    // through this construction loop itself, comfortably before reaching 20 levels — this loop
+    // IS the deepening non-cyclic chain the fix is meant to bound.
+    constexpr int kChainLength = 20;
+    bool threw = false;
+    QString message;
+    for (int level = 1; level <= kChainLength; ++level) {
+        WorkSpace ws;
+        ws.scene()->setContextDir(tmp.path());
+        auto *ic = new IC();
+        try {
+            ic->loadFile(QStringLiteral("level%1.panda").arg(level - 1), tmp.path());
+        } catch (const Pandaception &e) {
+            threw = true;
+            message = e.englishMessage();
+            delete ic; // never added to a scene on this path — safe to delete directly
+            break;
+        }
+        ws.scene()->addItem(ic);
+
+        QFile file(tmp.filePath(QStringLiteral("level%1.panda").arg(level)));
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        QDataStream stream(&file);
+        Serialization::writePandaHeader(stream);
+        ws.save(stream);
+    }
+
+    QVERIFY2(threw, "Building a chain of 20 nested file-backed ICs must eventually throw a "
+                    "nesting-depth exception, not crash or succeed unbounded.");
+    QVERIFY2(message.contains("nesting depth", Qt::CaseInsensitive),
+             qPrintable(QString("Expected a nesting-depth-limit error, got: %1").arg(message)));
+}

--- a/Tests/Integration/TestICInline.h
+++ b/Tests/Integration/TestICInline.h
@@ -27,6 +27,7 @@ private slots:
     // Workspace inline tab
     void testInlineTabSaveLoad();
     void testChildBlobPropagation();
+    void testInlineTabSaveThrowsWhenFileBackedIcMissingOnDisk();
 
     // Undo/redo
     void testUndoRedoEmbedExtract();

--- a/Tests/Integration/TestICInline.h
+++ b/Tests/Integration/TestICInline.h
@@ -200,6 +200,11 @@ private slots:
     void testIsEmbeddedICWithStaleBlobName();
     void testRegisterBlobCommandUndoRedo();
     void testRegisterBlobCommandRedoAfterExternalRemove();
+    void testRenameBlobCommandUndoRedo();
+    // Regression: a rename and an unrelated property edit must each undo independently — the
+    // old apply()-triggered, untracked renameBlob() call let a later UpdateCommand undo try to
+    // resolve the pre-rename blob name against a registry that no longer had it.
+    void testRenameBlobCommandThenUnrelatedUpdateBothUndoIndependently();
     void testLoadICMissingAllNameFieldsThrows();
     void testUniqueBlobNameEmptyBase();
     void testBlobReturnsEmptyForMissingName();

--- a/Tests/Integration/TestICInline.h
+++ b/Tests/Integration/TestICInline.h
@@ -180,7 +180,7 @@ private slots:
     // --- Edge cases: ICRegistry ---
 
     void testRenameBlobSameNameNoOp();
-    void testRenameBlobCollisionOverwrites();
+    void testRenameBlobCollisionRejected();
     void testRenameBlobNonExistentNoOp();
     void testRemoveBlobNonExistent();
     void testInitEmbeddedICMissingBlob();
@@ -200,6 +200,7 @@ private slots:
     void testIsEmbeddedICWithStaleBlobName();
     void testRegisterBlobCommandUndoRedo();
     void testRegisterBlobCommandRedoAfterExternalRemove();
+    void testRemoveBlobCommandUndoRedo();
     void testRenameBlobCommandUndoRedo();
     // Regression: a rename and an unrelated property edit must each undo independently — the
     // old apply()-triggered, untracked renameBlob() call let a later UpdateCommand undo try to
@@ -235,6 +236,10 @@ private slots:
 
     // Regression: C5 — onFileChanged must push UpdateBlobCommand for undo
     void testOnFileChangedPushesUndoCommandC5();
+
+    // Regression: pasting an embedded IC previously registered its blob directly into the
+    // registry, outside the undo system — undoing the paste left it orphaned forever.
+    void testPasteEmbeddedICBlobUndoRemovesOrphan();
 
 private:
     QString fixturesSrcDir() const;

--- a/Tests/Integration/TestICInline.h
+++ b/Tests/Integration/TestICInline.h
@@ -241,6 +241,16 @@ private slots:
     // registry, outside the undo system — undoing the paste left it orphaned forever.
     void testPasteEmbeddedICBlobUndoRemovesOrphan();
 
+    // Regression: embedICsByFile()/extractToFile() mutated live, already-in-scene ICs with no
+    // SimulationBlocker, unlike sibling onFileChanged() — a UAF risk if the IC contains a
+    // sequential element while the simulation is running.
+    void testEmbedICsByFileWithSequentialElementWhileSimulationRunning();
+
+    // Regression: ICLoader::loadFileDirectly() only had cycle detection, not a depth cap
+    // (unlike its sibling deserializeAndLoad()) — a long, non-cyclic chain of distinct file-
+    // backed ICs recursed unbounded and could exhaust the call stack.
+    void testLoadFileDirectlyEnforcesNestingDepthLimit();
+
 private:
     QString fixturesSrcDir() const;
     bool copyFixture(const QString &name);

--- a/Tests/Integration/TestSystemVerilogExport.cpp
+++ b/Tests/Integration/TestSystemVerilogExport.cpp
@@ -224,6 +224,70 @@ void TestSystemVerilogExport::testWirelessOrphanedRxCodegen()
     QVERIFY2(!content.isEmpty(), "Generated SystemVerilog should not be empty");
 }
 
+void TestSystemVerilogExport::testEmbeddedICLabelWithNewlineDoesNotInjectCode()
+{
+    // Regression: an IC's label was written raw into "// Module for <label>" and
+    // "// IC instance: <label>" comments. A label containing an embedded newline (settable via
+    // a crafted .panda file's label field, or MCP's create_element/set_element_properties
+    // "label" param — neither restricts content beyond length) could break out of the comment
+    // and inject a real line into the generated SystemVerilog file.
+    IC *icRaw = nullptr;
+    try {
+        icRaw = CPUTestUtils::loadBuildingBlockIC("level2_half_adder.panda");
+    } catch (const std::exception &ex) {
+        QFAIL(qPrintable(QString("Failed to load IC: %1").arg(QString::fromStdString(ex.what()))));
+        return;
+    }
+    std::unique_ptr<IC> ic(icRaw);
+    ic->setLabel("Evil\nmodule injected_module; endmodule");
+
+    std::vector<std::unique_ptr<InputSwitch>> switchOwners;
+    std::vector<std::unique_ptr<Led>> ledOwners;
+    std::vector<std::unique_ptr<Connection>> connOwners;
+    QVector<GraphicElement *> elements{ic.get()};
+
+    for (int i = 0; i < ic->inputSize(); ++i) {
+        auto sw = std::make_unique<InputSwitch>();
+        auto conn = std::make_unique<Connection>();
+        conn->setStartPort(sw->outputPort(0));
+        conn->setEndPort(ic->inputPort(i));
+        elements.append(sw.get());
+        connOwners.push_back(std::move(conn));
+        switchOwners.push_back(std::move(sw));
+    }
+
+    for (int i = 0; i < ic->outputSize(); ++i) {
+        auto led = std::make_unique<Led>();
+        auto conn = std::make_unique<Connection>();
+        conn->setStartPort(ic->outputPort(i));
+        conn->setEndPort(led->inputPort(0));
+        elements.append(led.get());
+        connOwners.push_back(std::move(conn));
+        ledOwners.push_back(std::move(led));
+    }
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QString verilogPath = tempDir.filePath("test_ic_label_injection.sv");
+
+    SystemVerilogCodeGen generator(verilogPath, elements);
+    try {
+        generator.generate();
+    } catch (const std::exception &e) {
+        QFAIL(qPrintable(QString("SystemVerilog generation threw an exception: %1").arg(e.what())));
+    }
+
+    QFile file(verilogPath);
+    QVERIFY2(file.open(QIODevice::ReadOnly | QIODevice::Text),
+             "Generated SystemVerilog file should be readable");
+    const QString content = QString::fromUtf8(file.readAll());
+    file.close();
+
+    QVERIFY2(!content.isEmpty(), "Generated SystemVerilog should not be empty");
+    QVERIFY2(!content.contains("\nmodule injected_module;"),
+             "Label newline must not inject a bare module declaration into the generated file");
+}
+
 bool TestSystemVerilogExport::validateWithIverilog(const QString &verilogFile)
 {
     QProcess process;

--- a/Tests/Integration/TestSystemVerilogExport.h
+++ b/Tests/Integration/TestSystemVerilogExport.h
@@ -16,6 +16,7 @@ private slots:
     // Wireless node codegen
     void testWirelessNodeGeneration();
     void testWirelessOrphanedRxCodegen();
+    void testEmbeddedICLabelWithNewlineDoesNotInjectCode();
 
     // Level 2 - Combinational circuits (all pure gates, no flip-flops)
     void testSystemVerilogExportHalfAdder();

--- a/Tests/Integration/TestWorkspace.cpp
+++ b/Tests/Integration/TestWorkspace.cpp
@@ -1072,3 +1072,45 @@ void TestWorkspace::testFlushPendingAutosaveRunsImmediatelyB3()
     // Now the autosave write happened.
     QVERIFY(Settings::autosaveFiles().size() >= 1);
 }
+
+void TestWorkspace::testFirstSaveCopiesExternalAppearanceFile()
+{
+    // A custom LED appearance picked before the project has ever been saved lives
+    // somewhere unrelated to the eventual project folder. The first real "Save" must
+    // copy it alongside the .panda file — otherwise GraphicElementSerializer::save()'s
+    // bare-filename reference can never be resolved again after a reload.
+    QTemporaryDir sourceDir;
+    QVERIFY2(sourceDir.isValid(), "Source temporary directory creation failed");
+    const QString imagePath = sourceDir.filePath("custom_led.svg");
+    QVERIFY(QFile::copy(":/Components/Output/Led/WhiteLed.svg", imagePath));
+
+    QTemporaryDir projectDir;
+    QVERIFY2(projectDir.isValid(), "Project temporary directory creation failed");
+    const QString saveFile = projectDir.filePath("circuit.panda");
+
+    WorkSpace workspace;
+    Scene *scene = workspace.scene();
+
+    auto *led = ElementFactory::buildElement(ElementType::Led);
+    scene->addItem(led);
+    led->setAppearance(false, imagePath);
+
+    try {
+        workspace.save(saveFile);
+    } catch (const Pandaception &e) {
+        QFAIL(qPrintable(QString("First save should not throw: %1").arg(e.what())));
+    }
+
+    const QString copiedImagePath = projectDir.filePath("custom_led.svg");
+    QVERIFY2(QFile::exists(copiedImagePath),
+             "Custom appearance file should be copied next to the project on its first save");
+
+    // Reloading must resolve the now-bare-filename reference against the copy that
+    // was just placed alongside it.
+    WorkSpace reloaded;
+    try {
+        reloaded.load(saveFile);
+    } catch (const Pandaception &e) {
+        QFAIL(qPrintable(QString("Reloading the saved project should not throw: %1").arg(e.what())));
+    }
+}

--- a/Tests/Integration/TestWorkspace.h
+++ b/Tests/Integration/TestWorkspace.h
@@ -69,6 +69,9 @@ private slots:
     // Regression: B2 — autosave truncates on shrink (no leftover-tail garbage)
     void testAutosaveTruncatesOnShrinkB2();
 
+    // Regression: custom LED appearance survives a never-before-saved project's first save
+    void testFirstSaveCopiesExternalAppearanceFile();
+
 private:
     QTemporaryDir m_tempDir;
 };

--- a/Tests/Integration/TestWorkspaceFileops.cpp
+++ b/Tests/Integration/TestWorkspaceFileops.cpp
@@ -439,6 +439,38 @@ void TestWorkspaceFileops::testFilePathPreservedAfterLoad()
     }
 }
 
+void TestWorkspaceFileops::testSaveFailureLeavesFileIdentityUnchanged()
+{
+    // Regression: WorkSpace::save() used to adopt the new file/contextDir identity before the
+    // QSaveFile open/commit was known to succeed. A save that never actually writes anything
+    // (bad target path) must leave the workspace's reported identity exactly as it was before.
+    WorkSpace workspace;
+    auto *andGate = ElementFactory::buildElement(ElementType::And);
+    workspace.scene()->addItem(andGate);
+
+    const QString beforePath = workspace.fileInfo().absoluteFilePath();
+    const QString beforeContextDir = workspace.scene()->contextDir();
+
+    const bool prevInteractive = Application::interactiveMode;
+    Application::interactiveMode = true;
+
+    const QString badPath = m_tempDir.path() + "/no_such_directory/project.panda";
+    bool threw = false;
+    WorkSpace::SaveOutcome outcome = WorkSpace::SaveOutcome::Saved;
+    try {
+        outcome = workspace.save(badPath);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+
+    Application::interactiveMode = prevInteractive;
+
+    QVERIFY2(threw || outcome == WorkSpace::SaveOutcome::ReadOnlyTarget,
+              "Expected save() to a nonexistent directory to fail (throw or ReadOnlyTarget)");
+    QCOMPARE(workspace.fileInfo().absoluteFilePath(), beforePath);
+    QCOMPARE(workspace.scene()->contextDir(), beforeContextDir);
+}
+
 void TestWorkspaceFileops::testFileExtensionPandaAppend()
 {
     // Test that file paths with .panda extension are recognized

--- a/Tests/Integration/TestWorkspaceFileops.h
+++ b/Tests/Integration/TestWorkspaceFileops.h
@@ -31,6 +31,7 @@ private slots:
     void testModifiedFlagClearedAfterSave();
     void testFilePathUpdatedAfterSave();
     void testFilePathPreservedAfterLoad();
+    void testSaveFailureLeavesFileIdentityUnchanged();
 
     void testFileExtensionPandaAppend();
     void testFileExtensionNoDuplicate();

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -183,6 +183,7 @@
 #include "Tests/Unit/Scene/TestSceneUndoredo.h"
 #include "Tests/Unit/Scene/TestWorkspace.h"
 // unit/serialization
+#include "Tests/Unit/Serialization/TestDolphinClipboard.h"
 #include "Tests/Unit/Serialization/TestDolphinSerializer.h"
 #include "Tests/Unit/Serialization/TestFileUtils.h"
 #include "Tests/Unit/Serialization/TestRecentFiles.h"
@@ -384,6 +385,7 @@ int main(int argc, char **argv)
         {"TestSceneUndoredo", []() -> QObject * { return new TestSceneUndoredo; }},
         {"TestPropertyShortcutHandler", []() -> QObject * { return new TestPropertyShortcutHandler; }},
         {"TestWorkspaceUnit", []() -> QObject * { return new TestWorkspaceUnit; }},
+        {"TestDolphinClipboard", []() -> QObject * { return new TestDolphinClipboard; }},
         {"TestDolphinSerializer", []() -> QObject * { return new TestDolphinSerializer; }},
         {"TestFileUtils", []() -> QObject * { return new TestFileUtils; }},
         {"TestRecentFilesUnit", []() -> QObject * { return new TestRecentFilesUnit; }},

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -115,6 +115,7 @@
 #include "Tests/System/TestWaveform.h"
 // unit/codegen
 #include "Tests/Unit/CodeGen/TestArduinoCodeGenUnit.h"
+#include "Tests/Unit/CodeGen/TestCodeGenUtils.h"
 #include "Tests/Unit/CodeGen/TestSystemVerilogCodeGenUnit.h"
 // unit/commands
 #include "Tests/Unit/Commands/TestCommands.h"
@@ -320,6 +321,7 @@ int main(int argc, char **argv)
         {"TestWaveform", []() -> QObject * { return new TestWaveform; }},
         {"TestBewavedDolphinGui", []() -> QObject * { return new TestBewavedDolphinGui; }},
         {"TestArduinoCodeGenUnit", []() -> QObject * { return new TestArduinoCodeGenUnit; }},
+        {"TestCodeGenUtils", []() -> QObject * { return new TestCodeGenUtils; }},
         {"TestSystemVerilogCodeGenUnit", []() -> QObject * { return new TestSystemVerilogCodeGenUnit; }},
         {"TestCommands", []() -> QObject * { return new TestCommands; }},
         {"TestCommon", []() -> QObject * { return new TestCommon; }},

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -173,6 +173,7 @@
 // unit/mcp
 #include "Tests/Unit/MCP/TestFileHandlerSecurity.h"
 #include "Tests/Unit/MCP/TestICHandlerSecurity.h"
+#include "Tests/Unit/MCP/TestMCPProcessor.h"
 // unit/scene
 #include "Tests/Unit/Scene/TestConnectionManager.h"
 #include "Tests/Unit/Scene/TestConnectionValidity.h"
@@ -376,6 +377,7 @@ int main(int argc, char **argv)
         {"TestStatusOps", []() -> QObject * { return new TestStatusOps; }},
         {"TestICHandlerSecurity", []() -> QObject * { return new TestICHandlerSecurity; }},
         {"TestFileHandlerSecurity", []() -> QObject * { return new TestFileHandlerSecurity; }},
+        {"TestMCPProcessor", []() -> QObject * { return new TestMCPProcessor; }},
         {"TestConnectionSerialization", []() -> QObject * { return new TestConnectionSerialization; }},
         {"TestConnections", []() -> QObject * { return new TestConnections; }},
         {"TestConnectionManager", []() -> QObject * { return new TestConnectionManager; }},

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -169,6 +169,7 @@
 #include "Tests/Unit/Logic/TestNodeLogic.h"
 #include "Tests/Unit/Logic/TestStatusOps.h"
 // unit/mcp
+#include "Tests/Unit/MCP/TestFileHandlerSecurity.h"
 #include "Tests/Unit/MCP/TestICHandlerSecurity.h"
 // unit/scene
 #include "Tests/Unit/Scene/TestConnectionManager.h"
@@ -369,6 +370,7 @@ int main(int argc, char **argv)
         {"TestNodeLogic", []() -> QObject * { return new TestNodeLogic; }},
         {"TestStatusOps", []() -> QObject * { return new TestStatusOps; }},
         {"TestICHandlerSecurity", []() -> QObject * { return new TestICHandlerSecurity; }},
+        {"TestFileHandlerSecurity", []() -> QObject * { return new TestFileHandlerSecurity; }},
         {"TestConnectionSerialization", []() -> QObject * { return new TestConnectionSerialization; }},
         {"TestConnections", []() -> QObject * { return new TestConnections; }},
         {"TestConnectionManager", []() -> QObject * { return new TestConnectionManager; }},

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -168,6 +168,8 @@
 #include "Tests/Unit/Logic/TestElementLogicErrors.h"
 #include "Tests/Unit/Logic/TestNodeLogic.h"
 #include "Tests/Unit/Logic/TestStatusOps.h"
+// unit/mcp
+#include "Tests/Unit/MCP/TestICHandlerSecurity.h"
 // unit/scene
 #include "Tests/Unit/Scene/TestConnectionManager.h"
 #include "Tests/Unit/Scene/TestConnectionValidity.h"
@@ -366,6 +368,7 @@ int main(int argc, char **argv)
         {"TestElementLogicErrors", []() -> QObject * { return new TestElementLogicErrors; }},
         {"TestNodeLogic", []() -> QObject * { return new TestNodeLogic; }},
         {"TestStatusOps", []() -> QObject * { return new TestStatusOps; }},
+        {"TestICHandlerSecurity", []() -> QObject * { return new TestICHandlerSecurity; }},
         {"TestConnectionSerialization", []() -> QObject * { return new TestConnectionSerialization; }},
         {"TestConnections", []() -> QObject * { return new TestConnections; }},
         {"TestConnectionManager", []() -> QObject * { return new TestConnectionManager; }},

--- a/Tests/Runners/TestWiredpanda.cpp
+++ b/Tests/Runners/TestWiredpanda.cpp
@@ -128,6 +128,7 @@
 #include "Tests/Unit/Common/TestThemeManager.h"
 // unit/core
 #include "Tests/Unit/Core/TestApplication.h"
+#include "Tests/Unit/Core/TestDragDropPayload.h"
 #include "Tests/Unit/Core/TestExerciseTourResources.h"
 #include "Tests/Unit/Core/TestInstallRelativePaths.h"
 #include "Tests/Unit/Core/TestNotifyCatch.h"
@@ -337,6 +338,7 @@ int main(int argc, char **argv)
         {"TestExerciseEngine", []() -> QObject * { return new TestExerciseEngine; }},
         {"TestUpdateChecker", []() -> QObject * { return new TestUpdateChecker; }},
         {"TestApplication", []() -> QObject * { return new TestApplication; }},
+        {"TestDragDropPayload", []() -> QObject * { return new TestDragDropPayload; }},
         {"TestNotifyCatch", []() -> QObject * { return new TestNotifyCatch; }},
         {"TestAudioBox", []() -> QObject * { return new TestAudioBox; }},
         {"TestBuzzer", []() -> QObject * { return new TestBuzzer; }},

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -1015,3 +1015,51 @@ void TestBewavedDolphinGui::testFitScreenClampsAndGuardsA26()
     QVERIFY(dolphin->m_zoom->fitScale() >= kMinFitScale);
     QVERIFY(dolphin->m_zoom->fitScale() <= kMaxFitScale);
 }
+
+void TestBewavedDolphinGui::testCreateWaveformResolvesAbsolutePathOutsideProjectDir()
+{
+    // A waveform file linked from outside the project directory (e.g. via
+    // associateToWiRedPanda()'s "Save As...") must still resolve by its absolute path —
+    // createWaveform() must not unconditionally discard the directory and only search
+    // the project's own folder.
+    QVERIFY(QDir(m_tempDir.path()).mkpath("project"));
+    QVERIFY(QDir(m_tempDir.path()).mkpath("elsewhere"));
+    const QString projectDir = m_tempDir.filePath("project");
+    const QString elsewhereDir = m_tempDir.filePath("elsewhere");
+    const QString dolphinPath = elsewhereDir + "/waveform.dolphin";
+
+    auto ws = createAndCircuit();
+
+    // Save a waveform with a known pattern to a .dolphin file living outside any project
+    // directory, via the same Save-As action other tests use.
+    {
+        StubDolphinHost host;
+        host.m_currentDir = QDir(elsewhereDir);
+        std::unique_ptr<BewavedDolphin> dolphin(new BewavedDolphin(ws->scene(), false, &host));
+        dolphin->setAttribute(Qt::WA_DeleteOnClose, false);
+        dolphin->createWaveform("");
+        dolphin->setCellValue(0, 0, 1);
+        dolphin->run();
+
+        auto *action = dolphin->findChild<QAction *>("actionSaveAs");
+        QVERIFY2(action, "actionSaveAs not found");
+        ScopedFileDialogStub guard;
+        guard.stub.saveResult = {dolphinPath, "Dolphin files (*.dolphin)"};
+        action->trigger();
+    }
+
+    QVERIFY(QFile::exists(dolphinPath));
+
+    // Open a fresh BewavedDolphin whose project directory is a different folder, and load
+    // the waveform by its full absolute path (as WorkSpace::dolphinFileName() would return
+    // after linking a file that lives outside the project).
+    StubDolphinHost host2;
+    host2.m_currentDir = QDir(projectDir);
+    std::unique_ptr<BewavedDolphin> dolphin2(new BewavedDolphin(ws->scene(), false, &host2));
+    dolphin2->setAttribute(Qt::WA_DeleteOnClose, false);
+    dolphin2->createWaveform(dolphinPath);
+
+    auto *model = dolphin2->model();
+    QVERIFY(model);
+    QCOMPARE(model->index(0, 0).data().toInt(), 1);
+}

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -15,6 +15,7 @@
 #include <QHeaderView>
 #include <QImage>
 #include <QItemSelectionModel>
+#include <QRegularExpression>
 #include <QScrollBar>
 #include <QSet>
 #include <QStandardItemModel>
@@ -28,6 +29,7 @@
 #include "App/Element/GraphicElements/And.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Element/GraphicElements/Led.h"
+#include "App/Scene/Commands.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/SimulationBlocker.h"
 #include "App/UI/FileDialogProvider.h"
@@ -1062,4 +1064,109 @@ void TestBewavedDolphinGui::testCreateWaveformResolvesAbsolutePathOutsideProject
     auto *model = dolphin2->model();
     QVERIFY(model);
     QCOMPARE(model->index(0, 0).data().toInt(), 1);
+}
+
+void TestBewavedDolphinGui::hardeningRunAndSaveToTxtMustCheckElementsStillLive()
+{
+    const QString path = QString(QUOTE(CURRENTDIR)) + "/../App/BeWavedDolphin/BeWavedDolphin.cpp";
+    QFile src(path);
+    QVERIFY2(src.open(QIODevice::ReadOnly), qPrintable(QString("Cannot open %1").arg(src.fileName())));
+    const QString source = QString::fromUtf8(src.readAll());
+    src.close();
+
+    auto bodyOf = [&source](const QString &qualifiedName) -> QString {
+        const QString pattern =
+            QStringLiteral("\\b") + QRegularExpression::escape(qualifiedName)
+            + QStringLiteral("\\s*\\([^)]*\\)\\s*\\{");
+        QRegularExpression rx(pattern);
+        const auto match = rx.match(source);
+        if (!match.hasMatch()) return {};
+
+        const qsizetype start = match.capturedEnd() - 1;
+        int depth = 0;
+        for (qsizetype i = start; i < source.size(); ++i) {
+            const QChar c = source.at(i);
+            if (c == '{') ++depth;
+            else if (c == '}') {
+                --depth;
+                if (depth == 0) return source.mid(start, i - start + 1);
+            }
+        }
+        return {};
+    };
+
+    const QStringList checkedFunctions = {"BewavedDolphin::run", "BewavedDolphin::saveToTxt"};
+    QStringList missingCheck;
+    for (const QString &name : checkedFunctions) {
+        const QString body = bodyOf(name);
+        if (body.isEmpty()) {
+            missingCheck << (name + " (function body not located)");
+            continue;
+        }
+        if (!body.contains("elementsStillLive")) {
+            missingCheck << name;
+        }
+    }
+
+    QVERIFY2(missingCheck.isEmpty(),
+             qPrintable(QString("The following functions dereference m_inputs/m_outputs via "
+                                "sweep() and must check elementsStillLive() first — an element "
+                                "deleted from the live scene since prepare() (main canvas, or an "
+                                "MCP client, neither blocked by this window's modality) would "
+                                "otherwise dangle:\n  - %1")
+                            .arg(missingCheck.join("\n  - "))));
+}
+
+void TestBewavedDolphinGui::testRunAndSaveToTxtHandleDeletedTrackedElement()
+{
+    auto ws = createAndCircuit();
+    auto *scene = ws->scene();
+    auto *dolphin = createDolphin(ws.get());
+
+    // Find the tracked InputSwitch backing waveform row 0, then delete it directly via a
+    // scene command — the same mutation an MCP client's delete_element would perform,
+    // bypassing this window's (GUI-only) modality entirely.
+    const auto &inputs = dolphin->inputElements();
+    QVERIFY(!inputs.isEmpty());
+    auto *trackedInput = inputs.first();
+    scene->receiveCommand(new DeleteItemsCommand({trackedInput}, scene));
+
+    // run() must skip the now-stale sweep rather than dereferencing the deleted element.
+    dolphin->run();
+
+    // saveToTxt() must fail cleanly instead of silently exporting garbage/partial data.
+    QString text;
+    QTextStream stream(&text);
+    QVERIFY_THROWS(std::exception, dolphin->saveToTxt(stream));
+}
+
+void TestBewavedDolphinGui::testConstructorWithParentEnablesWindowModality()
+{
+    auto ws = createAndCircuit();
+    QWidget parentWidget;
+
+    std::unique_ptr<BewavedDolphin> dolphin(new BewavedDolphin(ws->scene(), false, nullptr, &parentWidget));
+    dolphin->setAttribute(Qt::WA_DeleteOnClose, false);
+
+    QCOMPARE(dolphin->parentWidget(), &parentWidget);
+    QCOMPARE(dolphin->windowModality(), Qt::WindowModal);
+}
+
+void TestBewavedDolphinGui::testSaveToTxtClampsColumnCountForManyInputPorts()
+{
+    auto ws = std::make_unique<WorkSpace>();
+    auto *scene = ws->scene();
+    for (int i = 0; i < 12; ++i) {
+        scene->addItem(new InputSwitch());
+    }
+    scene->addItem(new Led());
+    auto *dolphin = createDolphin(ws.get());
+
+    QString text;
+    QTextStream stream(&text);
+    dolphin->saveToTxt(stream);
+
+    const QString firstLine = text.section('\n', 0, 0);
+    const qsizetype columnCount = firstLine.section(" : ", 0, 0).length();
+    QCOMPARE(columnCount, static_cast<qsizetype>(SignalModel::kMaxColumns));
 }

--- a/Tests/System/TestBewavedDolphinGui.h
+++ b/Tests/System/TestBewavedDolphinGui.h
@@ -92,6 +92,26 @@ private slots:
     // resolve by its absolute path, not just by basename inside the project's own folder.
     void testCreateWaveformResolvesAbsolutePathOutsideProjectDir();
 
+    // Regression: run()/saveToTxt() dereferenced m_inputs/m_outputs via sweep() with no
+    // check that those elements were still in the live scene — deleting one (main canvas,
+    // or an MCP client neither path's modality blocks) left them dangling. Source-level
+    // check, same shape as TestDanglingPointer.cpp's hardening_* tests: a plain behavioral
+    // repro isn't reliable here since reading recently-freed memory doesn't crash on every
+    // allocator/run.
+    void hardeningRunAndSaveToTxtMustCheckElementsStillLive();
+    // Behavioral companion: deleting a tracked element and then calling run()/saveToTxt()
+    // must not crash and must fail cleanly, not silently export garbage.
+    void testRunAndSaveToTxtHandleDeletedTrackedElement();
+    // Regression: BewavedDolphin's Qt::WindowModal setting was a no-op because the window
+    // was never given a real Qt parent (host is a non-QWidget interface) — the comment
+    // claiming "the user cannot interact with the main circuit" was false as implemented.
+    void testConstructorWithParentEnablesWindowModality();
+
+    // Regression: saveToTxt()'s column count had no cap, unlike its sibling
+    // on_actionCombinational_triggered — 12 input ports (2^12 = 4096 combinations) must
+    // clamp to SignalModel::kMaxColumns (2048), the same bound the sibling already uses.
+    void testSaveToTxtClampsColumnCountForManyInputPorts();
+
 private:
     QTemporaryDir m_tempDir;
 };

--- a/Tests/System/TestBewavedDolphinGui.h
+++ b/Tests/System/TestBewavedDolphinGui.h
@@ -88,6 +88,10 @@ private slots:
     void testZoomScaleTrackingA26();
     void testFitScreenClampsAndGuardsA26();
 
+    // Regression: a linked waveform file living outside the project directory must still
+    // resolve by its absolute path, not just by basename inside the project's own folder.
+    void testCreateWaveformResolvesAbsolutePathOutsideProjectDir();
+
 private:
     QTemporaryDir m_tempDir;
 };

--- a/Tests/Unit/CodeGen/TestCodeGenUtils.cpp
+++ b/Tests/Unit/CodeGen/TestCodeGenUtils.cpp
@@ -1,0 +1,29 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/CodeGen/TestCodeGenUtils.h"
+
+#include "App/CodeGen/CodeGenUtils.h"
+
+void TestCodeGenUtils::testSanitizeCommentStripsLineBreaks()
+{
+    // Regression: a label containing an embedded newline, written raw into a "// IC: <label>"
+    // comment by ArduinoCodeGen/SystemVerilogCodeGen, could break out of the comment and
+    // inject an arbitrary line into the generated file. sanitizeComment() must neutralize any
+    // line-break character so the label can never span more than the one comment line.
+    const QString malicious = QStringLiteral("Evil\ndigitalWrite(13, HIGH); //");
+    const QString sanitized = CodeGenUtils::sanitizeComment(malicious);
+
+    QVERIFY(!sanitized.contains(QLatin1Char('\n')));
+    QVERIFY(!sanitized.contains(QLatin1Char('\r')));
+
+    const QString withCarriageReturn = QStringLiteral("Evil\r\ninjected();");
+    QVERIFY(!CodeGenUtils::sanitizeComment(withCarriageReturn).contains(QLatin1Char('\n')));
+    QVERIFY(!CodeGenUtils::sanitizeComment(withCarriageReturn).contains(QLatin1Char('\r')));
+}
+
+void TestCodeGenUtils::testSanitizeCommentLeavesCleanTextUnchanged()
+{
+    const QString clean = QStringLiteral("Half Adder (4-bit)");
+    QCOMPARE(CodeGenUtils::sanitizeComment(clean), clean);
+}

--- a/Tests/Unit/CodeGen/TestCodeGenUtils.h
+++ b/Tests/Unit/CodeGen/TestCodeGenUtils.h
@@ -1,0 +1,16 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestCodeGenUtils : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testSanitizeCommentStripsLineBreaks();
+    void testSanitizeCommentLeavesCleanTextUnchanged();
+};

--- a/Tests/Unit/Commands/TestCommands.cpp
+++ b/Tests/Unit/Commands/TestCommands.cpp
@@ -9,6 +9,7 @@
 #include "App/Element/GraphicElements/AudioBox.h"
 #include "App/Element/GraphicElements/Buzzer.h"
 #include "App/Element/GraphicElements/Clock.h"
+#include "App/Element/GraphicElements/Display14.h"
 #include "App/Element/GraphicElements/Display7.h"
 #include "App/Element/GraphicElements/DLatch.h"
 #include "App/Element/GraphicElements/InputButton.h"
@@ -19,6 +20,7 @@
 #include "App/Element/GraphicElements/TruthTable.h"
 #include "App/IO/Serialization.h"
 #include "App/Scene/Commands.h"
+#include "App/Scene/Scene.h"
 #include "App/Wiring/Connection.h"
 #include "App/Wiring/Port.h"
 #include "Tests/Common/TestUtils.h"
@@ -664,6 +666,61 @@ void TestCommands::testMorphPreservesVolume()
     auto *restored = scene->elements().first();
     QCOMPARE(restored->elementType(), ElementType::Buzzer);
     QCOMPARE(restored->volume(), 0.25F);
+}
+
+void TestCommands::testMorphCommandUndoPreservesConnectionAddedWhileMorphed()
+{
+    // Regression: MorphCommand::undo() didn't record connections it had to drop the way
+    // redo() does (see the Display14->Display7 dangling-connection regression coverage in
+    // TestSceneUndoredo) — asymmetric with the tested, documented redo-direction behavior.
+    // A connection that exists on the morphed (larger) element but doesn't fit the original
+    // (smaller) type used to be silently lost forever when undo() reverted the morph; it
+    // must now be restored on the next redo(), symmetric with the redo-then-undo case.
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+    auto *undoStack = scene->undoStack();
+
+    auto *disp7 = new Display7();
+    auto *sw = new InputSwitch();
+    scene->receiveCommand(new AddItemsCommand(QList<QGraphicsItem *>{disp7, sw}, scene));
+    const int dispId = disp7->id();
+    const int swId = sw->id();
+    QCOMPARE(disp7->inputSize(), 8);
+
+    // Morph up to Display14 (15 inputs) — pure growth, nothing dropped.
+    scene->receiveCommand(new MorphCommand({disp7}, ElementType::Display14, scene));
+    auto *disp14 = dynamic_cast<GraphicElement *>(scene->itemById(dispId));
+    QVERIFY(disp14 != nullptr);
+    QCOMPARE(disp14->elementType(), ElementType::Display14);
+    QCOMPARE(disp14->inputSize(), 15);
+
+    // Add a wire directly to port 10 — a port that exists on Display14 but not on the
+    // original Display7 — bypassing the undo system, exactly as a separate user action would.
+    auto *conn = new Connection();
+    conn->setStartPort(sw->outputPort(0));
+    conn->setEndPort(disp14->inputPort(10));
+    scene->addItem(conn);
+    const int connId = conn->id();
+    QVERIFY(!disp14->inputPort(10)->connections().isEmpty());
+
+    // Undo the morph: Display7 has no port 10, so the connection can't survive.
+    undoStack->undo();
+
+    auto *restored7 = dynamic_cast<GraphicElement *>(scene->itemById(dispId));
+    QVERIFY(restored7 != nullptr);
+    QCOMPARE(restored7->elementType(), ElementType::Display7);
+    QCOMPARE(restored7->inputSize(), 8);
+    QVERIFY(scene->itemById(connId) == nullptr);
+
+    // Redo: back to Display14 — the connection must be restored, not lost forever.
+    undoStack->redo();
+
+    auto *redisp14 = dynamic_cast<GraphicElement *>(scene->itemById(dispId));
+    QVERIFY(redisp14 != nullptr);
+    QCOMPARE(redisp14->elementType(), ElementType::Display14);
+    QCOMPARE(redisp14->inputSize(), 15);
+    QVERIFY(!redisp14->inputPort(10)->connections().isEmpty());
+    QCOMPARE(redisp14->inputPort(10)->connections().constFirst()->startPort()->graphicElement()->id(), swId);
 }
 
 void TestCommands::testSplitCommandRedoThrowsBeforeAllocation()

--- a/Tests/Unit/Commands/TestCommands.h
+++ b/Tests/Unit/Commands/TestCommands.h
@@ -32,6 +32,7 @@ private slots:
     void testMorphCommand();
     void testMorphPreservesFlip();
     void testMorphPreservesVolume();
+    void testMorphCommandUndoPreservesConnectionAddedWhileMorphed();
     void testUpdateCommand();
     void testUpdateCommandPreservesClockPhase();
     void testUpdateCommandWirelessLabelRewiresChannel();

--- a/Tests/Unit/Core/TestDragDropPayload.cpp
+++ b/Tests/Unit/Core/TestDragDropPayload.cpp
@@ -1,0 +1,88 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/Core/TestDragDropPayload.h"
+
+#include <QDataStream>
+#include <QPoint>
+
+#include "App/Core/DragDropPayload.h"
+#include "App/Core/Enums.h"
+
+void TestDragDropPayload::testRoundTrip()
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << QPoint(3, 7);
+    stream << ElementType::IC;
+    stream << QStringLiteral("some/ic/file.panda");
+    stream << true;
+    stream << QStringLiteral("my_blob");
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    const auto payload = readDragDropPayload(readStream);
+
+    QCOMPARE(payload.offset, QPoint(3, 7));
+    QCOMPARE(payload.type, ElementType::IC);
+    QCOMPARE(payload.icFileName, QStringLiteral("some/ic/file.panda"));
+    QCOMPARE(payload.isEmbedded, true);
+    QCOMPARE(payload.blobName, QStringLiteral("my_blob"));
+}
+
+void TestDragDropPayload::testRejectsOversizedIcFileName()
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << QPoint(0, 0);
+    stream << ElementType::IC;
+    // Raw implausible length prefix (no real string data behind it) — this is exactly
+    // what a crafted drag payload would look like; readBoundedString must reject the
+    // length against the stream's actual remaining bytes instead of allocating it.
+    stream << static_cast<quint32>(0x7FFFFFFF);
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    bool threw = false;
+    try {
+        readDragDropPayload(readStream);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(threw, "Implausible icFileName length must be rejected, not allocated");
+}
+
+void TestDragDropPayload::testRejectsOversizedBlobName()
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << QPoint(0, 0);
+    stream << ElementType::IC;
+    stream << QStringLiteral("real_ic.panda");
+    stream << true;
+    stream << static_cast<quint32>(0x7FFFFFFF);
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    bool threw = false;
+    try {
+        readDragDropPayload(readStream);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(threw, "Implausible blobName length must be rejected, not allocated");
+}
+
+void TestDragDropPayload::testMissingOptionalFieldsDefaultGracefully()
+{
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << QPoint(1, 2);
+    stream << ElementType::And;
+    stream << QStringLiteral("legacy_payload.panda");
+    // Stream ends here — no isEmbedded/blobName, matching a pre-embedded-IC-support payload.
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    const auto payload = readDragDropPayload(readStream);
+
+    QCOMPARE(payload.icFileName, QStringLiteral("legacy_payload.panda"));
+    QCOMPARE(payload.isEmbedded, false);
+    QVERIFY(payload.blobName.isEmpty());
+}

--- a/Tests/Unit/Core/TestDragDropPayload.h
+++ b/Tests/Unit/Core/TestDragDropPayload.h
@@ -1,0 +1,23 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestDragDropPayload : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testRoundTrip();
+
+    // Regression: readDragDropPayload() used Qt's raw, unbounded QString
+    // deserialization for icFileName/blobName — a crafted drag-and-drop MIME
+    // payload (the drag source is not a trusted process) could trigger an
+    // OOM-sized QString::resize() before any validation.
+    void testRejectsOversizedIcFileName();
+    void testRejectsOversizedBlobName();
+    void testMissingOptionalFieldsDefaultGracefully();
+};

--- a/Tests/Unit/Core/TestUpdateChecker.cpp
+++ b/Tests/Unit/Core/TestUpdateChecker.cpp
@@ -3,6 +3,8 @@
 
 #include "Tests/Unit/Core/TestUpdateChecker.h"
 
+#include <QUrl>
+
 #include "App/Core/UpdateChecker.h"
 #include "Tests/Common/TestUtils.h"
 
@@ -83,4 +85,27 @@ void TestUpdateChecker::testAssetSelection()
     // the caller then falls back to the release page rather than a wrong binary.
     QVERIFY(!isMatchingReleaseAsset(linuxX86, "Linux", "ppc64"));
     QVERIFY(!isMatchingReleaseAsset(winX86, "Windows", "ppc64"));
+}
+
+void TestUpdateChecker::testSafeGitHubUrl()
+{
+    // Regression: browser_download_url/html_url from the GitHub API response were used for a
+    // network download + file write and QDesktopServices::openUrl with no scheme/host check.
+    // GitHub's release JSON only ever populates these fields as https://github.com/... — the
+    // CDN redirect happens only after fetching this URL, so its host never appears here.
+    QVERIFY(isSafeGitHubUrl(QUrl("https://github.com/gibis-unifesp/wiredpanda/releases/download/5.1.2/wiRedPanda.AppImage")));
+    QVERIFY(isSafeGitHubUrl(QUrl("https://github.com/gibis-unifesp/wiredpanda/releases/tag/5.1.2")));
+
+    // Wrong scheme: could otherwise have the app silently copy a local file into Downloads,
+    // or hand an unexpected URI scheme to the OS's protocol handler.
+    QVERIFY(!isSafeGitHubUrl(QUrl("file:///etc/passwd")));
+    QVERIFY(!isSafeGitHubUrl(QUrl("ftp://github.com/some/asset")));
+
+    // Lookalike hosts must not pass a substring/prefix check.
+    QVERIFY(!isSafeGitHubUrl(QUrl("https://github.com.evil.com/asset")));
+    QVERIFY(!isSafeGitHubUrl(QUrl("https://evil.com/github.com")));
+
+    // Invalid/empty URL.
+    QVERIFY(!isSafeGitHubUrl(QUrl()));
+    QVERIFY(!isSafeGitHubUrl(QUrl(QString())));
 }

--- a/Tests/Unit/Core/TestUpdateChecker.h
+++ b/Tests/Unit/Core/TestUpdateChecker.h
@@ -15,4 +15,5 @@ private slots:
     void testUpdateAvailable();
     void testNoUpdate();
     void testAssetSelection();
+    void testSafeGitHubUrl();
 };

--- a/Tests/Unit/Elements/TestAudioBox.cpp
+++ b/Tests/Unit/Elements/TestAudioBox.cpp
@@ -7,6 +7,7 @@
 
 #include <QDataStream>
 #include <QFile>
+#include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QTest>
 
@@ -407,4 +408,36 @@ void TestAudioBox::testSaveStoresFilenameOnlyInProjectDir()
     QVERIFY2(map.contains("audiobox"), "Saved data should contain 'audiobox' key");
     const QString savedPath = map.value("audiobox").toString();
     QCOMPARE(savedPath, tempInfo.fileName());
+}
+
+void TestAudioBox::testAudioSurvivesSaveLoadRoundTripWhenNotColocated()
+{
+    // Mirrors what UpdateCommand's undo/redo does for an unrelated property edit (e.g.
+    // dragging the volume slider): save() the just-applied state, then load() it right
+    // back — entirely in memory, regardless of whether the project has ever been saved.
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString audioPath = tempDir.filePath("custom_audio.wav");
+    QVERIFY(QFile::copy(":/Components/Output/Audio/wiredpanda.wav", audioPath));
+
+    auto audioBox1 = std::make_unique<AudioBox>();
+    audioBox1->setAudio(audioPath);
+
+    QByteArray data;
+    QDataStream saveStream(&data, QIODevice::WriteOnly);
+    audioBox1->save(saveStream);
+
+    auto audioBox2 = std::make_unique<AudioBox>();
+    QDataStream loadStream(data);
+    QHash<quint64, Port *> portMap;
+    SerializationContext context = {portMap, FormatRev::current, {}};
+
+    bool threw = false;
+    try {
+        audioBox2->load(loadStream, context);
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+
+    QVERIFY2(!threw, "a custom audio file not yet colocated with any project must survive an in-memory save/load round trip");
 }

--- a/Tests/Unit/Elements/TestAudioBox.h
+++ b/Tests/Unit/Elements/TestAudioBox.h
@@ -48,4 +48,5 @@ private slots:
     void testSetAudioWithForeignAbsolutePathMixedSlashes();
     void testSetAudioWithNonExistentFileFallback();
     void testSaveStoresFilenameOnlyInProjectDir();
+    void testAudioSurvivesSaveLoadRoundTripWhenNotColocated();
 };

--- a/Tests/Unit/Elements/TestBuzzer.cpp
+++ b/Tests/Unit/Elements/TestBuzzer.cpp
@@ -3,6 +3,7 @@
 
 #include "Tests/Unit/Elements/TestBuzzer.h"
 
+#include <limits>
 #include <memory>
 
 #include <QDataStream>
@@ -74,6 +75,44 @@ void TestBuzzer::testSetFrequency()
 
     buzzer.setFrequency(2000.0);
     QCOMPARE(buzzer.frequency(), 2000.0);
+}
+
+void TestBuzzer::testSetFrequencyRejectsNaN()
+{
+    Buzzer buzzer;
+    buzzer.setFrequency(880.0);
+    QCOMPARE(buzzer.frequency(), 880.0);
+
+    // NaN must be rejected, not stored — ToneGenerator::readData() casts a NaN-derived
+    // sample to qint16, which is undefined behaviour.
+    buzzer.setFrequency(std::numeric_limits<double>::quiet_NaN());
+    QCOMPARE(buzzer.frequency(), 880.0);
+}
+
+void TestBuzzer::testSetFrequencyRejectsInfinity()
+{
+    Buzzer buzzer;
+    buzzer.setFrequency(880.0);
+    QCOMPARE(buzzer.frequency(), 880.0);
+
+    buzzer.setFrequency(std::numeric_limits<double>::infinity());
+    QCOMPARE(buzzer.frequency(), 880.0);
+
+    buzzer.setFrequency(-std::numeric_limits<double>::infinity());
+    QCOMPARE(buzzer.frequency(), 880.0);
+}
+
+void TestBuzzer::testSetFrequencyRejectsZeroAndNegative()
+{
+    Buzzer buzzer;
+    buzzer.setFrequency(880.0);
+    QCOMPARE(buzzer.frequency(), 880.0);
+
+    buzzer.setFrequency(0.0);
+    QCOMPARE(buzzer.frequency(), 880.0);
+
+    buzzer.setFrequency(-100.0);
+    QCOMPARE(buzzer.frequency(), 880.0);
 }
 
 void TestBuzzer::testSetAudioBackwardCompat()

--- a/Tests/Unit/Elements/TestBuzzer.h
+++ b/Tests/Unit/Elements/TestBuzzer.h
@@ -20,6 +20,13 @@ private slots:
     void testSetFrequency();
     void testSetAudioBackwardCompat();
 
+    // Regression: setFrequency() must reject non-finite/non-positive values (the base
+    // GraphicElement::setFrequency() is a no-op, so Buzzer must guard itself, mirroring
+    // Clock::setFrequency()'s identical guard for the same untrusted-value class).
+    void testSetFrequencyRejectsNaN();
+    void testSetFrequencyRejectsInfinity();
+    void testSetFrequencyRejectsZeroAndNegative();
+
     // Playback control tests
     void testPlayStopTransition();
     void testPlayIdempotency();

--- a/Tests/Unit/Elements/TestClock.cpp
+++ b/Tests/Unit/Elements/TestClock.cpp
@@ -334,6 +334,33 @@ void TestClock::testUpdateClock()
     QVERIFY(clock.isOn());
 }
 
+void TestClock::testUpdateClockLargeBacklogResyncsInsteadOfBursting()
+{
+    // Regression: a large elapsed gap (e.g. the OS suspended the process while the
+    // simulation's QTimer stayed "active") used to be replayed as one toggle per subsequent
+    // updateClock() call until caught up — for a long-enough gap, thousands of rapid toggles.
+    // updateClock() must instead resync immediately, on the very first call after the gap,
+    // exactly like Simulation::start()'s explicit resetClock() already does for the
+    // stop/start case.
+    Clock clock;
+    clock.setFrequency(1.0); // 500ms half-period
+
+    const auto t0 = std::chrono::steady_clock::now();
+    clock.resetClock(t0);
+    QVERIFY(clock.isOn());
+
+    // Simulate a huge backlog: far beyond the resync threshold.
+    const auto hugeGap = t0 + std::chrono::hours(1);
+    clock.updateClock(hugeGap);
+    const bool stateAfterFirstCall = clock.isOn();
+
+    // If updateClock() resynced (the fix), its new internal time reference is now close to
+    // hugeGap, so a second call at the SAME timestamp is a no-op. If it instead single-stepped
+    // (the pre-fix behavior), it would still be far behind hugeGap and would toggle again.
+    clock.updateClock(hugeGap);
+    QCOMPARE(clock.isOn(), stateAfterFirstCall);
+}
+
 // ============================================================================
 // Serialization Tests
 // ============================================================================

--- a/Tests/Unit/Elements/TestClock.h
+++ b/Tests/Unit/Elements/TestClock.h
@@ -39,6 +39,7 @@ private slots:
     // Timing tests
     void testResetClock();
     void testUpdateClock();
+    void testUpdateClockLargeBacklogResyncsInsteadOfBursting();
 
     // Serialization tests
     void testSaveFrequencyDelay();

--- a/Tests/Unit/Elements/TestClocksAdvanced.cpp
+++ b/Tests/Unit/Elements/TestClocksAdvanced.cpp
@@ -3,6 +3,7 @@
 
 #include "Tests/Unit/Elements/TestClocksAdvanced.h"
 
+#include <chrono>
 #include <memory>
 
 #include "App/Element/ElementFactory.h"
@@ -68,16 +69,25 @@ void TestClocksAdvanced::testClockFrequencyEdgeCases()
 
 void TestClocksAdvanced::testClockTimingPrecision()
 {
-    // Test clock timing precision - verify frequency can be set and retrieved
-    auto clock = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    // Verify the clock's actual tick timing (not just that setFrequency()/frequency()
+    // round-trip): the first toggle must happen at, not before or long after, the configured
+    // half-period.
+    auto element = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto *clock = qobject_cast<Clock *>(element.get());
     QVERIFY(clock != nullptr);
 
-    // Set frequency and verify retrieval
-    clock->setFrequency(33.33);
-    QVERIFY(qFuzzyCompare(clock->frequency(), 33.33));
+    clock->setFrequency(10.0); // 50ms half-period
+    const auto t0 = std::chrono::steady_clock::now();
+    clock->resetClock(t0);
+    const bool initialState = clock->isOn();
 
-    clock->setFrequency(66.67);
-    QVERIFY(qFuzzyCompare(clock->frequency(), 66.67));
+    // Just before the half-period: must not have toggled yet.
+    clock->updateClock(t0 + std::chrono::milliseconds(49));
+    QCOMPARE(clock->isOn(), initialState);
+
+    // Just after the half-period: must have toggled exactly once.
+    clock->updateClock(t0 + std::chrono::milliseconds(51));
+    QCOMPARE(clock->isOn(), !initialState);
 }
 
 void TestClocksAdvanced::testClockSilentRejectionForExtremeFrequencies()
@@ -134,59 +144,149 @@ void TestClocksAdvanced::testTwoClocksDifferentFrequencies()
 
 void TestClocksAdvanced::testThreeClocksConcurrentExecution()
 {
-    // Test three clocks running simultaneously
-    auto clock1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
-    auto clock2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
-    auto clock3 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    // Verify three clocks with different frequencies tick independently and correctly when
+    // driven together, not just that setFrequency()/frequency() round-trip. Rather than
+    // hardcoding expected toggle counts (fragile to the strict-inequality boundary effect in
+    // Clock::updateClock()), compare each clock's toggle count when ticked together against
+    // its own toggle count when ticked in isolation over the identical timestamp sequence —
+    // concurrent execution must not perturb any clock's independent timing.
+    auto countToggles = [](Clock *clock, std::chrono::steady_clock::time_point t0, int durationMs) {
+        clock->resetClock(t0);
+        bool prev = clock->isOn();
+        int toggles = 0;
+        for (int ms = 1; ms <= durationMs; ++ms) {
+            clock->updateClock(t0 + std::chrono::milliseconds(ms));
+            if (clock->isOn() != prev) { ++toggles; prev = clock->isOn(); }
+        }
+        return toggles;
+    };
 
-    QVERIFY(clock1 != nullptr);
-    QVERIFY(clock2 != nullptr);
-    QVERIFY(clock3 != nullptr);
+    auto element1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto element2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto element3 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto *clock1 = qobject_cast<Clock *>(element1.get());
+    auto *clock2 = qobject_cast<Clock *>(element2.get());
+    auto *clock3 = qobject_cast<Clock *>(element3.get());
+    QVERIFY(clock1 && clock2 && clock3);
 
-    // Set different frequencies
     clock1->setFrequency(1.0);
     clock2->setFrequency(10.0);
     clock3->setFrequency(100.0);
 
-    // All frequencies should be independently maintained
-    QCOMPARE(clock1->frequency(), 1.0);
-    QCOMPARE(clock2->frequency(), 10.0);
-    QCOMPARE(clock3->frequency(), 100.0);
+    const auto t0 = std::chrono::steady_clock::now();
+    constexpr int kDurationMs = 1000;
+
+    // Baseline: each clock's own toggle count when ticked in isolation.
+    const int isolated1 = countToggles(clock1, t0, kDurationMs);
+    const int isolated2 = countToggles(clock2, t0, kDurationMs);
+    const int isolated3 = countToggles(clock3, t0, kDurationMs);
+    QVERIFY(isolated1 > 0);
+    QVERIFY(isolated2 > isolated1);
+    QVERIFY(isolated3 > isolated2);
+
+    // Now reset and re-run all three TOGETHER, ticked at every 1ms mark simultaneously
+    // (mirrors the real simulation's tick cadence) — each must toggle exactly as many times
+    // as it did in isolation.
+    clock1->resetClock(t0);
+    clock2->resetClock(t0);
+    clock3->resetClock(t0);
+    bool prev1 = clock1->isOn(), prev2 = clock2->isOn(), prev3 = clock3->isOn();
+    int together1 = 0, together2 = 0, together3 = 0;
+    for (int ms = 1; ms <= kDurationMs; ++ms) {
+        const auto t = t0 + std::chrono::milliseconds(ms);
+        clock1->updateClock(t);
+        clock2->updateClock(t);
+        clock3->updateClock(t);
+        if (clock1->isOn() != prev1) { ++together1; prev1 = clock1->isOn(); }
+        if (clock2->isOn() != prev2) { ++together2; prev2 = clock2->isOn(); }
+        if (clock3->isOn() != prev3) { ++together3; prev3 = clock3->isOn(); }
+    }
+
+    QCOMPARE(together1, isolated1);
+    QCOMPARE(together2, isolated2);
+    QCOMPARE(together3, isolated3);
 }
 
 void TestClocksAdvanced::testClockSynchronizationEdgeCases()
 {
-    // Test clock synchronization edge cases
-    auto clock1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
-    auto clock2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    // Verify actual synchronization behavior, not just that frequency values compare equal.
+    auto element1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto element2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto *clock1 = qobject_cast<Clock *>(element1.get());
+    auto *clock2 = qobject_cast<Clock *>(element2.get());
+    QVERIFY(clock1 && clock2);
 
-    QVERIFY(clock1 != nullptr);
-    QVERIFY(clock2 != nullptr);
-
-    // Set same frequency
     clock1->setFrequency(50.0);
     clock2->setFrequency(50.0);
 
-    QCOMPARE(clock1->frequency(), clock2->frequency());
+    const auto t0 = std::chrono::steady_clock::now();
+    clock1->resetClock(t0);
+    clock2->resetClock(t0);
 
-    // Modify one
-    clock1->setFrequency(60.0);
-    QVERIFY(!qFuzzyCompare(clock1->frequency(), clock2->frequency()));
+    // Two identically-configured clocks reset at the same instant must stay in phase —
+    // toggling in lockstep — across several ticks.
+    for (int ms = 1; ms <= 100; ++ms) {
+        const auto t = t0 + std::chrono::milliseconds(ms);
+        clock1->updateClock(t);
+        clock2->updateClock(t);
+        QCOMPARE(clock1->isOn(), clock2->isOn());
+    }
+
+    // A clock with a phase delay must NOT stay in lockstep with an in-phase clock.
+    auto element3 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto *clock3 = qobject_cast<Clock *>(element3.get());
+    QVERIFY(clock3 != nullptr);
+    clock3->setFrequency(50.0);
+    clock3->setDelay(0.5); // half a full period — exactly one half-period out of phase
+    clock3->resetClock(t0);
+
+    bool everDiverged = false;
+    for (int ms = 1; ms <= 100; ++ms) {
+        const auto t = t0 + std::chrono::milliseconds(ms);
+        clock1->updateClock(t);
+        clock3->updateClock(t);
+        if (clock1->isOn() != clock3->isOn()) {
+            everDiverged = true;
+        }
+    }
+    QVERIFY2(everDiverged, "A clock with a phase delay must diverge from an in-phase clock at some point");
 }
 
 void TestClocksAdvanced::testMultiClockPhaseRelationships()
 {
-    // Test phase relationships between multiple clocks
-    auto clock1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
-    auto clock2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    // Verify a genuine ~2:1 toggle-count ratio between two clocks in a 2:1 frequency ratio,
+    // ticked together across many periods of both — not just that the frequency values
+    // themselves divide to 2.0.
+    auto element1 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto element2 = std::unique_ptr<GraphicElement>(ElementFactory::buildElement(ElementType::Clock));
+    auto *clock1 = qobject_cast<Clock *>(element1.get());
+    auto *clock2 = qobject_cast<Clock *>(element2.get());
+    QVERIFY(clock1 && clock2);
 
-    QVERIFY(clock1 != nullptr);
-    QVERIFY(clock2 != nullptr);
+    clock1->setFrequency(100.0); // 5ms half-period
+    clock2->setFrequency(50.0);  // 10ms half-period — half of clock1's frequency
 
-    // Set frequencies in ratio
-    clock1->setFrequency(100.0);  // 100 Hz
-    clock2->setFrequency(50.0);   // 50 Hz (half of clock1)
+    const auto t0 = std::chrono::steady_clock::now();
+    clock1->resetClock(t0);
+    clock2->resetClock(t0);
 
-    // Verify ratio is maintained
-    QCOMPARE(clock1->frequency() / clock2->frequency(), 2.0);
+    int toggles1 = 0, toggles2 = 0;
+    bool prev1 = clock1->isOn(), prev2 = clock2->isOn();
+    // Many periods of both, so the strict-inequality boundary effect at the start/end of the
+    // window is negligible relative to the total count.
+    constexpr int kDurationMs = 2000;
+    for (int ms = 1; ms <= kDurationMs; ++ms) {
+        const auto t = t0 + std::chrono::milliseconds(ms);
+        clock1->updateClock(t);
+        clock2->updateClock(t);
+        if (clock1->isOn() != prev1) { ++toggles1; prev1 = clock1->isOn(); }
+        if (clock2->isOn() != prev2) { ++toggles2; prev2 = clock2->isOn(); }
+    }
+
+    QVERIFY(toggles1 > 0);
+    QVERIFY(toggles2 > 0);
+    const double ratio = static_cast<double>(toggles1) / static_cast<double>(toggles2);
+    QVERIFY2(ratio > 1.8 && ratio < 2.2,
+             qPrintable(QString("Expected ~2:1 toggle ratio, got %1:%2 (ratio %3)")
+                            .arg(toggles1).arg(toggles2).arg(ratio)));
 }

--- a/Tests/Unit/Elements/TestICRegistry.cpp
+++ b/Tests/Unit/Elements/TestICRegistry.cpp
@@ -3,9 +3,37 @@
 
 #include "Tests/Unit/Elements/TestICRegistry.h"
 
+#include <QDataStream>
+#include <QFile>
+#include <QRectF>
+#include <QTemporaryDir>
+
+#include "App/IO/Serialization.h"
 #include "App/Scene/ICRegistry.h"
+#include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
 #include "Tests/Common/TestUtils.h"
+
+namespace {
+// Writes a minimal .panda file: header + a metadata map referencing \a nextDep (if non-empty)
+// as a file-backed IC dependency. Mirrors TestSerialization.cpp's writePandaWithFileBackedIC —
+// just enough for makeBlobSelfContained()/copyPandaFile() to traverse.
+void writeChainedPandaFile(const QString &path, const QString &nextDep)
+{
+    QFile out(path);
+    QVERIFY(out.open(QIODevice::WriteOnly));
+    QDataStream stream(&out);
+    Serialization::writePandaHeader(stream);
+
+    QMap<QString, QVariant> metadata;
+    metadata["dolphinFileName"] = QString();
+    metadata["sceneRect"] = QRectF();
+    if (!nextDep.isEmpty()) {
+        metadata["fileBackedICs"] = QStringList{nextDep};
+    }
+    stream << metadata;
+}
+} // namespace
 
 void TestICRegistry::testICRegistration()
 {
@@ -23,9 +51,62 @@ void TestICRegistry::testICFileWatcher()
 
 void TestICRegistry::testRecursiveICLoading()
 {
+    // A short, legitimate dependency chain (root -> dep1 -> dep2, well under the
+    // nesting cap) must still resolve successfully, not be rejected.
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    writeChainedPandaFile(dir.filePath("dep2.panda"), QString());
+    writeChainedPandaFile(dir.filePath("dep1.panda"), "dep2.panda");
+    writeChainedPandaFile(dir.filePath("root.panda"), "dep1.panda");
+
     WorkSpace workspace;
-    ICRegistry registry(workspace.scene());
-    QVERIFY(registry.blobMap().isEmpty());
+    workspace.scene()->setContextDir(dir.path());
+    ICRegistry *registry = workspace.scene()->icRegistry();
+
+    QFile rootFile(dir.filePath("root.panda"));
+    QVERIFY(rootFile.open(QIODevice::ReadOnly));
+    const QByteArray rootBytes = rootFile.readAll();
+
+    bool threw = false;
+    try {
+        registry->registerBlob("root", rootBytes);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(!threw, "A short, legitimate dependency chain must not be rejected");
+    QVERIFY(registry->hasBlob("root"));
+}
+
+void TestICRegistry::testMakeBlobSelfContainedRejectsDeepDependencyChain()
+{
+    // A long but non-cyclic chain of distinct dependency files (each real, on disk,
+    // never repeated) must be rejected once it exceeds the nesting depth cap, instead
+    // of recursing until the call stack is exhausted.
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    constexpr int chainLength = 20; // > ICRegistry::kMaxBlobNestingDepth (16)
+    for (int i = 0; i < chainLength; ++i) {
+        const QString nextDep = (i + 1 < chainLength) ? QString("dep%1.panda").arg(i + 1) : QString();
+        writeChainedPandaFile(dir.filePath(QString("dep%1.panda").arg(i)), nextDep);
+    }
+
+    WorkSpace workspace;
+    workspace.scene()->setContextDir(dir.path());
+    ICRegistry *registry = workspace.scene()->icRegistry();
+
+    QFile firstFile(dir.filePath("dep0.panda"));
+    QVERIFY(firstFile.open(QIODevice::ReadOnly));
+    const QByteArray firstBytes = firstFile.readAll();
+
+    bool threw = false;
+    try {
+        registry->registerBlob("dep0", firstBytes);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(threw, "A dependency chain deeper than kMaxBlobNestingDepth must be rejected, not stack-overflow");
 }
 
 void TestICRegistry::testICValidation()

--- a/Tests/Unit/Elements/TestICRegistry.h
+++ b/Tests/Unit/Elements/TestICRegistry.h
@@ -16,4 +16,8 @@ private slots:
     void testICFileWatcher();
     void testRecursiveICLoading();
     void testICValidation();
+
+    // Regression: makeBlobSelfContained() only had cycle detection, no recursion depth
+    // cap, unlike ICLoader's identical-purpose kMaxICNestingDepth guard.
+    void testMakeBlobSelfContainedRejectsDeepDependencyChain();
 };

--- a/Tests/Unit/Elements/TestInputElements.cpp
+++ b/Tests/Unit/Elements/TestInputElements.cpp
@@ -647,3 +647,51 @@ void TestInputElements::testAppearanceWithNonExistentFileFallback()
 
     QVERIFY2(threw, "setAppearance should throw when neither full path nor filename fallback resolves");
 }
+
+void TestInputElements::testAppearanceReloadsAfterFileModified()
+{
+    // Regression: ElementAppearance used to keep its own base-pixmap cache keyed on the bare
+    // resolved path, so a *different* element loading the same path after the file's content
+    // changed on disk (e.g. a fresh element, or a reopened project) kept serving the stale,
+    // first-loaded pixmap out of that cache. setPixmap() now relies entirely on
+    // QPixmap::load()'s own internal caching, which keys on path + mtime + size, so a genuinely
+    // different file at the same path is picked up. Uses two separate elements rather than
+    // re-setting the same path twice on one element, since setPixmap() already short-circuits
+    // a same-path re-set on the *same* element (a different, unrelated optimization) — the bug
+    // this guards against is about a fresh load seeing stale cross-element cache data, not
+    // about redundant re-sets on one element. Sizes with different digit counts (9 vs 200) so
+    // the two files differ in byte length too — Qt's own load() cache keys on path + mtime +
+    // size, and two writes landing within the same filesystem mtime tick would otherwise defeat
+    // the test by coincidence if both files happened to be the same size.
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString path = tempDir.path() + "/reloadable.svg";
+
+    WorkSpace workspace;
+    workspace.scene()->setContextDir(tempDir.path());
+
+    auto writeSvg = [](const QString &filePath, int side) {
+        QFile file(filePath);
+        QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        const QByteArray svg = QString("<svg xmlns=\"http://www.w3.org/2000/svg\" "
+                                        "width=\"%1\" height=\"%1\"><rect width=\"%1\" height=\"%1\" "
+                                        "fill=\"red\"/></svg>").arg(side).toUtf8();
+        QCOMPARE(file.write(svg), svg.size());
+    };
+
+    writeSvg(path, 9);
+    auto *firstSwitch = new InputSwitch();
+    workspace.scene()->addItem(firstSwitch);
+    firstSwitch->setAppearance(false, path);
+    const QSizeF firstSize = firstSwitch->boundingRect().size();
+
+    writeSvg(path, 200);
+    auto *secondSwitch = new InputSwitch();
+    workspace.scene()->addItem(secondSwitch);
+    secondSwitch->setAppearance(false, path);
+    const QSizeF secondSize = secondSwitch->boundingRect().size();
+
+    QVERIFY2(firstSize != secondSize,
+             "A fresh element loading the same path after the file changed on disk must not "
+             "reuse another element's stale cached pixmap");
+}

--- a/Tests/Unit/Elements/TestInputElements.h
+++ b/Tests/Unit/Elements/TestInputElements.h
@@ -49,4 +49,5 @@ private slots:
     void testAppearanceWithForeignAbsolutePathBackslash();
     void testAppearanceWithForeignAbsolutePathMixedSlashes();
     void testAppearanceWithNonExistentFileFallback();
+    void testAppearanceReloadsAfterFileModified();
 };

--- a/Tests/Unit/Elements/TestLed.cpp
+++ b/Tests/Unit/Elements/TestLed.cpp
@@ -7,8 +7,10 @@
 
 #include <QDataStream>
 #include <QFile>
+#include <QTemporaryDir>
 #include <QTest>
 
+#include "App/Core/Common.h"
 #include "App/Element/GraphicElements/Led.h"
 #include "App/IO/SerializationContext.h"
 #include "App/Scene/Scene.h"
@@ -517,8 +519,92 @@ void TestLED::testSetAppearanceDefault()
     // Restore default appearance
     led.setAppearance(true, {});
     QVERIFY(true);
+}
 
-    // Set custom appearance (non-existent file is fine — just stores the path)
-    led.setAppearance(false, "/tmp/custom_led.png");
-    QVERIFY(true);
+void TestLED::testSetAppearanceWithAbsolutePathNoContextDir()
+{
+    // A freshly picked, existing, absolute path must apply directly even when the element
+    // has no scene/contextDir at all (e.g. before the project has ever been saved).
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString imagePath = tempDir.path() + "/custom_led.svg";
+    QVERIFY(QFile::copy(":/Components/Output/Led/WhiteLed.svg", imagePath));
+
+    Led led;
+    bool threw = false;
+    try {
+        led.setAppearance(false, imagePath);
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+
+    QVERIFY2(!threw, "setAppearance should resolve an existing absolute path directly even with no contextDir");
+}
+
+void TestLED::testSetAppearanceWithNonExistentFileThrows()
+{
+    Led led;
+
+    bool threw = false;
+    try {
+        led.setAppearance(false, "/tmp/nonexistent_custom_led_98765.png");
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+
+    QVERIFY2(threw, "setAppearance should throw when the absolute path does not exist");
+}
+
+void TestLED::testSetAppearanceRepeatedFailureThrowsOnce()
+{
+    Led led;
+    const QString badPath = "/tmp/nonexistent_custom_led_98765.png";
+
+    bool threwFirst = false;
+    try {
+        led.setAppearance(false, badPath);
+    } catch (const Pandaception &) {
+        threwFirst = true;
+    }
+
+    bool threwSecond = false;
+    try {
+        led.setAppearance(false, badPath);
+    } catch (const Pandaception &) {
+        threwSecond = true;
+    }
+
+    QVERIFY2(threwFirst, "the first attempt at a broken path should throw");
+    QVERIFY2(!threwSecond, "repeating the exact same broken path should not re-throw");
+}
+
+void TestLED::testAppearanceSurvivesSaveLoadRoundTripWhenNotColocated()
+{
+    // Mirrors what UpdateCommand's undo/redo does: save() the just-applied state, then
+    // load() it right back — entirely in memory, before the project is ever saved to disk.
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString imagePath = tempDir.path() + "/custom_led.svg";
+    QVERIFY(QFile::copy(":/Components/Output/Led/WhiteLed.svg", imagePath));
+
+    auto led1 = std::make_unique<Led>();
+    led1->setAppearance(false, imagePath);
+
+    QByteArray data;
+    QDataStream saveStream(&data, QIODevice::WriteOnly);
+    led1->save(saveStream);
+
+    auto led2 = std::make_unique<Led>();
+    QDataStream loadStream(data);
+    QHash<quint64, Port *> portMap;
+    SerializationContext context = {portMap, QVersionNumber(4, 1), {}};
+
+    bool threw = false;
+    try {
+        led2->load(loadStream, context);
+    } catch (const Pandaception &) {
+        threw = true;
+    }
+
+    QVERIFY2(!threw, "a custom appearance not yet colocated with any project must survive an in-memory save/load round trip");
 }

--- a/Tests/Unit/Elements/TestLed.h
+++ b/Tests/Unit/Elements/TestLed.h
@@ -47,4 +47,8 @@ private slots:
     // Appearance tests
     void testAppearanceStates();
     void testSetAppearanceDefault();
+    void testSetAppearanceWithAbsolutePathNoContextDir();
+    void testSetAppearanceWithNonExistentFileThrows();
+    void testSetAppearanceRepeatedFailureThrowsOnce();
+    void testAppearanceSurvivesSaveLoadRoundTripWhenNotColocated();
 };

--- a/Tests/Unit/Exercise/TestExerciseEngine.cpp
+++ b/Tests/Unit/Exercise/TestExerciseEngine.cpp
@@ -119,3 +119,40 @@ void TestExerciseEngine::testRetranslateEmitsRetranslatedOnly()
 
     Settings::setLanguage(originalLang);
 }
+
+void TestExerciseEngine::testNegativeMinCountClampsToZero()
+{
+    // Regression: a negative minCount (typo'd or malicious custom exercise JSON — Exercise/Tour
+    // content is end-user-writable) silently auto-satisfied "count < minCount" since any
+    // non-negative count is always >= a negative number, permanently skipping the check.
+    const char *const json = R"({
+        "id": "test-negative-mincount",
+        "title": "Test",
+        "steps": [
+            {
+                "key": "step0",
+                "instruction": "Instruction",
+                "requiredElements": [ { "type": "And", "minCount": -5 } ],
+                "requiredConnections": [ { "fromType": "And", "toType": "Or", "minCount": -3 } ]
+            }
+        ]
+    })";
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.filePath("negative_mincount.json");
+    {
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write(json);
+    }
+
+    ExerciseEngine engine;
+    QVERIFY(engine.loadFromResource(path));
+
+    const ExerciseStep &step = engine.currentStepData();
+    QCOMPARE(step.requiredElements.size(), 1);
+    QCOMPARE(step.requiredElements[0].minCount, 0);
+    QCOMPARE(step.requiredConnections.size(), 1);
+    QCOMPARE(step.requiredConnections[0].minCount, 0);
+}

--- a/Tests/Unit/Exercise/TestExerciseEngine.h
+++ b/Tests/Unit/Exercise/TestExerciseEngine.h
@@ -15,4 +15,5 @@ private slots:
     void testRetranslateWhileInactiveIsNoOp();
     void testRetranslatePreservesProgressAndData();
     void testRetranslateEmitsRetranslatedOnly();
+    void testNegativeMinCountClampsToZero();
 };

--- a/Tests/Unit/MCP/TestFileHandlerSecurity.cpp
+++ b/Tests/Unit/MCP/TestFileHandlerSecurity.cpp
@@ -1,0 +1,62 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/MCP/TestFileHandlerSecurity.h"
+
+#include <QImage>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTemporaryDir>
+
+#include "App/Element/GraphicElements/InputSwitch.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/UI/CircuitExporter.h"
+#include "App/UI/MainWindow.h"
+#include "MCP/Server/Handlers/FileHandler.h"
+
+void TestFileHandlerSecurity::testExportImagePngClampsExtremeSceneDimensions()
+{
+    MainWindow window;
+    auto *sw = new InputSwitch();
+    window.currentTab()->scene()->addItem(sw);
+    sw->setPos(1e9, 1e9);
+
+    FileHandler handler(&window, nullptr);
+
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString path = tmpDir.path() + "/extreme.png";
+
+    const QJsonObject params{{"filename", path}, {"format", "png"}};
+    const QJsonObject response = handler.handleCommand("export_image", params, {});
+    QVERIFY2(response.contains("result"), qPrintable(QJsonDocument(response).toJson()));
+
+    QImage image(path);
+    QVERIFY(!image.isNull());
+    QVERIFY(image.width() <= CircuitExporter::kMaxImageDimension);
+    QVERIFY(image.height() <= CircuitExporter::kMaxImageDimension);
+}
+
+void TestFileHandlerSecurity::testExportImageClampsExcessivePadding()
+{
+    MainWindow window;
+    window.currentTab()->scene()->addItem(new InputSwitch());
+
+    FileHandler handler(&window, nullptr);
+
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString path = tmpDir.path() + "/padded.png";
+
+    // Pre-fix, this unclamped padding value was applied directly to sceneRect before sizing
+    // the output buffer — a client could blow up even a trivial circuit through padding alone.
+    const QJsonObject params{{"filename", path}, {"format", "png"}, {"padding", 2000000000}};
+    const QJsonObject response = handler.handleCommand("export_image", params, {});
+    QVERIFY2(response.contains("result"), qPrintable(QJsonDocument(response).toJson()));
+
+    QImage image(path);
+    QVERIFY(!image.isNull());
+    QVERIFY(image.width() <= CircuitExporter::kMaxImageDimension);
+    QVERIFY(image.height() <= CircuitExporter::kMaxImageDimension);
+}

--- a/Tests/Unit/MCP/TestFileHandlerSecurity.h
+++ b/Tests/Unit/MCP/TestFileHandlerSecurity.h
@@ -1,0 +1,20 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+/// Regression coverage for MCP/Server/Handlers/FileHandler.cpp hardening found in a
+/// ninth-pass audit: export_image's PNG branch previously re-implemented (and never
+/// bounded) CircuitExporter's now-fixed unbounded-buffer allocation, and its "padding"
+/// parameter was accepted with no upper bound.
+class TestFileHandlerSecurity : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testExportImagePngClampsExtremeSceneDimensions();
+    void testExportImageClampsExcessivePadding();
+};

--- a/Tests/Unit/MCP/TestICHandlerSecurity.cpp
+++ b/Tests/Unit/MCP/TestICHandlerSecurity.cpp
@@ -1,0 +1,166 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/MCP/TestICHandlerSecurity.h"
+
+#include <QDataStream>
+#include <QDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTemporaryDir>
+
+#include "App/Element/GraphicElements/InputSwitch.h"
+#include "App/Element/GraphicElements/Led.h"
+#include "App/IO/Serialization.h"
+#include "App/Scene/ICRegistry.h"
+#include "App/Scene/Scene.h"
+#include "App/Scene/Workspace.h"
+#include "App/UI/MainWindow.h"
+#include "MCP/Server/Handlers/ICHandler.h"
+
+namespace {
+
+/// Writes a minimal, valid, loadable IC fixture (one switch, one LED) to \a path.
+void writeLeafIcFixture(const QString &path)
+{
+    WorkSpace ws;
+    ws.scene()->addItem(new InputSwitch());
+    ws.scene()->addItem(new Led());
+    QFile file(path);
+    QVERIFY2(file.open(QIODevice::WriteOnly), qPrintable(path));
+    QDataStream stream(&file);
+    Serialization::writePandaHeader(stream);
+    ws.save(stream);
+}
+
+/// Returns minimal, valid, self-contained panda bytes (one switch, one LED) — registerBlob()
+/// parses these via makeBlobSelfContained() to inline nested dependencies, so garbage bytes
+/// abort the whole test process rather than failing gracefully.
+QByteArray leafIcBytes()
+{
+    WorkSpace ws;
+    ws.scene()->addItem(new InputSwitch());
+    ws.scene()->addItem(new Led());
+    QByteArray bytes;
+    QDataStream stream(&bytes, QIODevice::WriteOnly);
+    Serialization::writePandaHeader(stream);
+    ws.save(stream);
+    return bytes;
+}
+
+} // namespace
+
+void TestICHandlerSecurity::testEmbedIcRejectsPathTraversalBlobName()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString icFileName = "leaf_ic";
+    writeLeafIcFixture(tmpDir.path() + "/" + icFileName + ".panda");
+
+    const QString projectPath = tmpDir.path() + "/project.panda";
+    WorkSpace().save(projectPath);
+
+    MainWindow window;
+    window.loadPandaFile(projectPath);
+    ICHandler handler(&window, nullptr);
+
+    const QJsonObject instParams{{"ic_name", icFileName}, {"x", 0}, {"y", 0}};
+    const QJsonObject instResponse = handler.handleCommand("instantiate_ic", instParams, {});
+    QVERIFY2(instResponse.contains("result"), qPrintable(QJsonDocument(instResponse).toJson()));
+    const int elementId = instResponse["result"].toObject()["element_id"].toInt();
+
+    const QJsonObject embedParams{{"element_id", elementId}, {"blob_name", "../../evil"}};
+    const QJsonObject embedResponse = handler.handleCommand("embed_ic", embedParams, {});
+    QVERIFY(embedResponse.contains("error"));
+    QVERIFY(!window.currentTab()->scene()->icRegistry()->hasBlob("../../evil"));
+}
+
+void TestICHandlerSecurity::testInstantiateIcInlineRejectsPathTraversalBlobName()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString icFileName = "leaf_ic2";
+    writeLeafIcFixture(tmpDir.path() + "/" + icFileName + ".panda");
+
+    const QString projectPath = tmpDir.path() + "/project.panda";
+    WorkSpace().save(projectPath);
+
+    MainWindow window;
+    window.loadPandaFile(projectPath);
+    ICHandler handler(&window, nullptr);
+
+    const QJsonObject params{
+        {"ic_name", icFileName}, {"x", 0}, {"y", 0}, {"inline", true}, {"blob_name", "../../evil"}};
+    const QJsonObject response = handler.handleCommand("instantiate_ic", params, {});
+    QVERIFY2(response.contains("error"), qPrintable(QJsonDocument(response).toJson()));
+    QVERIFY(!window.currentTab()->scene()->icRegistry()->hasBlob("../../evil"));
+}
+
+void TestICHandlerSecurity::testExtractIcConfinesFileNameToProjectDirectory()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString projectPath = tmpDir.path() + "/project.panda";
+    WorkSpace().save(projectPath);
+
+    MainWindow window;
+    window.loadPandaFile(projectPath);
+    ICHandler handler(&window, nullptr);
+
+    // No IC in the scene references this blob, so extractToFile() never re-parses it after
+    // writing — it only needs to exist for hasBlob() to pass while the confinement check
+    // (which runs first) is exercised.
+    window.currentTab()->scene()->icRegistry()->registerBlob("mytest", leafIcBytes());
+
+    // Relative traversal escaping the project directory.
+    const QJsonObject traversalParams{{"blob_name", "mytest"}, {"file_name", "../evil.panda"}};
+    const QJsonObject traversalResponse = handler.handleCommand("extract_ic", traversalParams, {});
+    QVERIFY(traversalResponse.contains("error"));
+    QVERIFY(!QFile::exists(QDir::cleanPath(tmpDir.path() + "/../evil.panda")));
+
+    // Absolute path escaping the project directory outright.
+    const QString outsidePath = QDir::cleanPath(tmpDir.path() + "/../outside_evil.panda");
+    const QJsonObject absoluteParams{{"blob_name", "mytest"}, {"file_name", outsidePath}};
+    const QJsonObject absoluteResponse = handler.handleCommand("extract_ic", absoluteParams, {});
+    QVERIFY(absoluteResponse.contains("error"));
+    QVERIFY(!QFile::exists(outsidePath));
+
+    // A legitimate subdirectory of the project directory remains allowed.
+    QVERIFY(QDir(tmpDir.path()).mkpath("subdir"));
+    const QJsonObject legitParams{{"blob_name", "mytest"}, {"file_name", "subdir/out.panda"}};
+    const QJsonObject legitResponse = handler.handleCommand("extract_ic", legitParams, {});
+    QVERIFY2(legitResponse.contains("result"), qPrintable(QJsonDocument(legitResponse).toJson()));
+    QVERIFY(QFile::exists(tmpDir.path() + "/subdir/out.panda"));
+}
+
+void TestICHandlerSecurity::testInstantiateIcLeavesNoElementOnLoadFailure()
+{
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+
+    const QString corruptPath = tmpDir.path() + "/corrupt.panda";
+    {
+        QFile file(corruptPath);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write("not a panda file");
+    }
+
+    const QString projectPath = tmpDir.path() + "/project.panda";
+    WorkSpace().save(projectPath);
+
+    MainWindow window;
+    window.loadPandaFile(projectPath);
+    ICHandler handler(&window, nullptr);
+
+    Scene *scene = window.currentTab()->scene();
+    const qsizetype countBefore = scene->elements().size();
+
+    const QJsonObject params{{"ic_name", "corrupt"}, {"x", 0}, {"y", 0}};
+    const QJsonObject response = handler.handleCommand("instantiate_ic", params, {});
+    QVERIFY2(response.contains("error"), qPrintable(QJsonDocument(response).toJson()));
+    QCOMPARE(scene->elements().size(), countBefore);
+}

--- a/Tests/Unit/MCP/TestICHandlerSecurity.h
+++ b/Tests/Unit/MCP/TestICHandlerSecurity.h
@@ -1,0 +1,21 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+/// Regression coverage for MCP/Server/Handlers/ICHandler.cpp hardening found in an
+/// eighth-pass audit: path traversal via unsanitized blob_name/file_name in embed_ic/
+/// extract_ic/instantiate_ic(inline), and a leaked IC on a failing instantiate_ic load.
+class TestICHandlerSecurity : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testEmbedIcRejectsPathTraversalBlobName();
+    void testInstantiateIcInlineRejectsPathTraversalBlobName();
+    void testExtractIcConfinesFileNameToProjectDirectory();
+    void testInstantiateIcLeavesNoElementOnLoadFailure();
+};

--- a/Tests/Unit/MCP/TestMCPProcessor.cpp
+++ b/Tests/Unit/MCP/TestMCPProcessor.cpp
@@ -1,0 +1,56 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/MCP/TestMCPProcessor.h"
+
+#include <QTest>
+
+#include "MCP/Server/Core/MCPProcessor.h"
+
+void TestMCPProcessor::testExtractStdinLinesSplitsCompleteLines()
+{
+    QByteArray buffer;
+    const QStringList lines = MCPProcessor::extractStdinLines(buffer, "abc\ndef\n");
+
+    QCOMPARE(lines, QStringList({"abc", "def"}));
+    QVERIFY(buffer.isEmpty());
+}
+
+void TestMCPProcessor::testExtractStdinLinesHandlesPartialLineAcrossCalls()
+{
+    QByteArray buffer;
+
+    const QStringList firstResult = MCPProcessor::extractStdinLines(buffer, "ab");
+    QVERIFY(firstResult.isEmpty());
+    QCOMPARE(buffer, QByteArray("ab"));
+
+    const QStringList secondResult = MCPProcessor::extractStdinLines(buffer, "c\n");
+    QCOMPARE(secondResult, QStringList({"abc"}));
+    QVERIFY(buffer.isEmpty());
+}
+
+void TestMCPProcessor::testExtractStdinLinesKeepsIncompleteLineAtExactCap()
+{
+    // No newline anywhere — the whole thing stays buffered, waiting for more data.
+    // Exactly at the cap must NOT be treated as an overflow.
+    QByteArray buffer;
+    const QByteArray chunk(MCPProcessor::kMaxStdinLineBytes, 'x');
+
+    const QStringList lines = MCPProcessor::extractStdinLines(buffer, chunk);
+
+    QVERIFY(lines.isEmpty());
+    QCOMPARE(buffer.size(), MCPProcessor::kMaxStdinLineBytes);
+}
+
+void TestMCPProcessor::testExtractStdinLinesDropsIncompleteLineOverCap()
+{
+    // One byte past the cap, still no newline: a client that never sends '\n' must not be
+    // allowed to grow the buffer without bound.
+    QByteArray buffer;
+    const QByteArray chunk(MCPProcessor::kMaxStdinLineBytes + 1, 'x');
+
+    const QStringList lines = MCPProcessor::extractStdinLines(buffer, chunk);
+
+    QVERIFY(lines.isEmpty());
+    QVERIFY2(buffer.isEmpty(), "Buffer must be dropped once it exceeds the cap with no newline");
+}

--- a/Tests/Unit/MCP/TestMCPProcessor.h
+++ b/Tests/Unit/MCP/TestMCPProcessor.h
@@ -1,0 +1,20 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+
+class TestMCPProcessor : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testExtractStdinLinesSplitsCompleteLines();
+    void testExtractStdinLinesHandlesPartialLineAcrossCalls();
+
+    // Regression: stdin is not a trusted channel — a client that never sends '\n' must not
+    // grow the pending-line buffer without bound.
+    void testExtractStdinLinesKeepsIncompleteLineAtExactCap();
+    void testExtractStdinLinesDropsIncompleteLineOverCap();
+};

--- a/Tests/Unit/Scene/TestPropertyShortcutHandler.cpp
+++ b/Tests/Unit/Scene/TestPropertyShortcutHandler.cpp
@@ -107,9 +107,23 @@ void TestPropertyShortcutHandler::testLedColorSecondary()
     workspace.scene()->clearSelection();
     led->setSelected(true);
 
+    auto *undoStack = workspace.scene()->undoStack();
+    const int countBefore = undoStack->count();
+
     // Led color is secondary property
     handler.nextSecondaryProperty();
     QVERIFY(led->color() != originalColor);
+    const QString cycledColor = led->color();
+
+    // Regression: this mutation used to bypass the undo system entirely — every sibling
+    // branch in adjustSecondaryProperty()/adjustMainProperty() wraps its change in an
+    // UpdateCommand via applyWithUndo(), but the Led branch set the color directly.
+    QCOMPARE(undoStack->count(), countBefore + 1);
+    QVERIFY(undoStack->canUndo());
+    undoStack->undo();
+    QCOMPARE(led->color(), originalColor);
+    undoStack->redo();
+    QCOMPARE(led->color(), cycledColor);
 
     handler.prevSecondaryProperty();
     QCOMPARE(led->color(), originalColor);
@@ -192,4 +206,37 @@ void TestPropertyShortcutHandler::testMorphPrevElement()
     auto selected = workspace.scene()->selectedElements();
     QCOMPARE(selected.size(), 1);
     QCOMPARE(selected.first()->elementType(), ElementType::Xnor);
+}
+
+void TestPropertyShortcutHandler::testMultiElementShortcutIsSingleUndoStep()
+{
+    // Regression: cycling a property on a multi-selection used to push one undo command
+    // per element, ungrouped — a single Ctrl+Z only reverted the last element touched.
+    // It must now be a single undo step for the whole action, like every other
+    // multi-element command in the app (e.g. the "Change wireless mode" macro).
+    WorkSpace workspace;
+    auto *clock1 = new Clock;
+    auto *clock2 = new Clock;
+    workspace.scene()->addItem(clock1);
+    workspace.scene()->addItem(clock2);
+    const double originalFreq1 = clock1->frequency();
+    const double originalFreq2 = clock2->frequency();
+
+    PropertyShortcutHandler handler(workspace.scene());
+    workspace.scene()->clearSelection();
+    clock1->setSelected(true);
+    clock2->setSelected(true);
+
+    auto *undoStack = workspace.scene()->undoStack();
+    const int countBefore = undoStack->count();
+
+    handler.nextMainProperty();
+
+    QCOMPARE(clock1->frequency(), originalFreq1 + 0.5);
+    QCOMPARE(clock2->frequency(), originalFreq2 + 0.5);
+    QCOMPARE(undoStack->count(), countBefore + 1);
+
+    undoStack->undo();
+    QCOMPARE(clock1->frequency(), originalFreq1);
+    QCOMPARE(clock2->frequency(), originalFreq2);
 }

--- a/Tests/Unit/Scene/TestPropertyShortcutHandler.h
+++ b/Tests/Unit/Scene/TestPropertyShortcutHandler.h
@@ -22,4 +22,5 @@ private slots:
     void testInputRotaryOutputSize();
     void testMorphNextElement();
     void testMorphPrevElement();
+    void testMultiElementShortcutIsSingleUndoStep();
 };

--- a/Tests/Unit/Scene/TestScene.cpp
+++ b/Tests/Unit/Scene/TestScene.cpp
@@ -7,8 +7,10 @@
 #include <memory>
 
 #include <QClipboard>
+#include <QImage>
 #include <QMimeData>
 #include <QTest>
+#include <QTransform>
 
 #include "App/Core/ItemWithId.h"
 #include "App/Core/MimeTypes.h"
@@ -1543,4 +1545,29 @@ void TestScene::testClipboardCanPasteMatchesPasteFormats()
     unrelated.setText("not circuit data");
     QVERIFY(!ClipboardManager::canPaste(&unrelated));
     QVERIFY(!ClipboardManager::canPaste(nullptr));
+}
+
+void TestScene::testBuildDragImageClampsExtremeSelectionExtent()
+{
+    // Regression: cloneDrag()'s ghost image was sized proportionally to the scene distance
+    // between selected elements — position validation on load only rejects non-finite
+    // coordinates, never bounds magnitude (the same gap CircuitExporter::renderToImage hit).
+    // One stray element at an extreme-but-finite position must not blow up the allocation.
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+
+    auto *sw1 = new InputSwitch();
+    scene->addItem(sw1);
+    auto *sw2 = new InputSwitch();
+    scene->addItem(sw2);
+    sw2->setPos(1e7, 1e7);
+
+    const QRectF rect = sw1->sceneBoundingRect().united(sw2->sceneBoundingRect()).adjusted(-8, -8, 8, 8);
+
+    // Identity transform mirrors 100% zoom, the worst case for this bug.
+    const QImage image = ClipboardManager::buildDragImage(scene, QTransform(), rect);
+
+    QVERIFY(!image.isNull());
+    QVERIFY(image.width() <= ClipboardManager::kMaxDragImageDimension);
+    QVERIFY(image.height() <= ClipboardManager::kMaxDragImageDimension);
 }

--- a/Tests/Unit/Scene/TestScene.h
+++ b/Tests/Unit/Scene/TestScene.h
@@ -91,4 +91,5 @@ private slots:
 
     // Regression: F4 — paste gate must accept every format paste() reads
     void testClipboardCanPasteMatchesPasteFormats();
+    void testBuildDragImageClampsExtremeSelectionExtent();
 };

--- a/Tests/Unit/Serialization/TestDolphinClipboard.cpp
+++ b/Tests/Unit/Serialization/TestDolphinClipboard.cpp
@@ -1,0 +1,80 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "Tests/Unit/Serialization/TestDolphinClipboard.h"
+
+#include <limits>
+
+#include <QDataStream>
+#include <QItemSelection>
+
+#include "App/BeWavedDolphin/DolphinClipboard.h"
+#include "App/BeWavedDolphin/SignalModel.h"
+
+void TestDolphinClipboard::testPasteRoundTrip()
+{
+    SignalModel source(2, 3);
+    source.setInputRows(2);
+    source.setValue(0, 0, 1);
+    source.setValue(0, 1, 0);
+    source.setValue(1, 0, 0);
+    source.setValue(1, 1, 1);
+
+    QItemSelection ranges(source.index(0, 0), source.index(1, 1));
+
+    QByteArray data;
+    {
+        QDataStream stream(&data, QIODevice::WriteOnly);
+        DolphinClipboard::copy(source, ranges, stream);
+    }
+
+    SignalModel target(2, 3);
+    target.setInputRows(2);
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    DolphinClipboard::paste(target, ranges, readStream);
+
+    QCOMPARE(target.value(0, 0), 1);
+    QCOMPARE(target.value(0, 1), 0);
+    QCOMPARE(target.value(1, 0), 0);
+    QCOMPARE(target.value(1, 1), 1);
+}
+
+void TestDolphinClipboard::testPasteTruncatesImplausibleItemCount()
+{
+    // A crafted payload claiming ~1.8e19 items, but only two real 24-byte entries
+    // actually follow. Before the fix this spun the paste loop for that many
+    // iterations instead of stopping where the real data ends.
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << std::numeric_limits<quint64>::max();
+    stream << static_cast<quint64>(0) << static_cast<quint64>(0) << static_cast<quint64>(1);
+    stream << static_cast<quint64>(1) << static_cast<quint64>(1) << static_cast<quint64>(1);
+
+    SignalModel target(2, 2);
+    target.setInputRows(2);
+    QItemSelection ranges(target.index(0, 0), target.index(0, 0));
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    DolphinClipboard::paste(target, ranges, readStream);
+
+    QCOMPARE(target.value(0, 0), 1);
+    QCOMPARE(target.value(1, 1), 1);
+}
+
+void TestDolphinClipboard::testPasteWithNoDataDoesNothing()
+{
+    // Announces 5 items but no entry data follows at all.
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << static_cast<quint64>(5);
+
+    SignalModel target(2, 2);
+    target.setInputRows(2);
+    target.setValue(0, 0, 0);
+    QItemSelection ranges(target.index(0, 0), target.index(0, 0));
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    DolphinClipboard::paste(target, ranges, readStream);
+
+    QCOMPARE(target.value(0, 0), 0);
+}

--- a/Tests/Unit/Serialization/TestDolphinClipboard.h
+++ b/Tests/Unit/Serialization/TestDolphinClipboard.h
@@ -1,0 +1,21 @@
+// Copyright 2015 - 2026, GIBIS-UNIFESP and the wiRedPanda contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QTest>
+
+class TestDolphinClipboard : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testPasteRoundTrip();
+
+    // Regression: DolphinClipboard::paste() read its item count straight off the
+    // system clipboard with no bound, so a crafted/corrupt payload could spin the
+    // paste loop for eons instead of failing fast.
+    void testPasteTruncatesImplausibleItemCount();
+    void testPasteWithNoDataDoesNothing();
+};

--- a/Tests/Unit/Serialization/TestFileUtils.cpp
+++ b/Tests/Unit/Serialization/TestFileUtils.cpp
@@ -3,13 +3,10 @@
 
 #include "Tests/Unit/Serialization/TestFileUtils.h"
 
-#include <QDataStream>
 #include <QFile>
-#include <QRectF>
 #include <QTemporaryDir>
 
 #include "App/IO/FileUtils.h"
-#include "App/IO/Serialization.h"
 #include "Tests/Common/TestUtils.h"
 
 void TestFileUtils::testCopyToDirEmptyPath()
@@ -66,53 +63,6 @@ void TestFileUtils::testCopyToDirResourcePath()
     QVERIFY(true); // no crash
 }
 
-void TestFileUtils::testCopyPandaDepsBasic()
-{
-    // copyPandaDeps takes 3 args: pandaPath, srcDir, destDir
-    QTemporaryDir sourceDir;
-    QTemporaryDir destDir;
-
-    // Write a minimal file that won't parse as a real .panda — just verifies no crash
-    QString sourcePanda = sourceDir.path() + "/circuit.panda";
-    QFile pandaFile(sourcePanda);
-    QVERIFY(pandaFile.open(QIODevice::WriteOnly));
-    pandaFile.write("not a real panda file");
-    pandaFile.close();
-
-    FileUtils::copyPandaDeps(sourcePanda, sourceDir.path(), destDir.path());
-    QVERIFY(true); // no crash
-}
-
-void TestFileUtils::testCopyPandaDepsRecursive()
-{
-    QTemporaryDir sourceDir;
-    QTemporaryDir destDir;
-
-    QString sourcePanda = sourceDir.path() + "/parent.panda";
-    QFile pandaFile(sourcePanda);
-    QVERIFY(pandaFile.open(QIODevice::WriteOnly));
-    pandaFile.write("not a real panda file");
-    pandaFile.close();
-
-    FileUtils::copyPandaDeps(sourcePanda, sourceDir.path(), destDir.path());
-    QVERIFY(true); // no crash
-}
-
-void TestFileUtils::testCopyPandaDepsNoDependencies()
-{
-    QTemporaryDir sourceDir;
-    QTemporaryDir destDir;
-
-    QString sourcePanda = sourceDir.path() + "/simple.panda";
-    QFile pandaFile(sourcePanda);
-    QVERIFY(pandaFile.open(QIODevice::WriteOnly));
-    pandaFile.write("not a real panda file");
-    pandaFile.close();
-
-    FileUtils::copyPandaDeps(sourcePanda, sourceDir.path(), destDir.path());
-    QVERIFY(true); // no crash
-}
-
 void TestFileUtils::testCopyToDirThrowsOnFailure()
 {
     // Pre-fix QFile::copy's bool return was discarded; a failed copy left the
@@ -129,41 +79,4 @@ void TestFileUtils::testCopyToDirThrowsOnFailure()
     // Destination directory does not exist — QFile::copy returns false.
     const QString badDest = sourceDir.path() + "/no/such/subdirectory";
     QVERIFY_THROWS(std::exception, FileUtils::copyToDir(sourceFile, badDest));
-}
-
-namespace {
-// Writes a minimal .panda file with only the header + a metadata map containing
-// a single fileBackedICs entry. Just enough for copyPandaDeps to traverse.
-void writePandaWithFileBackedIC(const QString &path, const QString &referencedIC)
-{
-    QFile out(path);
-    QVERIFY(out.open(QIODevice::WriteOnly));
-    QDataStream stream(&out);
-    Serialization::writePandaHeader(stream);
-
-    QMap<QString, QVariant> metadata;
-    metadata["dolphinFileName"] = QString();
-    metadata["sceneRect"] = QRectF();
-    metadata["fileBackedICs"] = QStringList{referencedIC};
-    stream << metadata;
-}
-} // namespace
-
-void TestFileUtils::testCopyPandaDepsTerminatesOnCircularMetadata()
-{
-    // Hand-craft two .panda files that reference each other in their
-    // fileBackedICs metadata. Pre-fix copyPandaDeps would infinite-recurse
-    // until stack overflow; the visited-set guard short-circuits the cycle.
-    QTemporaryDir sourceDir;
-    QTemporaryDir destDir;
-    QVERIFY(sourceDir.isValid() && destDir.isValid());
-
-    const QString aPath = sourceDir.path() + "/a.panda";
-    const QString bPath = sourceDir.path() + "/b.panda";
-    writePandaWithFileBackedIC(aPath, "b.panda");
-    writePandaWithFileBackedIC(bPath, "a.panda");
-
-    // Should return promptly — if it doesn't terminate the test runner kills us.
-    FileUtils::copyPandaDeps(aPath, sourceDir.path(), destDir.path());
-    QVERIFY(true);
 }

--- a/Tests/Unit/Serialization/TestFileUtils.h
+++ b/Tests/Unit/Serialization/TestFileUtils.h
@@ -18,14 +18,6 @@ private slots:
     void testCopyToDirFileAlreadyExists();
     void testCopyToDirResourcePath();
 
-    // copyPandaDeps tests (3 tests)
-    void testCopyPandaDepsBasic();
-    void testCopyPandaDepsRecursive();
-    void testCopyPandaDepsNoDependencies();
-
     // Regression: D17 — copy failures must throw
     void testCopyToDirThrowsOnFailure();
-
-    // Regression: D16 — circular fileBackedICs metadata must not infinite-recurse
-    void testCopyPandaDepsTerminatesOnCircularMetadata();
 };

--- a/Tests/Unit/Serialization/TestSerialization.cpp
+++ b/Tests/Unit/Serialization/TestSerialization.cpp
@@ -1543,6 +1543,32 @@ void TestSerialization::testCopyPandaFileTerminatesOnCircularMetadata()
     QVERIFY(true);
 }
 
+void TestSerialization::testCopyPandaFileRejectsDeepDependencyChain()
+{
+    // A long but non-cyclic chain of distinct dependency files (each real, on disk, never
+    // repeated) must be rejected once it exceeds the nesting depth cap — the visited-set
+    // cycle guard alone doesn't bound this, unlike the circular-reference case above.
+    QTemporaryDir sourceDir;
+    QTemporaryDir destDir;
+    QVERIFY(sourceDir.isValid() && destDir.isValid());
+
+    constexpr int chainLength = 20; // > the copyPandaFile nesting depth cap (16)
+    for (int i = 0; i < chainLength; ++i) {
+        const QString path = sourceDir.path() + QString("/dep%1.panda").arg(i);
+        const QString nextDep = (i + 1 < chainLength) ? QString("dep%1.panda").arg(i + 1) : QString();
+        writePandaWithFileBackedIC(path, nextDep);
+    }
+
+    bool threw = false;
+    try {
+        Serialization::copyPandaFile(QFileInfo(sourceDir.path() + "/dep0.panda"),
+                                      QFileInfo(destDir.path() + "/dep0.panda"));
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(threw, "A dependency chain deeper than the nesting cap must be rejected, not stack-overflow");
+}
+
 // ============================================================================
 // libFuzzer Regressions
 // ============================================================================

--- a/Tests/Unit/Serialization/TestSerialization.cpp
+++ b/Tests/Unit/Serialization/TestSerialization.cpp
@@ -3,8 +3,10 @@
 
 #include "Tests/Unit/Serialization/TestSerialization.h"
 
+#include <QDataStream>
 #include <QFile>
 #include <QFileInfo>
+#include <QRectF>
 #include <QTest>
 
 #include "App/Element/ElementFactory.h"
@@ -1461,6 +1463,83 @@ void TestSerialization::testVersionedBackupMultiVersions()
     QFile f42(backup42);
     QVERIFY(f42.open(QIODevice::ReadOnly));
     QCOMPARE(f42.readAll(), content42);
+}
+
+// ============================================================================
+// File-copy utility — Serialization::copyPandaFile
+// ============================================================================
+
+namespace {
+// Writes a minimal .panda file with only the header + a metadata map containing
+// a single fileBackedICs entry — just enough for copyPandaFile to traverse.
+void writePandaWithFileBackedIC(const QString &path, const QString &referencedIC)
+{
+    QFile out(path);
+    QVERIFY(out.open(QIODevice::WriteOnly));
+    QDataStream stream(&out);
+    Serialization::writePandaHeader(stream);
+
+    QMap<QString, QVariant> metadata;
+    metadata["dolphinFileName"] = QString();
+    metadata["sceneRect"] = QRectF();
+    metadata["fileBackedICs"] = QStringList{referencedIC};
+    stream << metadata;
+}
+} // namespace
+
+void TestSerialization::testCopyPandaFileCopiesNonPandaContent()
+{
+    // copyPandaFile always copies the file itself, even when its content doesn't parse
+    // as a panda file — only the *recursion* into fileBackedICs is skipped on parse failure.
+    QTemporaryDir sourceDir;
+    QTemporaryDir destDir;
+    QVERIFY(sourceDir.isValid() && destDir.isValid());
+
+    const QString sourcePanda = sourceDir.path() + "/circuit.panda";
+    { QFile f(sourcePanda); QVERIFY(f.open(QIODevice::WriteOnly)); f.write("not a real panda file"); }
+
+    const QString destPanda = destDir.path() + "/circuit.panda";
+    Serialization::copyPandaFile(QFileInfo(sourcePanda), QFileInfo(destPanda));
+
+    QVERIFY2(QFile::exists(destPanda), "The file itself must still be copied");
+}
+
+void TestSerialization::testCopyPandaFileCopiesFileBackedDependency()
+{
+    // A real fileBackedICs entry must be discovered and copied alongside the parent file.
+    QTemporaryDir sourceDir;
+    QTemporaryDir destDir;
+    QVERIFY(sourceDir.isValid() && destDir.isValid());
+
+    const QString parentPath = sourceDir.path() + "/parent.panda";
+    const QString depPath = sourceDir.path() + "/dependency.panda";
+    writePandaWithFileBackedIC(parentPath, "dependency.panda");
+    writePandaWithFileBackedIC(depPath, {});
+
+    Serialization::copyPandaFile(QFileInfo(parentPath), QFileInfo(destDir.path() + "/parent.panda"));
+
+    QVERIFY2(QFile::exists(destDir.path() + "/parent.panda"), "Parent file must be copied");
+    QVERIFY2(QFile::exists(destDir.path() + "/dependency.panda"), "Referenced dependency must also be copied");
+}
+
+void TestSerialization::testCopyPandaFileTerminatesOnCircularMetadata()
+{
+    // Hand-craft two .panda files that reference each other in their
+    // fileBackedICs metadata. Pre-fix copyPandaDeps (now merged into
+    // copyPandaFile) would infinite-recurse until stack overflow; the
+    // visited-set guard short-circuits the cycle.
+    QTemporaryDir sourceDir;
+    QTemporaryDir destDir;
+    QVERIFY(sourceDir.isValid() && destDir.isValid());
+
+    const QString aPath = sourceDir.path() + "/a.panda";
+    const QString bPath = sourceDir.path() + "/b.panda";
+    writePandaWithFileBackedIC(aPath, "b.panda");
+    writePandaWithFileBackedIC(bPath, "a.panda");
+
+    // Should return promptly — if it doesn't terminate the test runner kills us.
+    Serialization::copyPandaFile(QFileInfo(aPath), QFileInfo(destDir.path() + "/a.panda"));
+    QVERIFY(true);
 }
 
 // ============================================================================

--- a/Tests/Unit/Serialization/TestSerialization.cpp
+++ b/Tests/Unit/Serialization/TestSerialization.cpp
@@ -6,6 +6,7 @@
 #include <QDataStream>
 #include <QFile>
 #include <QFileInfo>
+#include <QKeySequence>
 #include <QRectF>
 #include <QTest>
 
@@ -1803,4 +1804,56 @@ void TestSerialization::testFuzzRegressionNonFiniteRotation()
         threw = true;
     }
     QVERIFY2(threw, "Non-finite element rotation must be rejected, not loaded");
+}
+
+void TestSerialization::testReadBoundedKeySequenceRoundTrip()
+{
+    const QKeySequence original(Qt::CTRL | Qt::Key_A);
+
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << original;
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    const QKeySequence result = Serialization::readBoundedKeySequence(readStream);
+
+    QCOMPARE(result, original);
+}
+
+void TestSerialization::testReadBoundedKeySequenceAcceptsMaxFourKeys()
+{
+    // A QKeySequence holds at most 4 chained key combinations — count == 4 is the
+    // legitimate maximum and must still be accepted, not just count < 4.
+    const QKeySequence original(Qt::Key_A, Qt::Key_B, Qt::Key_C, Qt::Key_D);
+    QCOMPARE(original.count(), 4);
+
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << original;
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    const QKeySequence result = Serialization::readBoundedKeySequence(readStream);
+
+    QCOMPARE(result, original);
+}
+
+void TestSerialization::testReadBoundedKeySequenceRejectsImplausibleCount()
+{
+    // Regression: GraphicElementSerializer::loadTrigger() (old-format loader, versions
+    // 1.9-4.0) used Qt's raw, unbounded QKeySequence deserialization, which reserve()s a
+    // QList<int> sized by this stream-controlled count before validating it. A crafted
+    // old-format .panda file with a valid header/version and this count is enough to
+    // trigger the allocation.
+    QByteArray data;
+    QDataStream stream(&data, QIODevice::WriteOnly);
+    stream << static_cast<quint32>(0x7FFFFFFF); // implausible count, no real data behind it
+
+    QDataStream readStream(&data, QIODevice::ReadOnly);
+    bool threw = false;
+    try {
+        Serialization::readBoundedKeySequence(readStream);
+    } catch (...) {
+        threw = true;
+    }
+    QVERIFY2(threw, "Implausible QKeySequence count must be rejected, not allocated");
 }

--- a/Tests/Unit/Serialization/TestSerialization.h
+++ b/Tests/Unit/Serialization/TestSerialization.h
@@ -88,6 +88,12 @@ private slots:
     void testVersionedBackupPreservesOriginal();// original file content unchanged after backup
     void testVersionedBackupMultiVersions();    // different versions produce different backup files
 
+    // File-copy utility (Serialization::copyPandaFile)
+    void testCopyPandaFileCopiesNonPandaContent();          // non-panda content still gets copied, no recursion
+    void testCopyPandaFileCopiesFileBackedDependency();     // a real fileBackedICs entry is also copied
+    // Regression: D16 — circular fileBackedICs metadata must not infinite-recurse
+    void testCopyPandaFileTerminatesOnCircularMetadata();
+
     // libFuzzer regression fixtures (Tests/Fuzz/regressions/) — malformed
     // .panda inputs that must throw cleanly under ASan, never crash.
     void testFuzzRegressionCleanupUAF();

--- a/Tests/Unit/Serialization/TestSerialization.h
+++ b/Tests/Unit/Serialization/TestSerialization.h
@@ -93,6 +93,9 @@ private slots:
     void testCopyPandaFileCopiesFileBackedDependency();     // a real fileBackedICs entry is also copied
     // Regression: D16 — circular fileBackedICs metadata must not infinite-recurse
     void testCopyPandaFileTerminatesOnCircularMetadata();
+    // Regression: a long, non-cyclic chain of distinct fileBackedICs dependencies must be
+    // rejected past a fixed nesting depth, not recurse until the call stack is exhausted.
+    void testCopyPandaFileRejectsDeepDependencyChain();
 
     // libFuzzer regression fixtures (Tests/Fuzz/regressions/) — malformed
     // .panda inputs that must throw cleanly under ASan, never crash.

--- a/Tests/Unit/Serialization/TestSerialization.h
+++ b/Tests/Unit/Serialization/TestSerialization.h
@@ -110,6 +110,13 @@ private slots:
     void testFuzzRegressionNonFinitePosition();         // ic_nonfinite_position (fuzz_ic_file)
     void testFuzzRegressionNonFiniteRotation();         // ic_nonfinite_rotation (fuzz_ic_file)
 
+    // Regression: GraphicElementSerializer::loadTrigger() (old-format, version 1.9-4.0)
+    // used raw, unbounded QKeySequence deserialization instead of the bounded reader
+    // already used by the new-format path.
+    void testReadBoundedKeySequenceRoundTrip();
+    void testReadBoundedKeySequenceAcceptsMaxFourKeys();
+    void testReadBoundedKeySequenceRejectsImplausibleCount();
+
 private:
     // Helper methods
     QByteArray saveToMemory(WorkSpace &workspace);

--- a/Tests/Unit/Simulation/TestDanglingPointer.cpp
+++ b/Tests/Unit/Simulation/TestDanglingPointer.cpp
@@ -468,11 +468,12 @@ void TestDanglingPointer::bug7_icRegistryFileChangedMustNotLeaveDanglingPointers
              "Could not find end of ICRegistry::onFileChanged body.");
     const QString body = source.mid(bodyStart, bodyEnd - bodyStart + 1);
 
-    QVERIFY2(body.contains("SimulationBlocker"),
-             "ICRegistry::onFileChanged must open a SimulationBlocker "
-             "scope around the reload loop so the 1 ms simulation QTimer "
-             "is quiescent while each IC's m_internalElements is freed "
-             "and replaced.");
+    QVERIFY2(body.contains("reloadTargetsAtomically"),
+             "ICRegistry::onFileChanged must reload targets through "
+             "reloadTargetsAtomically(), which opens a SimulationBlocker "
+             "scope around the whole reload loop so the 1 ms simulation "
+             "QTimer is quiescent while each IC's m_internalElements is "
+             "freed and replaced.");
 
     QVERIFY2(body.contains("setCircuitUpdateRequired"),
              "ICRegistry::onFileChanged must call setCircuitUpdateRequired() "
@@ -480,6 +481,83 @@ void TestDanglingPointer::bug7_icRegistryFileChangedMustNotLeaveDanglingPointers
              "The previous simulation()->restart() was too weak — it only "
              "invalidated the outer Simulation::m_sortedElements, leaving "
              "each IC's m_sortedInternalElements untouched.");
+}
+
+// Hardening — embedICsByFile()/extractToFile() reload live, already-in-scene
+// ICs exactly like onFileChanged() (bug7) does, via ic->loadFromBlob()/
+// loadFile(), but had no SimulationBlocker at all — including in their own
+// rollback path. Same H2 use-after-free shape: an IC's internal flip-flop
+// elements are freed by resetInternalState() while Simulation::m_sequentialElements
+// still points at them, and nothing stopped the 1 ms timer for the duration.
+// Fixed by routing all three functions through one shared
+// ICRegistry::reloadTargetsAtomically() helper. Source-level check, same
+// shape as bug6/bug7, for the same reason: the real reentrancy window can't
+// be triggered deterministically inside single-threaded QtTest.
+void TestDanglingPointer::hardening_icRegistryReloadHelpersMustUseSimulationBlocker()
+{
+    const QString path =
+        QString(QUOTE(CURRENTDIR)) + "/../App/Scene/ICRegistry.cpp";
+    QFile src(path);
+    QVERIFY2(src.open(QIODevice::ReadOnly),
+             qPrintable(QString("Cannot open %1").arg(src.fileName())));
+    const QString source = QString::fromUtf8(src.readAll());
+    src.close();
+
+    auto bodyOf = [&source](const QString &qualifiedName) -> QString {
+        // [\s\S]*? (lazy, spans newlines) rather than [^)]* — reloadTargetsAtomically's own
+        // parameter list contains std::function<void(IC *)>, a nested closing paren that a
+        // negated-character-class match can't see past to find the parameter list's real end.
+        const QString pattern =
+            QStringLiteral("\\b") + QRegularExpression::escape(qualifiedName)
+            + QStringLiteral("\\s*\\([\\s\\S]*?\\)\\s*\\{");
+        QRegularExpression rx(pattern);
+        const auto match = rx.match(source);
+        if (!match.hasMatch()) return {};
+
+        const qsizetype start = match.capturedEnd() - 1;
+        int depth = 0;
+        for (qsizetype i = start; i < source.size(); ++i) {
+            const QChar c = source.at(i);
+            if (c == '{') ++depth;
+            else if (c == '}') {
+                --depth;
+                if (depth == 0) return source.mid(start, i - start + 1);
+            }
+        }
+        return {};
+    };
+
+    const QString helperBody = bodyOf("ICRegistry::reloadTargetsAtomically");
+    QVERIFY2(!helperBody.isEmpty(), "Could not locate ICRegistry::reloadTargetsAtomically definition.");
+    QVERIFY2(helperBody.contains("SimulationBlocker"),
+             "ICRegistry::reloadTargetsAtomically must open a SimulationBlocker "
+             "scope around its whole loop over targets, not just each individual "
+             "mutation — the timer must stay stopped between iterations too, since "
+             "Simulation::m_sequentialElements stays stale until the caller's "
+             "setCircuitUpdateRequired() runs after the entire loop completes.");
+
+    const QStringList reloadCallers = {
+        "ICRegistry::embedICsByFile",
+        "ICRegistry::extractToFile",
+    };
+    QStringList missingCall;
+    for (const QString &name : reloadCallers) {
+        const QString body = bodyOf(name);
+        if (body.isEmpty()) {
+            missingCall << (name + " (function body not located)");
+            continue;
+        }
+        if (!body.contains("reloadTargetsAtomically")) {
+            missingCall << name;
+        }
+    }
+
+    QVERIFY2(missingCall.isEmpty(),
+             qPrintable(QString("The following functions mutate live, already-in-scene "
+                                "IC elements and must go through reloadTargetsAtomically() "
+                                "(which opens a SimulationBlocker for the whole loop) rather "
+                                "than mutating them directly:\n  - %1")
+                            .arg(missingCall.join("\n  - "))));
 }
 
 // Combined integration reproduction of WIREDPANDA-H2. Same tick path the

--- a/Tests/Unit/Simulation/TestDanglingPointer.h
+++ b/Tests/Unit/Simulation/TestDanglingPointer.h
@@ -91,6 +91,12 @@ private slots:
     /// the file-watcher path.
     void bug7_icRegistryFileChangedMustNotLeaveDanglingPointers();
 
+    /// Hardening — embedICsByFile()/extractToFile() had no SimulationBlocker
+    /// at all (unlike their sibling onFileChanged()/bug7), despite mutating
+    /// live, already-in-scene ICs the same way. Source-level check, same
+    /// shape as bug6/bug7.
+    void hardening_icRegistryReloadHelpersMustUseSimulationBlocker();
+
     /// Combined H2 reproduction — sits at the end so the process crash
     /// only affects this last slot. Covers the concrete path that
     /// Simulation.cpp:87's `element->updateLogic()` took in production.

--- a/Tests/Unit/Ui/TestCircuitExporter.cpp
+++ b/Tests/Unit/Ui/TestCircuitExporter.cpp
@@ -82,3 +82,18 @@ void TestCircuitExporter::testRenderToPdfHandlesExtremeSceneDimensionsPromptly()
     CircuitExporter::renderToPdf(workspace.scene(), path);
     QVERIFY(QFile::exists(path));
 }
+
+void TestCircuitExporter::testRenderScaledImageClampsExtremeDimensionsDirectly()
+{
+    WorkSpace workspace;
+    auto *sw = new InputSwitch();
+    workspace.scene()->addItem(sw);
+    sw->setPos(1e7, 1e7);
+
+    const QRectF paddedRect = workspace.scene()->itemsBoundingRect().adjusted(-64, -64, 64, 64);
+    const QImage image = CircuitExporter::renderScaledImage(workspace.scene(), paddedRect);
+
+    QVERIFY(!image.isNull());
+    QVERIFY(image.width() <= CircuitExporter::kMaxImageDimension);
+    QVERIFY(image.height() <= CircuitExporter::kMaxImageDimension);
+}

--- a/Tests/Unit/Ui/TestCircuitExporter.cpp
+++ b/Tests/Unit/Ui/TestCircuitExporter.cpp
@@ -3,8 +3,11 @@
 
 #include "Tests/Unit/Ui/TestCircuitExporter.h"
 
+#include <QFile>
+#include <QImage>
 #include <QTemporaryDir>
 
+#include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Scene/Workspace.h"
 #include "App/UI/CircuitExporter.h"
 #include "Tests/Common/TestUtils.h"
@@ -27,4 +30,55 @@ void TestCircuitExporter::testRenderToImageThrowsOnInvalidPath()
     WorkSpace workspace;
     const QString path = "/nonexistent/directory/that/does/not/exist/img.png";
     QVERIFY_THROWS(std::exception, CircuitExporter::renderToImage(workspace.scene(), path));
+}
+
+void TestCircuitExporter::testRenderToImagePaddingIsTransparentNotGarbage()
+{
+    // Deliberately no updateTheme() call — Scene's background BRUSH is only set by
+    // updateTheme(), so an un-themed scene's padding pixels come straight from the image's
+    // initial fill wherever the (always-drawn, theme-independent) grid dots don't land.
+    // Pixel (8, 8) sits at scene coordinate (rect.left() + 8, rect.top() + 8): since the
+    // empty scene's padded rect starts at a multiple of Constants::gridSize (16), (0, 0)
+    // lands exactly on a grid dot, but the 8 px offset falls squarely between dots.
+    WorkSpace workspace;
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + "/test.png";
+    CircuitExporter::renderToImage(workspace.scene(), path);
+
+    QImage image(path);
+    QVERIFY(!image.isNull());
+    QCOMPARE(qAlpha(image.pixel(8, 8)), 0);
+}
+
+void TestCircuitExporter::testRenderToImageClampsExtremeSceneDimensions()
+{
+    WorkSpace workspace;
+    auto *sw = new InputSwitch();
+    workspace.scene()->addItem(sw);
+    sw->setPos(1e7, 1e7);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + "/extreme.png";
+    CircuitExporter::renderToImage(workspace.scene(), path);
+
+    QImage image(path);
+    QVERIFY(!image.isNull());
+    QVERIFY(image.width() <= CircuitExporter::kMaxImageDimension);
+    QVERIFY(image.height() <= CircuitExporter::kMaxImageDimension);
+}
+
+void TestCircuitExporter::testRenderToPdfHandlesExtremeSceneDimensionsPromptly()
+{
+    WorkSpace workspace;
+    auto *sw = new InputSwitch();
+    workspace.scene()->addItem(sw);
+    sw->setPos(1e7, 1e7);
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = dir.path() + "/extreme.pdf";
+    CircuitExporter::renderToPdf(workspace.scene(), path);
+    QVERIFY(QFile::exists(path));
 }

--- a/Tests/Unit/Ui/TestCircuitExporter.h
+++ b/Tests/Unit/Ui/TestCircuitExporter.h
@@ -35,4 +35,10 @@ private slots:
     // vulnerable code path (unlike the pixel-buffer issue, which is renderToImage-only,
     // since renderToPdf's page size is fixed) and must complete promptly too.
     void testRenderToPdfHandlesExtremeSceneDimensionsPromptly();
+
+    // Regression: renderToImage() was refactored into a thin wrapper around
+    // CircuitExporter::renderScaledImage() so the MCP export_image handler could reuse the
+    // same bounding logic instead of re-implementing (and never bounding) it. Pin the
+    // extracted function's own contract directly, independent of the file round-trip above.
+    void testRenderScaledImageClampsExtremeDimensionsDirectly();
 };

--- a/Tests/Unit/Ui/TestCircuitExporter.h
+++ b/Tests/Unit/Ui/TestCircuitExporter.h
@@ -16,4 +16,23 @@ private slots:
 
     // Regression: D19 — renderToImage must throw on save failure
     void testRenderToImageThrowsOnInvalidPath();
+
+    // Regression: QPixmap(size) is uninitialized until painted over; Scene only paints its
+    // background opaquely once Scene::updateTheme() has run. A WorkSpace that never called
+    // it (this test, deliberately) must still produce a fully-painted (not garbage) image.
+    void testRenderToImagePaddingIsTransparentNotGarbage();
+
+    // Regression: an element at an extreme-but-finite position (the only check on load
+    // rejects non-finite, not large, coordinates) must not allocate a proportionally-sized
+    // pixel buffer — output must stay within CircuitExporter::kMaxImageDimension.
+    void testRenderToImageClampsExtremeSceneDimensions();
+
+    // Regression: Scene::drawBackground()'s grid-dot loop had no bound on point count and
+    // operates on the *unscaled* exposed rect — an extreme-but-finite element position made
+    // it try to build a point list with billions of entries (confirmed via debugger: ~1e10
+    // iterations in progress at the 300s watchdog timeout), hanging well before either
+    // export function's own size cap ever mattered. renderToPdf shares the exact same
+    // vulnerable code path (unlike the pixel-buffer issue, which is renderToImage-only,
+    // since renderToPdf's page size is fixed) and must complete promptly too.
+    void testRenderToPdfHandlesExtremeSceneDimensionsPromptly();
 };

--- a/Tests/Unit/Ui/TestICDropZone.cpp
+++ b/Tests/Unit/Ui/TestICDropZone.cpp
@@ -3,6 +3,15 @@
 
 #include "Tests/Unit/Ui/TestICDropZone.h"
 
+#include <QApplication>
+#include <QDataStream>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QSignalSpy>
+
+#include "App/Core/Enums.h"
+#include "App/Core/MimeTypes.h"
+#include "App/IO/Serialization.h"
 #include "App/UI/ICDropZone.h"
 #include "Tests/Common/TestUtils.h"
 
@@ -16,4 +25,29 @@ void TestICDropZone::testICMimeData()
 {
     ICDropZone dropZone(ICDropZone::Section::Embedded);
     QVERIFY(dropZone.acceptDrops());
+}
+
+void TestICDropZone::testDropEventRejectsOversizedPayload()
+{
+    // Crafted payload: valid panda header + offset + type, then an implausible
+    // icFileName length prefix with no real data behind it.
+    QByteArray itemData;
+    QDataStream stream(&itemData, QIODevice::WriteOnly);
+    Serialization::writePandaHeader(stream);
+    stream << QPoint(0, 0);
+    stream << ElementType::IC;
+    stream << static_cast<quint32>(0x7FFFFFFF);
+
+    QMimeData mimeData;
+    mimeData.setData(MimeType::DragDrop, itemData);
+
+    ICDropZone dropZone(ICDropZone::Section::FileBased);
+    QSignalSpy embedSpy(&dropZone, &ICDropZone::embedByFileRequested);
+    QSignalSpy extractSpy(&dropZone, &ICDropZone::extractByBlobNameRequested);
+
+    QDropEvent dropEvent(QPointF(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(&dropZone, &dropEvent);
+
+    QCOMPARE(embedSpy.count(), 0);
+    QCOMPARE(extractSpy.count(), 0);
 }

--- a/Tests/Unit/Ui/TestICDropZone.h
+++ b/Tests/Unit/Ui/TestICDropZone.h
@@ -14,4 +14,8 @@ private slots:
 
     void testICDropEvent();
     void testICMimeData();
+
+    // Regression: a crafted drag payload with an implausible icFileName/blobName
+    // length must be rejected, not crash or hang the drop handler.
+    void testDropEventRejectsOversizedPayload();
 };

--- a/Tests/Unit/Ui/TestTrashButton.cpp
+++ b/Tests/Unit/Ui/TestTrashButton.cpp
@@ -3,8 +3,15 @@
 
 #include "Tests/Unit/Ui/TestTrashButton.h"
 
+#include <QApplication>
+#include <QDataStream>
+#include <QDropEvent>
 #include <QMimeData>
+#include <QSignalSpy>
 
+#include "App/Core/Enums.h"
+#include "App/Core/MimeTypes.h"
+#include "App/IO/Serialization.h"
 #include "App/UI/TrashButton.h"
 #include "Tests/Common/TestUtils.h"
 
@@ -25,4 +32,29 @@ void TestTrashButton::testEmptyDrop()
 {
     TrashButton button;
     QVERIFY(true);
+}
+
+void TestTrashButton::testDropEventRejectsOversizedPayload()
+{
+    // Crafted payload: valid panda header + offset + type, then an implausible
+    // icFileName length prefix with no real data behind it.
+    QByteArray itemData;
+    QDataStream stream(&itemData, QIODevice::WriteOnly);
+    Serialization::writePandaHeader(stream);
+    stream << QPoint(0, 0);
+    stream << ElementType::IC;
+    stream << static_cast<quint32>(0x7FFFFFFF);
+
+    QMimeData mimeData;
+    mimeData.setData(MimeType::DragDrop, itemData);
+
+    TrashButton button;
+    QSignalSpy removeFileSpy(&button, &TrashButton::removeICFile);
+    QSignalSpy removeEmbeddedSpy(&button, &TrashButton::removeEmbeddedIC);
+
+    QDropEvent dropEvent(QPointF(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(&button, &dropEvent);
+
+    QCOMPARE(removeFileSpy.count(), 0);
+    QCOMPARE(removeEmbeddedSpy.count(), 0);
 }

--- a/Tests/Unit/Ui/TestTrashButton.h
+++ b/Tests/Unit/Ui/TestTrashButton.h
@@ -15,4 +15,8 @@ private slots:
     void testDragEnterEvent();
     void testDropEvent();
     void testEmptyDrop();
+
+    // Regression: a crafted drag payload with an implausible icFileName/blobName
+    // length must be rejected, not crash or hang the drop handler.
+    void testDropEventRejectsOversizedPayload();
 };


### PR DESCRIPTION
## Summary

Started as a fix for custom LED appearance paths silently failing or spamming
errors, then grew into a broad deep-review series (multiple passes, each one
fix built/tested/revert-verified/committed independently) covering path
resolution, undo/redo correctness, and untrusted-input hardening across
`App/` and `MCP/`.

**Custom appearance/file path resolution** (the original scope):
- Stop custom appearance paths from silently failing or spamming errors;
  apply the same fix to AudioBox and BeWavedDolphin's linked-waveform files.
- Dedup `FileUtils::copyPandaDeps` into `Serialization::copyPandaFile`.

**Undo/redo correctness**:
- Give embedded-IC blob rename its own undo step instead of an `UpdateCommand`
  side effect; reject colliding blob renames; track pasted blobs in undo.
- Make property-shortcut commands fully and atomically undoable.
- Make `MorphCommand::undo()` symmetric with `redo()` for dropped connections.
- Close two IC-loading safety gaps found during a simulation-engine audit
  (missing `SimulationBlocker` around live IC reloads; missing recursion
  depth cap on the direct-file IC load path).
- Resync `Clock` instead of bursting after a large wall-clock gap (e.g. OS
  suspend); fix `TestClocksAdvanced` tests that didn't exercise the behavior
  their names claimed.
- Stop `WorkSpace::save()` from corrupting state on failure; stop
  `BeWavedDolphin` from leaving dangling scene references.

**Untrusted-input / resource-exhaustion hardening** (MCP calls, crafted
`.panda` files, clipboard/drag-and-drop payloads):
- Bound MCP's stdin line buffering against a client that never sends a
  newline.
- Bound IC dependency-chain recursion depth in two more places
  (`ICRegistry::makeBlobSelfContained`, `Serialization::copyPandaFile`).
- Bound the old-format trigger `QKeySequence` read, drag-and-drop payload
  reads, `DolphinClipboard::paste()`'s item count, and the clone-drag ghost
  image allocation -- all previously unbounded reads/allocations driven by
  stream- or client-supplied counts.
- Bound the appearance pixmap caches via `QPixmapCache` instead of an
  unbounded `QHash`.
- Reject non-finite/non-positive `Buzzer` frequency (mirrors `Clock`'s
  existing guard).
- Stop IC labels from injecting lines into generated Arduino/SystemVerilog
  code.
- Close a path-traversal write and a leaked IC in MCP's `ICHandler`.
- Share `CircuitExporter`'s bounded renderer with MCP's `export_image`, and
  bound `Scene`'s grid loop and `CircuitExporter`'s image buffer.
- Clamp negative `minCount` from exercise step JSON.
- Validate GitHub API URLs before download/open in the update checker.

## Test plan

- [x] `cmake --build --preset debug` succeeds
- [x] `ctest --preset debug` -- 191/191 passing
- [x] Rebased cleanly onto current `master` with no conflicts
- [x] Each fix individually revert-verified (temporarily defeated, confirmed
      its regression test fails, restored) before being committed