### PR TITLE
feat(minimap): make the minimap draggable and resizable

### DIFF
--- a/App/Core/Settings.cpp
+++ b/App/Core/Settings.cpp
@@ -297,19 +297,12 @@ void Settings::setMinimapVisible(bool visible)
     setValue("minimap/visible", visible);
 }
 
-Settings::MinimapCorner Settings::minimapCorner()
+QRect Settings::minimapGeometry()
 {
-    const QVariant v = value("minimap/corner");
-    if (!v.isValid())
-        return MinimapCorner::BottomRight;
-    const int saved = v.toInt();
-    if (saved >= 0 && saved <= static_cast<int>(MinimapCorner::BottomRight)) {
-        return static_cast<MinimapCorner>(saved);
-    }
-    return MinimapCorner::BottomRight;
+    return value("minimap/geometry").toRect();
 }
 
-void Settings::setMinimapCorner(MinimapCorner corner)
+void Settings::setMinimapGeometry(const QRect &geometry)
 {
-    setValue("minimap/corner", static_cast<int>(corner));
+    setValue("minimap/geometry", geometry);
 }

--- a/App/Core/Settings.h
+++ b/App/Core/Settings.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <QByteArray>
+#include <QRect>
 #include <QSettings>
 #include <QStringList>
 
@@ -98,19 +99,13 @@ public:
     static bool welcomeTourShown();
     static void setWelcomeTourShown(bool shown);
 
-    /// Corner of the workspace where the minimap overview is anchored.
-    enum class MinimapCorner {
-        TopLeft,
-        TopRight,
-        BottomLeft,
-        BottomRight,
-    };
-
     // Minimap preferences
     static bool minimapVisible();
     static void setMinimapVisible(bool visible);
-    static MinimapCorner minimapCorner();
-    static void setMinimapCorner(MinimapCorner corner);
+    /// Position/size of the minimap overview, relative to its parent WorkSpace. Invalid
+    /// (QRect().isValid() == false) if never set -- callers fall back to a default corner.
+    static QRect minimapGeometry();
+    static void setMinimapGeometry(const QRect &geometry);
 
 private:
     static QVariant value(const QString &key);

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -64,6 +64,7 @@ WorkSpace::WorkSpace(QWidget *parent)
     m_minimap = new MinimapWidget(&m_scene, &m_view, this);
     m_minimap->setObjectName("minimap");
     m_minimap->raise();
+    connect(m_minimap, &MinimapWidget::geometryChangeFinished, this, &WorkSpace::onMinimapGeometryChangeFinished);
 
     // Adjust the scene rect after every zoom so that all items remain reachable
     // via panning, even when zoomed in very close
@@ -128,7 +129,7 @@ void WorkSpace::resizeEvent(QResizeEvent *event)
     QWidget::resizeEvent(event);
 
     if (m_minimap)
-        positionMinimap(Settings::minimapCorner());
+        applyMinimapGeometry();
 
     if (m_exerciseOverlay && m_exerciseOverlay->isVisible())
         m_exerciseOverlay->repositionToParent();
@@ -140,39 +141,56 @@ void WorkSpace::setMinimapVisible(bool visible)
     m_minimap->setVisible(visible);
 }
 
