### PR TITLE
fix(ci): correct translation-status PR comment and a precedence bug

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -145,8 +145,7 @@ jobs:
           for ts_file in wpanda_*.ts; do
             if [[ -f "$ts_file" ]]; then
               # Check if file is valid XML
-              error_output=$(xmllint --noout "$ts_file" 2>&1)
-              if [ $? -ne 0 ]; then
+              if ! error_output=$(xmllint --noout "$ts_file" 2>&1); then
                 echo "❌ Invalid XML in $ts_file"
                 echo "Error details: $error_output"
                 exit 1
@@ -198,7 +197,7 @@ jobs:
       contents: write           # needed to commit backup-file cleanup
       pull-requests: write      # needed to comment on PRs
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'Weblate') || contains(github.event.pull_request.user.login, 'weblate')
+    if: github.event_name == 'pull_request' && (contains(github.event.pull_request.title, 'Weblate') || contains(github.event.pull_request.user.login, 'weblate'))
 
     steps:
       - name: Checkout code
@@ -239,8 +238,7 @@ jobs:
           for ts_file in wpanda_*.ts; do
             if [[ -f "$ts_file" ]]; then
               # Validate XML
-              error_output=$(xmllint --noout "$ts_file" 2>&1)
-              if [ $? -ne 0 ]; then
+              if ! error_output=$(xmllint --noout "$ts_file" 2>&1); then
                 echo "❌ XML validation failed for $ts_file"
                 echo "Error details: $error_output"
                 exit 1
@@ -336,10 +334,11 @@ jobs:
               const content = fs.readFileSync(path.join(translationsDir, tsFile), 'utf8');
 
               const totalMatches = content.match(/<message>/g);
-              const finishedMatches = content.match(/type="finished"/g);
+              const unfinishedMatches = content.match(/type="unfinished"/g);
 
               const total = totalMatches ? totalMatches.length : 0;
-              const finished = finishedMatches ? finishedMatches.length : 0;
+              const unfinished = unfinishedMatches ? unfinishedMatches.length : 0;
+              const finished = total - unfinished;
               const percentage = total > 0 ? Math.round((finished / total) * 100) : 0;
 
               let status = '🔴 Low';


### PR DESCRIPTION
## Summary

Investigating why PR #476's "Translation Status" comment showed every language, including `en` itself, at 0% (0/623) traced to a real bug in `.github/workflows/translate.yml`, not a translation-content problem. Deep-reviewed the whole file while in there per request.

- The reported bug: the "Add PR comment with translation status" step counted finished strings by matching `type="finished"`. Qt's `.ts` format never writes that marker: a completed `<translation>` tag has no `type` attribute at all; only incomplete ones are marked `type="unfinished"`. So `finished` was always `0`, making the percentage a constant 0% regardless of actual completion - which is exactly why `en` (fully translated by definition) showed 0% too. Fixed to compute `finished = total - unfinished`, mirroring the already-correct bash logic in this same file's `validate-translations` job.
- Latent `&&`/`||` precedence bug in `weblate-pr-handler`'s job `if:` - `event_name == 'pull_request' && A || B` parses as `(event_name == 'pull_request' && A) || B`, so the trailing OR wasn't actually gated on the event type. Harmless today only because no other trigger in this workflow populates `github.event.pull_request`; added the missing parentheses so it stays correct if that changes.
- Two SC2181 shellcheck hits (indirect `$?` checks) fixed as a free byproduct of running this repo's own actionlint gate directly against the file.
- Checked one more candidate (`github.event.pull_request.head.repo.full_name` spliced into a shell condition) against git history - that was already a deliberate, documented decision in a prior CodeQL-alert-fixing commit, not an oversight, so left untouched.

## Adversarial validation

- Reproduced the exact current bug by extracting the buggy JS and running it against the real `wpanda_*.ts` files: 0% (0/623) for every language, matching the reported table exactly. Ran the fix against the same 39 real files: correctly 100% (623/623) everywhere. Then, to rule out "always shows 100%" as a false-positive fix, ran it against a synthetic 4-message catalog (2 finished + 2 unfinished): old logic still reports 0% (0/4); new logic correctly reports 50% (2/4).
- Built a truth table over 5 scenarios (3 realistic, 2 adversarial) comparing old vs. new `if:` condition logic (JS has the same `&&`/`||` precedence as GitHub Actions expressions). Old and new agree on every current/legitimate scenario; they diverge exactly on the adversarial case predicted (old wrongly evaluates true, new correctly evaluates false), with zero behavior change to anything that happens today.
- Applied all fixes to a scratch copy and re-ran this repo's own actionlint binary: 2 SC2181 hits to 0, exit code 0, still valid YAML.

## Test plan

- actionlint on the edited file: 0 hits, exit code 0
- YAML validity check passes
- git diff --stat touches only .github/workflows/translate.yml
- Next real Weblate/translation PR should show correct percentages in the comment (can't be verified until this merges and the next such PR triggers the job)

Generated with Claude Code