### PR TITLE
fix(minimap): restore persisted geometry reliably at startup

### DIFF
--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -128,11 +128,33 @@ void WorkSpace::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
 
-    if (m_minimap)
+    // Guard with isVisible(): MainWindow restores its geometry (including queuing a maximized
+    // state) before this tab is ever created, so this widget's very first resize fires while
+    // it's still not genuinely on screen -- carrying the pre-maximize "normal" size, not the
+    // final one. Consuming applyMinimapGeometry()'s one-time restore against that stale size
+    // would lose the persisted position for the rest of the session (subsequent resizes only
+    // re-clamp, they don't re-read Settings). Skipping it here lets the real, later resize --
+    // once the window manager actually applies the maximized geometry -- do the restore
+    // instead. showEvent() below covers windows that never resize again after becoming visible.
+    if (m_minimap && isVisible())
         applyMinimapGeometry();
 
     if (m_exerciseOverlay && m_exerciseOverlay->isVisible())
         m_exerciseOverlay->repositionToParent();
+}
+
+void WorkSpace::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+
+    // Backstop for windows that never resize again after becoming visible (e.g. a
+    // non-maximized launch, where restoreGeometry() already applied the final size before
+    // show()) -- resizeEvent() above would otherwise never get a chance to restore at all.
+    // Deferred briefly so a genuine maximize resize (handled above) wins the race when it's
+    // fast enough; applyMinimapGeometry() only restores once (m_minimapPositioned), so a
+    // redundant call here just re-clamps the already-correct geometry.
+    if (m_minimap)
+        QTimer::singleShot(100, this, [this] { applyMinimapGeometry(); });
 }
 
 void WorkSpace::setMinimapVisible(bool visible)

--- a/App/Scene/Workspace.h
+++ b/App/Scene/Workspace.h
@@ -152,6 +152,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 signals:
     /**

--- a/Tests/Unit/Scene/TestWorkspace.cpp
+++ b/Tests/Unit/Scene/TestWorkspace.cpp
@@ -133,3 +133,28 @@ void TestWorkspaceUnit::testMinimapRestoreClampsOversizedGeometry()
     QVERIFY(workspace.m_minimap->x() >= margin);
     QVERIFY(workspace.m_minimap->y() >= margin);
 }
+
+void TestWorkspaceUnit::testMinimapIgnoresPreShowResizeThenRestoresOnShow()
+{
+    const QRect persisted(30, 40, 200, 150);
+    Settings::setMinimapGeometry(persisted);
+
+    WorkSpace workspace;
+    // Resize while still hidden, exactly like MainWindow does via restoreGeometry() before
+    // it's ever shown (which, for a window that was maximized at quit, applies the smaller
+    // pre-maximize "normal" size first). Whatever resizeEvent(s) this produces must not
+    // consume the one-time restore -- otherwise it locks in geometry clamped against a size
+    // the window never actually settles at.
+    workspace.resize(160, 120);
+    QVERIFY(!workspace.m_minimapPositioned);
+
+    // Resize to the real final size and show it. Since nothing resizes again after becoming
+    // visible (unlike a maximize, which would trigger a further visible resizeEvent), the
+    // showEvent() backstop timer is what performs the restore here.
+    workspace.resize(400, 300);
+    workspace.show();
+    QTest::qWait(300);
+
+    QVERIFY(workspace.m_minimapPositioned);
+    QCOMPARE(workspace.m_minimap->geometry(), persisted);
+}

--- a/Tests/Unit/Scene/TestWorkspace.h
+++ b/Tests/Unit/Scene/TestWorkspace.h
@@ -21,4 +21,5 @@ private slots:
     void testMinimapRestoresPersistedGeometry();
     void testMinimapReclampsOnSubsequentResize();
     void testMinimapRestoreClampsOversizedGeometry();
+    void testMinimapIgnoresPreShowResizeThenRestoresOnShow();
 };


### PR DESCRIPTION
## Summary
- The minimap's persisted position/size (added in recent feat(minimap) commits) wasn't restoring on relaunch -- it always snapped back to the same spot.
- Root cause: MainWindow restores its geometry and creates the first tab before ever calling show(). For a window that was maximized at quit, Qt applies the pre-maximize "normal" size first and queues the maximized state separately, so WorkSpace's first resizeEvent fires with a stale size at a moment when it isn't genuinely on screen yet. applyMinimapGeometry()'s one-time restore latched against those wrong bounds, and was never corrected once the real maximize applied (subsequent resizes only re-clamp, by design, so mid-session Settings changes don't cause a jump).
- Fix: guard resizeEvent()'s restore call with isVisible() so the premature pre-show resize is skipped, letting a later, genuine on-screen resize (e.g. the real maximize) restore correctly -- plus a short showEvent()-scheduled timer as a backstop for windows that never resize again after becoming visible (non-maximized launches).

## Test plan
- [x] ctest --preset debug -- 191/191 passed
- [x] New regression test TestWorkspaceUnit::testMinimapIgnoresPreShowResizeThenRestoresOnShow, exercising the real resize()/show() event path rather than bypassing it
- [ ] Manual: drag the minimap, quit, relaunch, confirm it opens in the same spot (both maximized and non-maximized at quit)

Generated with Claude Code