-void WorkSpace::setMinimapCorner(Settings::MinimapCorner corner)
-{
-    positionMinimap(corner);
-}
-
-void WorkSpace::positionMinimap(Settings::MinimapCorner corner)
+void WorkSpace::applyMinimapGeometry()
 {
     if (!m_minimap)
         return;
 
     const int margin = 12;
     const QRect viewGeom = m_view.geometry();
-    int x = viewGeom.right() - m_minimap->width() - margin;
-    int y = viewGeom.bottom() - m_minimap->height() - margin;
 
-    switch (corner) {
-    case Settings::MinimapCorner::BottomLeft:
-        x = viewGeom.left() + margin;
-        y = viewGeom.bottom() - m_minimap->height() - margin;
-        break;
-    case Settings::MinimapCorner::TopLeft:
-        x = viewGeom.left() + margin;
-        y = viewGeom.top() + margin;
-        break;
-    case Settings::MinimapCorner::TopRight:
-        x = viewGeom.right() - m_minimap->width() - margin;
-        y = viewGeom.top() + margin;
-        break;
-    case Settings::MinimapCorner::BottomRight:
-        break; // x/y already default to this
+    if (!m_minimapPositioned) {
+        m_minimapPositioned = true;
+
+        const QRect restored = Settings::minimapGeometry();
+        if (restored.isValid()) {
+            // Clamp size before position: a geometry persisted from a larger window/monitor
+            // could otherwise still overflow, or push the position clamp negative.
+            const int maxWidth = qMax(m_minimap->minimumWidth(), viewGeom.width() - 2 * margin);
+            const int maxHeight = qMax(m_minimap->minimumHeight(), viewGeom.height() - 2 * margin);
+            const int width = qBound(m_minimap->minimumWidth(), restored.width(), maxWidth);
+            const int height = qBound(m_minimap->minimumHeight(), restored.height(), maxHeight);
+            const int x = qBound(margin, restored.x(), viewGeom.width() - width - margin);
+            const int y = qBound(margin, restored.y(), viewGeom.height() - height - margin);
+            m_minimap->setGeometry(x, y, width, height);
+            return;
+        }
+
+        // No persisted geometry (first launch, or never moved/resized): default to the
+        // widget's own default size, anchored bottom-right.
+        const int x = viewGeom.right() - m_minimap->width() - margin;
+        const int y = viewGeom.bottom() - m_minimap->height() - margin;
+        m_minimap->move(qMax(x, margin), qMax(y, margin));
+        return;
     }
 
-    m_minimap->move(qMax(x, margin), qMax(y, margin));
+    // Subsequent resizes: re-clamp the minimap's own current geometry into the new bounds.
+    // Deliberately does not re-read Settings -- that's only the persisted copy, refreshed on
+    // user-driven moves/resizes (onMinimapGeometryChangeFinished()); re-reading it here on
+    // every window resize would stomp legitimate in-session geometry with a stale value.
+    const QRect current = m_minimap->geometry();
+    const int maxWidth = qMax(m_minimap->minimumWidth(), viewGeom.width() - 2 * margin);
+    const int maxHeight = qMax(m_minimap->minimumHeight(), viewGeom.height() - 2 * margin);
+    const int width = qBound(m_minimap->minimumWidth(), current.width(), maxWidth);
+    const int height = qBound(m_minimap->minimumHeight(), current.height(), maxHeight);
+    const int x = qBound(margin, current.x(), viewGeom.width() - width - margin);
+    const int y = qBound(margin, current.y(), viewGeom.height() - height - margin);
+    m_minimap->setGeometry(x, y, width, height);
+}
+
+void WorkSpace::onMinimapGeometryChangeFinished(const QRect &geometry)
+{
+    Settings::setMinimapGeometry(geometry);
 }
 
 Scene *WorkSpace::scene()

--- a/App/Scene/Workspace.h
+++ b/App/Scene/Workspace.h
@@ -124,7 +124,6 @@ public:
 
     // Minimap control
     void setMinimapVisible(bool visible);
-    void setMinimapCorner(Settings::MinimapCorner corner);
 
     // --- Waveform Integration ---
 
@@ -178,8 +177,14 @@ private:
     /// Atomically sets m_fileInfo and the scene's contextDir from \a filePath.
     void setCurrentFile(const QString &filePath);
 
-    /// Repositions m_minimap in its configured \a corner relative to m_view's geometry.
-    void positionMinimap(Settings::MinimapCorner corner);
+    /// Restores/reclamps m_minimap's geometry against the current view bounds. On the
+    /// first call, applies the persisted Settings::minimapGeometry() (size-then-position
+    /// clamped) or a hardcoded default corner if none is set; later calls just re-clamp
+    /// the minimap's current geometry into the (possibly shrunk) new bounds.
+    void applyMinimapGeometry();
+
+    /// Persists \a geometry as the user's minimap placement/size.
+    void onMinimapGeometryChangeFinished(const QRect &geometry);
 
     // --- Members ---
 
@@ -194,6 +199,10 @@ private:
 
     // Minimap overview widget (small, shows full scene and viewport)
     class MinimapWidget *m_minimap = nullptr;
+    /// True once applyMinimapGeometry() has applied its first (restored-or-default)
+    /// geometry; gates whether later resizeEvent()s re-read Settings (first time) or
+    /// just re-clamp the minimap's own current geometry (every time after).
+    bool m_minimapPositioned = false;
 
     // Inline IC tab state
     bool m_isInlineIC = false;

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -145,19 +145,11 @@ MainWindow::MainWindow(const QString &fileName, QWidget *parent)
     qCDebug(zero) << "Building a new tab.";
     createNewTab();
 
-    // Restore minimap visibility preference and apply to current tab if any.
+    // Restore minimap visibility preference and apply to current tab if any. Position/size
+    // are restored by WorkSpace itself (from Settings::minimapGeometry(), applied in its
+    // first resizeEvent()) -- no push needed from here.
     m_ui->actionShowMinimap->setChecked(Settings::minimapVisible());
     if (currentTab()) currentTab()->setMinimapVisible(Settings::minimapVisible());
-    m_ui->menuMinimapPosition->setEnabled(Settings::minimapVisible());
-    // Restore minimap corner preference
-    const Settings::MinimapCorner corner = Settings::minimapCorner();
-    switch (corner) {
-    case Settings::MinimapCorner::TopLeft: m_ui->actionMinimapTopLeft->setChecked(true); break;
-    case Settings::MinimapCorner::TopRight: m_ui->actionMinimapTopRight->setChecked(true); break;
-    case Settings::MinimapCorner::BottomLeft: m_ui->actionMinimapBottomLeft->setChecked(true); break;
-    case Settings::MinimapCorner::BottomRight: m_ui->actionMinimapBottomRight->setChecked(true); break;
-    }
-    if (currentTab()) currentTab()->setMinimapCorner(corner);
 
     qCDebug(zero) << "Opening file if not empty.";
     if (!fileName.isEmpty()) {
@@ -378,17 +370,6 @@ void MainWindow::setupConnections()
     connect(m_ui->actionICPreview,             &QAction::triggered,       this,                &MainWindow::on_actionICPreview_triggered);
     connect(m_ui->actionCheckForUpdates,       &QAction::triggered,       this,                &MainWindow::on_actionCheckForUpdates_triggered);
     connect(m_ui->actionShowMinimap,           &QAction::triggered,       this,                &MainWindow::on_actionShowMinimap_triggered);
-    connect(m_ui->actionMinimapTopLeft,        &QAction::triggered,       this,                &MainWindow::on_actionMinimapTopLeft_triggered);
-    connect(m_ui->actionMinimapTopRight,       &QAction::triggered,       this,                &MainWindow::on_actionMinimapTopRight_triggered);
-    connect(m_ui->actionMinimapBottomLeft,     &QAction::triggered,       this,                &MainWindow::on_actionMinimapBottomLeft_triggered);
-    connect(m_ui->actionMinimapBottomRight,    &QAction::triggered,       this,                &MainWindow::on_actionMinimapBottomRight_triggered);
-    // Minimap position actions are mutually exclusive (radio-style), same as the theme group below.
-    auto *minimapCornerGroup = new QActionGroup(this);
-    minimapCornerGroup->setExclusive(true);
-    minimapCornerGroup->addAction(m_ui->actionMinimapTopLeft);
-    minimapCornerGroup->addAction(m_ui->actionMinimapTopRight);
-    minimapCornerGroup->addAction(m_ui->actionMinimapBottomLeft);
-    minimapCornerGroup->addAction(m_ui->actionMinimapBottomRight);
     connect(m_ui->actionLightTheme,            &QAction::triggered,       this,                &MainWindow::on_actionLightTheme_triggered);
     connect(m_ui->actionMute,                  &QAction::triggered,       this,                &MainWindow::on_actionMute_triggered);
     connect(m_ui->actionNew,                   &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::newTab);
@@ -825,9 +806,10 @@ void MainWindow::onCurrentTabChanged(WorkSpace *newTab)
     m_binder->bind(newTab);
     m_palette->updateICList(icListFile());
 
-    // Apply minimap visibility and corner preferences to the newly activated tab.
+    // Apply the minimap visibility preference to the newly activated tab. Position/size are
+    // per-tab (each WorkSpace restores its own from Settings::minimapGeometry() on first
+    // layout), so there's nothing to push here for those.
     newTab->setMinimapVisible(Settings::minimapVisible());
-    newTab->setMinimapCorner(Settings::minimapCorner());
 
     // Hide management buttons for inline IC tabs (they use currentFile/currentDir which are empty)
     setICButtonsVisible(!newTab->isInlineIC());
@@ -1357,43 +1339,6 @@ void MainWindow::on_actionShowMinimap_triggered(const bool checked)
         sentryBreadcrumb("ui", QStringLiteral("Show minimap: %1").arg(checked));
         Settings::setMinimapVisible(checked);
         if (currentTab()) currentTab()->setMinimapVisible(checked);
-        m_ui->menuMinimapPosition->setEnabled(checked);
-    });
-}
-
-void MainWindow::on_actionMinimapTopLeft_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ui", QStringLiteral("Minimap corner: top-left"));
-        Settings::setMinimapCorner(Settings::MinimapCorner::TopLeft);
-        if (currentTab()) currentTab()->setMinimapCorner(Settings::MinimapCorner::TopLeft);
-    });
-}
-
-void MainWindow::on_actionMinimapTopRight_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ui", QStringLiteral("Minimap corner: top-right"));
-        Settings::setMinimapCorner(Settings::MinimapCorner::TopRight);
-        if (currentTab()) currentTab()->setMinimapCorner(Settings::MinimapCorner::TopRight);
-    });
-}
-
-void MainWindow::on_actionMinimapBottomLeft_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ui", QStringLiteral("Minimap corner: bottom-left"));
-        Settings::setMinimapCorner(Settings::MinimapCorner::BottomLeft);
-        if (currentTab()) currentTab()->setMinimapCorner(Settings::MinimapCorner::BottomLeft);
-    });
-}
-
-void MainWindow::on_actionMinimapBottomRight_triggered()
-{
-    Application::guardedSlot(this, [this] {
-        sentryBreadcrumb("ui", QStringLiteral("Minimap corner: bottom-right"));
-        Settings::setMinimapCorner(Settings::MinimapCorner::BottomRight);
-        if (currentTab()) currentTab()->setMinimapCorner(Settings::MinimapCorner::BottomRight);
     });
 }
 

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -262,10 +262,6 @@ private:
     void on_actionLabelsUnderIcons_triggered(const bool checked);
     void on_actionICPreview_triggered(const bool checked);
     void on_actionCheckForUpdates_triggered(const bool checked);
-    void on_actionMinimapBottomLeft_triggered();
-    void on_actionMinimapBottomRight_triggered();
-    void on_actionMinimapTopLeft_triggered();
-    void on_actionMinimapTopRight_triggered();
     void on_actionMute_triggered(const bool checked);
     void on_actionPlay_toggled(const bool checked);
     void on_actionReportTranslationError_triggered();

--- a/App/UI/MainWindowUI.cpp
+++ b/App/UI/MainWindowUI.cpp
@@ -184,18 +184,6 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     actionShowMinimap = new QAction(MainWindow);
     actionShowMinimap->setObjectName("actionShowMinimap");
     actionShowMinimap->setCheckable(true);
-    actionMinimapTopLeft = new QAction(MainWindow);
-    actionMinimapTopLeft->setObjectName("actionMinimapTopLeft");
-    actionMinimapTopLeft->setCheckable(true);
-    actionMinimapTopRight = new QAction(MainWindow);
-    actionMinimapTopRight->setObjectName("actionMinimapTopRight");
-    actionMinimapTopRight->setCheckable(true);
-    actionMinimapBottomLeft = new QAction(MainWindow);
-    actionMinimapBottomLeft->setObjectName("actionMinimapBottomLeft");
-    actionMinimapBottomLeft->setCheckable(true);
-    actionMinimapBottomRight = new QAction(MainWindow);
-    actionMinimapBottomRight->setObjectName("actionMinimapBottomRight");
-    actionMinimapBottomRight->setCheckable(true);
     actionAboutThisVersion = new QAction(MainWindow);
     actionAboutThisVersion->setObjectName("actionAboutThisVersion");
     actionRestart = new QAction(MainWindow);
@@ -627,8 +615,6 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuView->setObjectName("menuView");
     menuTheme = new QMenu(menuView);
     menuTheme->setObjectName("menuTheme");
-    menuMinimapPosition = new QMenu(menuView);
-    menuMinimapPosition->setObjectName("menuMinimapPosition");
     menuLanguage = new QMenu(menuBar);
     menuLanguage->setObjectName("menuLanguage");
     menuSimulation = new QMenu(menuBar);
@@ -741,11 +727,6 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuView->addAction(actionFastMode);
     menuView->addAction(actionShowMinimap);
     menuView->addSeparator();
-    menuView->addAction(menuMinimapPosition->menuAction());
-    menuMinimapPosition->addAction(actionMinimapTopLeft);
-    menuMinimapPosition->addAction(actionMinimapTopRight);
-    menuMinimapPosition->addAction(actionMinimapBottomLeft);
-    menuMinimapPosition->addAction(actionMinimapBottomRight);
     menuView->addAction(menuTheme->menuAction());
     menuView->addAction(actionFullscreen);
     menuView->addAction(actionLabelsUnderIcons);
@@ -863,10 +844,6 @@ void MainWindowUi::retranslateUi()
     actionLabelsUnderIcons->setText(QCoreApplication::translate("MainWindow", "Labels under icons"));
     actionICPreview->setText(QCoreApplication::translate("MainWindow", "Show IC Preview"));
     actionShowMinimap->setText(QCoreApplication::translate("MainWindow", "Show Minimap"));
-    actionMinimapTopLeft->setText(QCoreApplication::translate("MainWindow", "Top-left"));
-    actionMinimapTopRight->setText(QCoreApplication::translate("MainWindow", "Top-right"));
-    actionMinimapBottomLeft->setText(QCoreApplication::translate("MainWindow", "Bottom-left"));
-    actionMinimapBottomRight->setText(QCoreApplication::translate("MainWindow", "Bottom-right"));
     actionAboutThisVersion->setText(QCoreApplication::translate("MainWindow", "About this version"));
     actionCheckForUpdates->setText(QCoreApplication::translate("MainWindow", "Check for updates automatically"));
     actionRestart->setText(QCoreApplication::translate("MainWindow", "&Restart"));
@@ -902,7 +879,6 @@ void MainWindowUi::retranslateUi()
     menuHelp->setTitle(QCoreApplication::translate("MainWindow", "&Help"));
     menuView->setTitle(QCoreApplication::translate("MainWindow", "&View"));
     menuTheme->setTitle(QCoreApplication::translate("MainWindow", "&Theme"));
-    menuMinimapPosition->setTitle(QCoreApplication::translate("MainWindow", "Minimap &Position"));
     menuLanguage->setTitle(QCoreApplication::translate("MainWindow", "&Language"));
     menuSimulation->setTitle(QCoreApplication::translate("MainWindow", "Sim&ulation"));
     menuExamples->setTitle(QCoreApplication::translate("MainWindow", "Examples"));

--- a/App/UI/MainWindowUI.h
+++ b/App/UI/MainWindowUI.h
@@ -101,10 +101,6 @@ public:
     QAction *actionICPreview = nullptr;
     QAction *actionCheckForUpdates = nullptr;
     QAction *actionShowMinimap = nullptr;
-    QAction *actionMinimapTopLeft = nullptr;
-    QAction *actionMinimapTopRight = nullptr;
-    QAction *actionMinimapBottomLeft = nullptr;
-    QAction *actionMinimapBottomRight = nullptr;
     QAction *actionLightTheme = nullptr;
     QAction *actionDarkTheme = nullptr;
     QAction *actionSystemTheme = nullptr;
@@ -240,7 +236,6 @@ public:
     QMenu *menuEdit = nullptr;
     QMenu *menuView = nullptr;
     QMenu *menuTheme = nullptr;
-    QMenu *menuMinimapPosition = nullptr;
     QMenu *menuLanguage = nullptr;
     QMenu *menuSimulation = nullptr;
     QMenu *menuExamples = nullptr;

--- a/App/UI/MinimapWidget.cpp
+++ b/App/UI/MinimapWidget.cpp
@@ -104,6 +104,10 @@ void MinimapWidget::paintEvent(QPaintEvent * /*event*/)
     painter.setPen(pen);
     painter.setBrush(Qt::NoBrush);
     painter.drawRect(vr);
+
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    drawMoveHandle(painter);
+    drawResizeGrips(painter);
 }
 
 void MinimapWidget::mousePressEvent(QMouseEvent *event)
@@ -395,6 +399,64 @@ void MinimapWidget::moveBy(const QPoint &delta)
     move(x, y);
 }
 
+void MinimapWidget::drawMoveHandle(QPainter &painter) const
+{
+    const QRect handle = moveHandleRect();
+    const bool highlighted = m_moving || m_hoverMoveHandle;
+
+    QColor bg = highlighted ? palette().highlight().color() : palette().windowText().color();
+    bg.setAlpha(highlighted ? 90 : 35);
+    painter.fillRect(handle, bg);
+
+    // Grip dots (2 rows x 3 columns), the same affordance used for draggable strips/handles
+    // elsewhere (e.g. splitter/dock handles) -- signals "grab here" at a glance.
+    QColor dotColor = palette().windowText().color();
+    dotColor.setAlpha(highlighted ? 230 : 140);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(dotColor);
+
+    const QPointF center = handle.center();
+    constexpr double dotRadius = 1.2;
+    constexpr double spacingX = 6.0;
+    constexpr double spacingY = 5.0;
+    for (const double rowOffset : {-spacingY / 2.0, spacingY / 2.0}) {
+        for (const double colOffset : {-spacingX, 0.0, spacingX}) {
+            painter.drawEllipse(center + QPointF(colOffset, rowOffset), dotRadius, dotRadius);
+        }
+    }
+}
+
+void MinimapWidget::drawResizeGrips(QPainter &painter) const
+{
+    struct Corner {
+        ResizeMode mode;
+        QPoint origin;
+        int armX; // arm direction along x: +1 rightwards, -1 leftwards
+        int armY; // arm direction along y: +1 downwards, -1 upwards
+    };
+
+    constexpr int inset = 3;
+    constexpr int armLength = 9;
+    const QRect r = rect();
+    const Corner corners[] = {
+        {ResizeMode::TopLeft, QPoint(inset, inset), 1, 1},
+        {ResizeMode::TopRight, QPoint(r.width() - 1 - inset, inset), -1, 1},
+        {ResizeMode::BottomLeft, QPoint(inset, r.height() - 1 - inset), 1, -1},
+        {ResizeMode::BottomRight, QPoint(r.width() - 1 - inset, r.height() - 1 - inset), -1, -1},
+    };
+
+    for (const Corner &corner : corners) {
+        const bool highlighted = m_resizing ? m_resizeMode == corner.mode : m_hoverResizeMode == corner.mode;
+        QColor color = highlighted ? palette().highlight().color() : palette().windowText().color();
+        color.setAlpha(highlighted ? 230 : 130);
+        QPen pen(color);
+        pen.setWidthF(highlighted ? 2.0 : 1.4);
+        painter.setPen(pen);
+        painter.drawLine(corner.origin, corner.origin + QPoint(corner.armX * armLength, 0));
+        painter.drawLine(corner.origin, corner.origin + QPoint(0, corner.armY * armLength));
+    }
+}
+
 void MinimapWidget::mouseMoveEvent(QMouseEvent *event)
 {
     if (m_resizing) {
@@ -412,14 +474,7 @@ void MinimapWidget::mouseMoveEvent(QMouseEvent *event)
     }
 
     if (!m_dragging) {
-        const ResizeMode mode = resizeModeAt(event->pos());
-        if (mode != ResizeMode::None) {
-            setCursor(cursorForResizeMode(mode));
-        } else if (isMoveHandle(event->pos())) {
-            setCursor(Qt::OpenHandCursor);
-        } else {
-            unsetCursor();
-        }
+        updateHoverState(event->pos());
     }
 
     if (!m_dragging || !m_scene || !m_view) {
@@ -460,16 +515,36 @@ void MinimapWidget::mouseReleaseEvent(QMouseEvent *event)
 void MinimapWidget::enterEvent(QEnterEvent *event)
 {
     QWidget::enterEvent(event);
-    const ResizeMode mode = resizeModeAt(mapFromGlobal(QCursor::pos()));
-    if (mode != ResizeMode::None) {
-        setCursor(cursorForResizeMode(mode));
-    } else if (isMoveHandle(mapFromGlobal(QCursor::pos()))) {
-        setCursor(Qt::OpenHandCursor);
-    }
+    updateHoverState(mapFromGlobal(QCursor::pos()));
 }
 
 void MinimapWidget::leaveEvent(QEvent *event)
 {
     QWidget::leaveEvent(event);
     unsetCursor();
+    if (m_hoverResizeMode != ResizeMode::None || m_hoverMoveHandle) {
+        m_hoverResizeMode = ResizeMode::None;
+        m_hoverMoveHandle = false;
+        update();
+    }
+}
+
+void MinimapWidget::updateHoverState(const QPoint &pos)
+{
+    const ResizeMode mode = resizeModeAt(pos);
+    const bool onMoveHandle = mode == ResizeMode::None && isMoveHandle(pos);
+
+    if (mode != ResizeMode::None) {
+        setCursor(cursorForResizeMode(mode));
+    } else if (onMoveHandle) {
+        setCursor(Qt::OpenHandCursor);
+    } else {
+        unsetCursor();
+    }
+
+    if (mode != m_hoverResizeMode || onMoveHandle != m_hoverMoveHandle) {
+        m_hoverResizeMode = mode;
+        m_hoverMoveHandle = onMoveHandle;
+        update(); // repaint so the corner/move-strip highlight tracks the hover state
+    }
 }

--- a/App/UI/MinimapWidget.cpp
+++ b/App/UI/MinimapWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "App/UI/MinimapWidget.h"
 
+#include <QCursor>
 #include <QEvent>
 #include <QMouseEvent>
 #include <QPaintDevice>
@@ -21,8 +22,11 @@ MinimapWidget::MinimapWidget(Scene *scene, GraphicsView *view, QWidget *parent)
     setAttribute(Qt::WA_OpaquePaintEvent);
     setAttribute(Qt::WA_NoSystemBackground, false);
     setFocusPolicy(Qt::NoFocus);
-    // Default minimap size; can be tuned later or made a setting.
-    setFixedSize(220, 160);
+    // Resizable via drag handles on the edges/corners (see resizeModeAt()); the minimum
+    // keeps the viewport-outline overlay and mascot content legible.
+    setMinimumSize(160, 120);
+    resize(220, 160);
+    setMouseTracking(true); // hover cursor feedback over resize/move handles without a button held
     setToolTip(tr("Mini-map: click or drag to navigate"));
     setAccessibleName(tr("Circuit minimap"));
     setWhatsThis(tr("A miniature overview of the whole circuit. Click or drag inside it to "
@@ -106,6 +110,26 @@ void MinimapWidget::mousePressEvent(QMouseEvent *event)
 {
     if (!m_scene || !m_view) {
         return;
+    }
+
+    if (event->button() == Qt::LeftButton) {
+        const ResizeMode mode = resizeModeAt(event->pos());
+        if (mode != ResizeMode::None) {
+            m_resizing = true;
+            m_resizeMode = mode;
+            m_lastGlobalPos = event->globalPosition().toPoint();
+            grabMouse();
+            event->accept();
+            return;
+        }
+
+        if (isMoveHandle(event->pos())) {
+            m_moving = true;
+            m_lastGlobalPos = event->globalPosition().toPoint();
+            grabMouse();
+            event->accept();
+            return;
+        }
     }
 
     m_view->centerOn(widgetToScene(event->pos()));
@@ -221,8 +245,183 @@ QPointF MinimapWidget::widgetToScene(const QPointF &p) const
     return QPointF(x, y);
 }
 
+MinimapWidget::ResizeMode MinimapWidget::resizeModeAt(const QPoint &pos) const
+{
+    const int handleSize = 8;
+    const QRect r = rect();
+    const bool nearLeft = pos.x() <= handleSize;
+    const bool nearRight = pos.x() >= r.width() - handleSize;
+    const bool nearTop = pos.y() <= handleSize;
+    const bool nearBottom = pos.y() >= r.height() - handleSize;
+
+    if (nearTop && nearLeft) {
+        return ResizeMode::TopLeft;
+    }
+    if (nearTop && nearRight) {
+        return ResizeMode::TopRight;
+    }
+    if (nearBottom && nearLeft) {
+        return ResizeMode::BottomLeft;
+    }
+    if (nearBottom && nearRight) {
+        return ResizeMode::BottomRight;
+    }
+    if (nearLeft) {
+        return ResizeMode::Left;
+    }
+    if (nearRight) {
+        return ResizeMode::Right;
+    }
+    if (nearTop) {
+        return ResizeMode::Top;
+    }
+    if (nearBottom) {
+        return ResizeMode::Bottom;
+    }
+    return ResizeMode::None;
+}
+
+Qt::CursorShape MinimapWidget::cursorForResizeMode(ResizeMode mode) const
+{
+    switch (mode) {
+    case ResizeMode::Top:
+    case ResizeMode::Bottom:
+        return Qt::SizeVerCursor;
+    case ResizeMode::Left:
+    case ResizeMode::Right:
+        return Qt::SizeHorCursor;
+    case ResizeMode::TopLeft:
+    case ResizeMode::BottomRight:
+        return Qt::SizeFDiagCursor;
+    case ResizeMode::TopRight:
+    case ResizeMode::BottomLeft:
+        return Qt::SizeBDiagCursor;
+    default:
+        return Qt::ArrowCursor;
+    }
+}
+
+void MinimapWidget::applyResize(const QPoint &globalPos)
+{
+    const QPoint delta = globalPos - m_lastGlobalPos;
+    const QRect oldGeom = geometry();
+    QRect geom = oldGeom;
+
+    // Keep the widget's own aspect ratio stable while resizing -- based on the scene's
+    // content, same fallback chain as computeTransform() (itemsBoundingRect, then
+    // sceneRect), so a resize while empty/degenerate still has a sane 1:1 ratio.
+    const auto sceneAspectRatio = [this]() -> double {
+        QRectF src = m_scene ? m_scene->itemsBoundingRect() : QRectF();
+        if (!src.isValid() || src.isEmpty())
+            src = m_scene ? m_scene->sceneRect() : QRectF();
+        if (!src.isValid() || src.width() <= 0.0 || src.height() <= 0.0)
+            return 1.0;
+        return src.width() / src.height();
+    };
+
+    const double aspect = sceneAspectRatio();
+    int newWidth = geom.width();
+    int newHeight = geom.height();
+
+    const bool top = m_resizeMode == ResizeMode::Top || m_resizeMode == ResizeMode::TopLeft || m_resizeMode == ResizeMode::TopRight;
+    const bool bottom = m_resizeMode == ResizeMode::Bottom || m_resizeMode == ResizeMode::BottomLeft || m_resizeMode == ResizeMode::BottomRight;
+    const bool left = m_resizeMode == ResizeMode::Left || m_resizeMode == ResizeMode::TopLeft || m_resizeMode == ResizeMode::BottomLeft;
+    const bool right = m_resizeMode == ResizeMode::Right || m_resizeMode == ResizeMode::TopRight || m_resizeMode == ResizeMode::BottomRight;
+
+    if ((top && right) || (top && left) || (bottom && right) || (bottom && left)) {
+        // Diagonal handle: follow whichever axis the cursor is moving faster along, derive
+        // the other from the locked aspect ratio.
+        const bool horizontalDominant = qAbs(delta.x()) >= qAbs(delta.y());
+        if (horizontalDominant) {
+            newWidth = left ? geom.width() - delta.x() : geom.width() + delta.x();
+            newHeight = qRound(newWidth / aspect);
+        } else {
+            newHeight = top ? geom.height() - delta.y() : geom.height() + delta.y();
+            newWidth = qRound(newHeight * aspect);
+        }
+    } else if (top || bottom) {
+        newHeight = top ? geom.height() - delta.y() : geom.height() + delta.y();
+        newWidth = qRound(newHeight * aspect);
+    } else if (left || right) {
+        newWidth = left ? geom.width() - delta.x() : geom.width() + delta.x();
+        newHeight = qRound(newWidth / aspect);
+    }
+
+    newWidth = qMax(minimumWidth(), newWidth);
+    newHeight = qMax(minimumHeight(), newHeight);
+    if (newWidth < minimumWidth()) {
+        newWidth = minimumWidth();
+        newHeight = qMax(minimumHeight(), qRound(newWidth / aspect));
+    }
+    if (newHeight < minimumHeight()) {
+        newHeight = minimumHeight();
+        newWidth = qMax(minimumWidth(), qRound(newHeight * aspect));
+    }
+
+    geom.setSize(QSize(newWidth, newHeight));
+    if (top) {
+        geom.setTop(oldGeom.top() + (oldGeom.height() - newHeight));
+    }
+    if (left) {
+        geom.setLeft(oldGeom.left() + (oldGeom.width() - newWidth));
+    }
+
+    if (geom != oldGeom) {
+        setGeometry(geom);
+    }
+    m_lastGlobalPos = globalPos;
+}
+
+QRect MinimapWidget::moveHandleRect() const
+{
+    return QRect(0, 0, width(), 24);
+}
+
+bool MinimapWidget::isMoveHandle(const QPoint &pos) const
+{
+    return moveHandleRect().contains(pos);
+}
+
+void MinimapWidget::moveBy(const QPoint &delta)
+{
+    if (!parentWidget())
+        return;
+
+    const QPoint newPos = pos() + delta;
+    const QRect parentRect = parentWidget()->rect();
+    const int margin = 12;
+    const int x = qBound(margin, newPos.x(), parentRect.width() - width() - margin);
+    const int y = qBound(margin, newPos.y(), parentRect.height() - height() - margin);
+    move(x, y);
+}
+
 void MinimapWidget::mouseMoveEvent(QMouseEvent *event)
 {
+    if (m_resizing) {
+        applyResize(event->globalPosition().toPoint());
+        invalidateCache();
+        event->accept();
+        return;
+    }
+
+    if (m_moving) {
+        moveBy(event->globalPosition().toPoint() - m_lastGlobalPos);
+        m_lastGlobalPos = event->globalPosition().toPoint();
+        event->accept();
+        return;
+    }
+
+    if (!m_dragging) {
+        const ResizeMode mode = resizeModeAt(event->pos());
+        if (mode != ResizeMode::None) {
+            setCursor(cursorForResizeMode(mode));
+        } else if (isMoveHandle(event->pos())) {
+            setCursor(Qt::OpenHandCursor);
+        } else {
+            unsetCursor();
+        }
+    }
+
     if (!m_dragging || !m_scene || !m_view) {
         QWidget::mouseMoveEvent(event);
         return;
@@ -235,10 +434,42 @@ void MinimapWidget::mouseMoveEvent(QMouseEvent *event)
 
 void MinimapWidget::mouseReleaseEvent(QMouseEvent *event)
 {
+    if (m_resizing) {
+        m_resizing = false;
+        m_resizeMode = ResizeMode::None;
+        releaseMouse();
+        event->accept();
+        emit geometryChangeFinished(geometry());
+        return;
+    }
+    if (m_moving) {
+        m_moving = false;
+        releaseMouse();
+        event->accept();
+        emit geometryChangeFinished(geometry());
+        return;
+    }
     if (m_dragging) {
         m_dragging = false;
         event->accept();
         return;
     }
     QWidget::mouseReleaseEvent(event);
+}
+
+void MinimapWidget::enterEvent(QEnterEvent *event)
+{
+    QWidget::enterEvent(event);
+    const ResizeMode mode = resizeModeAt(mapFromGlobal(QCursor::pos()));
+    if (mode != ResizeMode::None) {
+        setCursor(cursorForResizeMode(mode));
+    } else if (isMoveHandle(mapFromGlobal(QCursor::pos()))) {
+        setCursor(Qt::OpenHandCursor);
+    }
+}
+
+void MinimapWidget::leaveEvent(QEvent *event)
+{
+    QWidget::leaveEvent(event);
+    unsetCursor();
 }

--- a/App/UI/MinimapWidget.h
+++ b/App/UI/MinimapWidget.h
@@ -11,6 +11,7 @@
 
 class Scene;
 class GraphicsView;
+class QPainter;
 
 class MinimapWidget : public QWidget
 {
@@ -67,6 +68,8 @@ private:
     bool m_moving = false;
     QPoint m_lastGlobalPos;
     ResizeMode m_resizeMode = ResizeMode::None;
+    ResizeMode m_hoverResizeMode = ResizeMode::None; ///< handle under the cursor, when not dragging
+    bool m_hoverMoveHandle = false;                  ///< move strip under the cursor, when not dragging
     QTimer m_throttle;        ///< throttle timer to limit redraws
 
     // Compute mapping parameters used by both paint and mouse handling.
@@ -82,4 +85,12 @@ private:
     QRect moveHandleRect() const;
     bool isMoveHandle(const QPoint &pos) const;
     void moveBy(const QPoint &delta);
+
+    // Cursor + hover-highlight state for the handles at pos, shared by mouseMoveEvent()
+    // and enterEvent() (and called directly by tests, since it takes a plain QPoint).
+    void updateHoverState(const QPoint &pos);
+
+    // Visual affordances painted so the handles are discoverable without hovering first.
+    void drawMoveHandle(QPainter &painter) const;
+    void drawResizeGrips(QPainter &painter) const;
 };

--- a/App/UI/MinimapWidget.h
+++ b/App/UI/MinimapWidget.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <QEnterEvent>
 #include <QPixmap>
+#include <QRect>
 #include <QTimer>
 #include <QWidget>
 
@@ -26,24 +28,58 @@ public slots:
     void onThrottleTimeout();
     void updateOverlay();
 
+signals:
+    /// Emitted once a drag-move or drag-resize finishes (mouseReleaseEvent), carrying the
+    /// widget's final geometry -- not on every mouseMoveEvent, so listeners persisting this
+    /// (e.g. to Settings) aren't spammed mid-drag.
+    void geometryChangeFinished(const QRect &geometry);
+
 protected:
     void paintEvent(QPaintEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override; // swallow wheel events so main view doesn't zoom
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
+    enum class ResizeMode {
+        None,
+        Top,
+        Bottom,
+        Left,
+        Right,
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight
+    };
+
     Scene *m_scene = nullptr;
     GraphicsView *m_view = nullptr;
     QPixmap m_cache;           ///< cached rendering of the scene for fast repaints
     bool m_cacheDirty = true;  ///< whether cache needs to be regenerated
     QRectF m_cacheSrc;         ///< source rect the cache was rendered from; a change invalidates it
     bool m_dragging = false;
+    bool m_resizing = false;
+    bool m_moving = false;
+    QPoint m_lastGlobalPos;
+    ResizeMode m_resizeMode = ResizeMode::None;
     QTimer m_throttle;        ///< throttle timer to limit redraws
 
     // Compute mapping parameters used by both paint and mouse handling.
     bool computeTransform(QRectF &srcOut, double &scaleOut, double &dxOut, double &dyOut, double &usedWOut, double &usedHOut) const;
     QPointF widgetToScene(const QPointF &p) const;
+
+    // Edge/corner resize handles.
+    ResizeMode resizeModeAt(const QPoint &pos) const;
+    Qt::CursorShape cursorForResizeMode(ResizeMode mode) const;
+    void applyResize(const QPoint &globalPos);
+
+    // Move handle: a strip along the top of the widget, dragged to reposition it freely.
+    QRect moveHandleRect() const;
+    bool isMoveHandle(const QPoint &pos) const;
+    void moveBy(const QPoint &delta);
 };

--- a/Tests/Unit/Common/TestSettings.cpp
+++ b/Tests/Unit/Common/TestSettings.cpp
@@ -92,6 +92,16 @@ void TestSettings::testTypedDolphinGeometry()
     QCOMPARE(Settings::dolphinGeometry(), geometry);
 }
 
+void TestSettings::testTypedMinimapGeometry()
+{
+    // Unset: invalid, so callers know to fall back to a default position/size.
+    QVERIFY(!Settings::minimapGeometry().isValid());
+
+    const QRect geometry(30, 40, 200, 150);
+    Settings::setMinimapGeometry(geometry);
+    QCOMPARE(Settings::minimapGeometry(), geometry);
+}
+
 void TestSettings::testTypedFastMode()
 {
     Settings::setFastMode(true);

--- a/Tests/Unit/Common/TestSettings.h
+++ b/Tests/Unit/Common/TestSettings.h
@@ -23,6 +23,7 @@ private slots:
     void testTypedSplitterGeometry();
     void testTypedSplitterState();
     void testTypedDolphinGeometry();
+    void testTypedMinimapGeometry();
     void testTypedFastMode();
     void testTypedLabelsUnderIcons();
     void testTypedUpdateChecksDisabled();

--- a/Tests/Unit/Scene/TestWorkspace.cpp
+++ b/Tests/Unit/Scene/TestWorkspace.cpp
@@ -45,26 +45,91 @@ void TestWorkspaceUnit::testFullScreenHandling()
     QVERIFY(workspace.simulation() != nullptr);
 }
 
-void TestWorkspaceUnit::testMinimapCornerPositioning()
+void TestWorkspaceUnit::testMinimapDefaultPositionWithoutPersistedGeometry()
 {
+    Settings::setMinimapGeometry(QRect()); // ensure a clean slate regardless of test order
+
     WorkSpace workspace;
     workspace.resize(400, 300);
     workspace.layout()->activate();
+    // resizeEvent() isn't reliably delivered to a never-shown top-level widget in a headless
+    // test run (layout activation still sizes m_view correctly via the layout engine, just
+    // not through the event path) -- call the geometry logic directly, same as the app's
+    // own resizeEvent() does.
+    workspace.applyMinimapGeometry();
 
     const QRect viewGeom = workspace.m_view.geometry();
     const int margin = 12;
     const int minimapW = workspace.m_minimap->width();
     const int minimapH = workspace.m_minimap->height();
 
-    workspace.setMinimapCorner(Settings::MinimapCorner::TopLeft);
-    QCOMPARE(workspace.m_minimap->pos(), QPoint(viewGeom.left() + margin, viewGeom.top() + margin));
-
-    workspace.setMinimapCorner(Settings::MinimapCorner::TopRight);
-    QCOMPARE(workspace.m_minimap->pos(), QPoint(viewGeom.right() - minimapW - margin, viewGeom.top() + margin));
-
-    workspace.setMinimapCorner(Settings::MinimapCorner::BottomLeft);
-    QCOMPARE(workspace.m_minimap->pos(), QPoint(viewGeom.left() + margin, viewGeom.bottom() - minimapH - margin));
-
-    workspace.setMinimapCorner(Settings::MinimapCorner::BottomRight);
+    // No persisted geometry: falls back to the widget's own default size, bottom-right.
     QCOMPARE(workspace.m_minimap->pos(), QPoint(viewGeom.right() - minimapW - margin, viewGeom.bottom() - minimapH - margin));
+}
+
+void TestWorkspaceUnit::testMinimapRestoresPersistedGeometry()
+{
+    const QRect persisted(30, 40, 200, 150);
+    Settings::setMinimapGeometry(persisted);
+
+    WorkSpace workspace;
+    workspace.resize(400, 300);
+    workspace.layout()->activate();
+    workspace.applyMinimapGeometry();
+
+    QCOMPARE(workspace.m_minimap->geometry(), persisted);
+}
+
+void TestWorkspaceUnit::testMinimapReclampsOnSubsequentResize()
+{
+    Settings::setMinimapGeometry(QRect(30, 40, 200, 150));
+
+    WorkSpace workspace;
+    workspace.resize(400, 300);
+    workspace.layout()->activate();
+    workspace.applyMinimapGeometry();
+    QCOMPARE(workspace.m_minimap->geometry(), QRect(30, 40, 200, 150));
+
+    // Change the persisted value mid-session: a later resize must re-clamp the minimap's
+    // own current geometry, not re-read (and jump to) this new Settings value -- Settings
+    // is only ever written *from* a user-driven move/resize, never read again after the
+    // first layout.
+    Settings::setMinimapGeometry(QRect(0, 0, 50, 50));
+
+    // Shrunk drastically -- comfortably above the minimap's own 160x120 minimum (so this
+    // exercises re-clamping the position, not the Qt-enforced size floor), but well below
+    // where (30,40,200,150) still fits.
+    workspace.resize(200, 180);
+    workspace.layout()->activate();
+    workspace.applyMinimapGeometry();
+
+    const QRect viewGeom = workspace.m_view.geometry();
+    const int margin = 12;
+    const QRect result = workspace.m_minimap->geometry();
+
+    QVERIFY2(result != QRect(0, 0, 50, 50), "must not have jumped to the changed Settings value");
+    QVERIFY2(result.x() >= margin && result.x() + result.width() <= viewGeom.width() - margin,
+             "x must be re-clamped within the shrunk view");
+    QVERIFY2(result.y() >= margin && result.y() + result.height() <= viewGeom.height() - margin,
+             "y must be re-clamped within the shrunk view");
+}
+
+void TestWorkspaceUnit::testMinimapRestoreClampsOversizedGeometry()
+{
+    // Persisted from a much larger window/monitor than the one being restored into.
+    Settings::setMinimapGeometry(QRect(10, 10, 900, 700));
+
+    WorkSpace workspace;
+    workspace.resize(300, 200);
+    workspace.layout()->activate();
+    workspace.applyMinimapGeometry();
+
+    const QRect viewGeom = workspace.m_view.geometry();
+    const int margin = 12;
+    QVERIFY2(workspace.m_minimap->width() <= viewGeom.width() - 2 * margin,
+             "restored size must be clamped to fit the current view, not just repositioned");
+    QVERIFY2(workspace.m_minimap->height() <= viewGeom.height() - 2 * margin,
+             "restored size must be clamped to fit the current view, not just repositioned");
+    QVERIFY(workspace.m_minimap->x() >= margin);
+    QVERIFY(workspace.m_minimap->y() >= margin);
 }

--- a/Tests/Unit/Scene/TestWorkspace.h
+++ b/Tests/Unit/Scene/TestWorkspace.h
@@ -17,5 +17,8 @@ private slots:
     void testModificationTracking();
     void testICEditing();
     void testFullScreenHandling();
-    void testMinimapCornerPositioning();
+    void testMinimapDefaultPositionWithoutPersistedGeometry();
+    void testMinimapRestoresPersistedGeometry();
+    void testMinimapReclampsOnSubsequentResize();
+    void testMinimapRestoreClampsOversizedGeometry();
 };

--- a/Tests/Unit/Ui/TestMinimapWidget.cpp
+++ b/Tests/Unit/Ui/TestMinimapWidget.cpp
@@ -250,3 +250,40 @@ void TestMinimapWidget::testMoveByClampsToParentBounds()
     QCOMPARE(minimap.x(), margin);
     QCOMPARE(minimap.y(), margin);
 }
+
+void TestMinimapWidget::testHoverStateOverCornerSetsResizeCursorAndHighlight()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    minimap.updateHoverState(QPoint(0, 0)); // top-left corner
+
+    QCOMPARE(minimap.m_hoverResizeMode, MinimapWidget::ResizeMode::TopLeft);
+    QVERIFY(!minimap.m_hoverMoveHandle);
+    QCOMPARE(minimap.cursor().shape(), Qt::SizeFDiagCursor);
+}
+
+void TestMinimapWidget::testHoverStateOverMoveStripSetsOpenHandCursorAndHighlight()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    minimap.updateHoverState(QPoint(minimap.width() / 2, 15)); // top strip, below the top resize zone (y<=8)
+
+    QCOMPARE(minimap.m_hoverResizeMode, MinimapWidget::ResizeMode::None);
+    QVERIFY(minimap.m_hoverMoveHandle);
+    QCOMPARE(minimap.cursor().shape(), Qt::OpenHandCursor);
+}
+
+void TestMinimapWidget::testHoverStateOverInteriorClearsHighlightAndCursor()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    minimap.updateHoverState(QPoint(0, 0)); // corner first, so state actually changes back below
+    minimap.updateHoverState(QPoint(minimap.width() / 2, minimap.height() / 2)); // interior
+
+    QCOMPARE(minimap.m_hoverResizeMode, MinimapWidget::ResizeMode::None);
+    QVERIFY(!minimap.m_hoverMoveHandle);
+    QCOMPARE(minimap.cursor().shape(), Qt::ArrowCursor);
+}

--- a/Tests/Unit/Ui/TestMinimapWidget.cpp
+++ b/Tests/Unit/Ui/TestMinimapWidget.cpp
@@ -149,3 +149,104 @@ void TestMinimapWidget::testAccessibleNameSet()
     QVERIFY(!minimap.accessibleName().isEmpty());
     QVERIFY(!minimap.whatsThis().isEmpty());
 }
+
+void TestMinimapWidget::testResizeModeAtEdgesAndCorners()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view()); // default size 220x160
+
+    using Mode = MinimapWidget::ResizeMode;
+    const int w = minimap.width();
+    const int h = minimap.height();
+
+    QCOMPARE(minimap.resizeModeAt(QPoint(0, h / 2)), Mode::Left);
+    QCOMPARE(minimap.resizeModeAt(QPoint(w - 1, h / 2)), Mode::Right);
+    QCOMPARE(minimap.resizeModeAt(QPoint(w / 2, 0)), Mode::Top);
+    QCOMPARE(minimap.resizeModeAt(QPoint(w / 2, h - 1)), Mode::Bottom);
+    QCOMPARE(minimap.resizeModeAt(QPoint(0, 0)), Mode::TopLeft);
+    QCOMPARE(minimap.resizeModeAt(QPoint(w - 1, 0)), Mode::TopRight);
+    QCOMPARE(minimap.resizeModeAt(QPoint(0, h - 1)), Mode::BottomLeft);
+    QCOMPARE(minimap.resizeModeAt(QPoint(w - 1, h - 1)), Mode::BottomRight);
+}
+
+void TestMinimapWidget::testResizeModeAtInteriorIsNone()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    QCOMPARE(minimap.resizeModeAt(QPoint(minimap.width() / 2, minimap.height() / 2)), MinimapWidget::ResizeMode::None);
+}
+
+void TestMinimapWidget::testApplyResizePreservesAspectRatio()
+{
+    WorkSpace workspace;
+    // A 2:1 items bounding rect drives applyResize()'s locked aspect ratio.
+    auto *rectItem = new QGraphicsRectItem(QRectF(0, 0, 400, 200));
+    rectItem->setPen(Qt::NoPen);
+    workspace.scene()->addItem(rectItem);
+
+    MinimapWidget minimap(workspace.scene(), workspace.view()); // starts at 220x160
+    minimap.m_resizeMode = MinimapWidget::ResizeMode::Right;
+    minimap.m_lastGlobalPos = QPoint(0, 0);
+    minimap.applyResize(QPoint(40, 0)); // drag the right edge out by 40px
+
+    QCOMPARE(minimap.width(), 260);
+    QVERIFY2(qAbs(static_cast<double>(minimap.width()) / minimap.height() - 2.0) < 0.05,
+             "resize must preserve the scene's 2:1 aspect ratio");
+}
+
+void TestMinimapWidget::testApplyResizeClampsToMinimumSize()
+{
+    WorkSpace workspace;
+    auto *rectItem = new QGraphicsRectItem(QRectF(0, 0, 400, 200));
+    rectItem->setPen(Qt::NoPen);
+    workspace.scene()->addItem(rectItem);
+
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+    minimap.m_resizeMode = MinimapWidget::ResizeMode::Right;
+    minimap.m_lastGlobalPos = QPoint(0, 0);
+    minimap.applyResize(QPoint(-1000, 0)); // drag drastically inward, past the minimum
+
+    QCOMPARE(minimap.width(), minimap.minimumWidth());
+    QCOMPARE(minimap.height(), minimap.minimumHeight());
+}
+
+void TestMinimapWidget::testMoveHandleRectCoversTopStrip()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    QCOMPARE(minimap.moveHandleRect(), QRect(0, 0, minimap.width(), 24));
+}
+
+void TestMinimapWidget::testIsMoveHandleDetectsTopStripOnly()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    QVERIFY(minimap.isMoveHandle(QPoint(minimap.width() / 2, 5)));
+    QVERIFY(!minimap.isMoveHandle(QPoint(minimap.width() / 2, 50)));
+}
+
+void TestMinimapWidget::testMoveByClampsToParentBounds()
+{
+    WorkSpace workspace;
+    QWidget parentWidget;
+    parentWidget.resize(300, 200);
+
+    MinimapWidget minimap(workspace.scene(), workspace.view(), &parentWidget);
+    minimap.move(50, 50);
+
+    // A huge move-right/down delta must clamp to the 12px margin, not push the widget
+    // (partially or fully) outside the parent.
+    minimap.moveBy(QPoint(10000, 10000));
+
+    const int margin = 12;
+    QCOMPARE(minimap.x(), parentWidget.width() - minimap.width() - margin);
+    QCOMPARE(minimap.y(), parentWidget.height() - minimap.height() - margin);
+
+    // Same for the opposite direction.
+    minimap.moveBy(QPoint(-10000, -10000));
+    QCOMPARE(minimap.x(), margin);
+    QCOMPARE(minimap.y(), margin);
+}

--- a/Tests/Unit/Ui/TestMinimapWidget.h
+++ b/Tests/Unit/Ui/TestMinimapWidget.h
@@ -20,4 +20,13 @@ private slots:
     void testWidgetToSceneClampsOutOfBoundsX();
     void testWidgetToSceneNullSceneDegradesToOrigin();
     void testAccessibleNameSet(); // #14 accessibility sweep
+
+    // Drag-to-resize / drag-to-move
+    void testResizeModeAtEdgesAndCorners();
+    void testResizeModeAtInteriorIsNone();
+    void testApplyResizePreservesAspectRatio();
+    void testApplyResizeClampsToMinimumSize();
+    void testMoveHandleRectCoversTopStrip();
+    void testIsMoveHandleDetectsTopStripOnly();
+    void testMoveByClampsToParentBounds();
 };

--- a/Tests/Unit/Ui/TestMinimapWidget.h
+++ b/Tests/Unit/Ui/TestMinimapWidget.h
@@ -29,4 +29,9 @@ private slots:
     void testMoveHandleRectCoversTopStrip();
     void testIsMoveHandleDetectsTopStripOnly();
     void testMoveByClampsToParentBounds();
+
+    // Visual affordances: hover state driving the handle highlight/cursor.
+    void testHoverStateOverCornerSetsResizeCursorAndHighlight();
+    void testHoverStateOverMoveStripSetsOpenHandCursorAndHighlight();
+    void testHoverStateOverInteriorClearsHighlightAndCursor();
 };


### PR DESCRIPTION
## Summary

Recreates the intent of `feat/minimap/issue_339` (issue #339, already closed) on top of
master's own `MinimapWidget` (PR #426, same author) instead of rebasing through an
add/add conflict — both branches independently built a minimap, so a literal rebase
would re-litigate settled review decisions from #426. Full reasoning is in each commit
message.

- Adds drag-to-move (top strip) and drag-to-resize (edge/corner handles, aspect-ratio
  preserving) interactions, replacing the old four-corner position picker.
- Persists the minimap's geometry (position + size), restored on next launch and
  re-clamped safely on window resize.
- Removes the now-redundant `View > Minimap Position` submenu.
- Adds visual affordances (a grip-dot move strip, corner resize brackets) that highlight
  on hover/drag, so the handles are discoverable without sweeping the mouse over the
  widget first.
- Fixes two real bugs found while porting the original branch's intent: an
  auto-resize-to-scene-aspect-ratio call that silently discarded manual resizes, and an
  unclamped restore that could overflow when reopened on a smaller window/monitor.

Refs #339 (already closed by #426 — no auto-close keyword needed).

## Test plan

- [x] `ctest --preset debug` — 191/191 passing, including new `TestMinimapWidget`,
      `TestWorkspaceUnit`, and `TestSettings` coverage
- [x] CI: Sanitizers (ASan + UBSan) green; Build green on 10/11 platforms (the sole
      failure was an unrelated Qt-mirror SSL flake on windows-11-arm during Qt install)
- [x] Verified the first commit builds and passes tests standalone (self-contained history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)