### PR TITLE
Fix blurry element rendering at high zoom, and two Tour/Exercise simulation bugs

### DIFF
--- a/App/Element/GraphicElements/Demux.cpp
+++ b/App/Element/GraphicElements/Demux.cpp
@@ -125,13 +125,25 @@ QRectF Demux::boundingRect() const
 
 void Demux::generatePixmap()
 {
+    // The body is drawn as vectors in drawBody()/paint(); m_pixmap is kept only so the base
+    // pixmapCenter()/boundingRect() have the right size (its image content is never displayed).
     const int height = static_cast<int>(renderBodyBounds().height());
 
-    QPixmap tempPixmap(64, height);
-    tempPixmap.fill(Qt::transparent);
+    QPixmap sizingPixmap(64, height);
+    sizingPixmap.fill(Qt::transparent);
+    m_appearance.setRenderPixmap(sizingPixmap);
+    update();
+}
 
-    QPainter painter(&tempPixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
+void Demux::drawBody(QPainter *painter)
+{
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing);
+    // boundingRect()'s top-left may be negative when ports extend past the 64×64 body; align the
+    // local origin with it so the body lands exactly where the old rasterised pixmap was blitted.
+    painter->translate(boundingRect().topLeft());
+
+    const int height = pixmap().rect().height();
 
     // Trapezoid body: narrower on left (input side), wider on right (output side)
     const int bodyTop = 8;
@@ -139,19 +151,19 @@ void Demux::generatePixmap()
     const int leftInset = 8; // fixed inset for the narrower left side
 
     // Outer dark shape
-    painter.setBrush(QColor(38, 38, 38));
-    painter.setPen(QPen(QColor(38, 38, 38), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter->setBrush(QColor(38, 38, 38));
+    painter->setPen(QPen(QColor(38, 38, 38), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 
     QPolygonF outer;
     outer << QPointF(22, bodyTop + leftInset)
           << QPointF(22, bodyBottom - leftInset)
           << QPointF(42, bodyBottom)
           << QPointF(42, bodyTop);
-    painter.drawPolygon(outer);
+    painter->drawPolygon(outer);
 
     // Inner white fill
-    painter.setBrush(QColor(252, 252, 252));
-    painter.setPen(QPen(QColor(252, 252, 252), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter->setBrush(QColor(252, 252, 252));
+    painter->setPen(QPen(QColor(252, 252, 252), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 
     const int fillInset = 4;
     QPolygonF inner;
@@ -159,9 +171,9 @@ void Demux::generatePixmap()
           << QPointF(22 + fillInset, bodyBottom - leftInset - fillInset + 2)
           << QPointF(42 - fillInset, bodyBottom - fillInset)
           << QPointF(42 - fillInset, bodyTop + fillInset);
-    painter.drawPolygon(inner);
+    painter->drawPolygon(inner);
 
-    m_appearance.setRenderPixmap(tempPixmap);
+    painter->restore();
 }
 
 void Demux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -177,7 +189,8 @@ void Demux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWi
         painter->restore();
     }
 
-    painter->drawPixmap(boundingRect().topLeft(), pixmap());
+    // Draw the body as vectors (crisp at any zoom) rather than blitting a fixed-resolution pixmap.
+    drawBody(painter);
 }
 
 void Demux::updateLogic()

--- a/App/Element/GraphicElements/Demux.h
+++ b/App/Element/GraphicElements/Demux.h
@@ -46,6 +46,10 @@ public:
 private:
     void generatePixmap();
 
+    /// Draws the trapezoid body straight onto \a painter as vectors, so it stays crisp at any
+    /// zoom instead of blitting a fixed-resolution pixmap.
+    void drawBody(QPainter *painter);
+
     // Prevent direct input size setting - inputs are derived from output size
     void setInputSize(const int size) override;
 

--- a/App/Element/GraphicElements/Display14.cpp
+++ b/App/Element/GraphicElements/Display14.cpp
@@ -4,6 +4,7 @@
 #include "App/Element/GraphicElements/Display14.h"
 
 #include <QPainter>
+#include <QSvgRenderer>
 
 #include "App/Element/ElementFactory.h"
 #include "App/Element/ElementInfo.h"
@@ -65,21 +66,21 @@ struct ElementInfo<Display14> {
 Display14::Display14(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display14, parent)
 {
-    a  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(1));
-    b  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(2));
-    c  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(3));
-    d  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(4));
-    e  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(5));
-    f  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(6));
-    g1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(7));
-    g2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(8));
-    h  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(9));
-    j  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(10));
-    k  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(11));
-    l  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(12));
-    m  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(13));
-    n  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(14));
-    dp = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(15));
+    a  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(1));
+    b  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(2));
+    c  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(3));
+    d  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(4));
+    e  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(5));
+    f  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(6));
+    g1 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(7));
+    g2 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(8));
+    h  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(9));
+    j  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(10));
+    k  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(11));
+    l  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(12));
+    m  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(13));
+    n  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(14));
+    dp = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(15));
 
     Display14::updatePortsProperties();
 }
@@ -122,24 +123,26 @@ void Display14::updatePortsProperties()
 
 void Display14::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-    // Base class paints the off-state background; active segments are overlaid additively
+    // Base class paints the off-state background; active segments are overlaid as vector
+    // renders on top, crisp at any zoom.
     GraphicElement::paint(painter, option, widget);
 
-    if (inputPort(0)->status() == Status::Active)  { painter->drawPixmap(0, 0, g1.at(m_colorNumber)); }
-    if (inputPort(1)->status() == Status::Active)  { painter->drawPixmap(0, 0, f.at(m_colorNumber));  }
-    if (inputPort(2)->status() == Status::Active)  { painter->drawPixmap(0, 0, e.at(m_colorNumber));  }
-    if (inputPort(3)->status() == Status::Active)  { painter->drawPixmap(0, 0, d.at(m_colorNumber));  }
-    if (inputPort(4)->status() == Status::Active)  { painter->drawPixmap(0, 0, a.at(m_colorNumber));  }
-    if (inputPort(5)->status() == Status::Active)  { painter->drawPixmap(0, 0, b.at(m_colorNumber));  }
-    if (inputPort(6)->status() == Status::Active)  { painter->drawPixmap(0, 0, dp.at(m_colorNumber)); }
-    if (inputPort(7)->status() == Status::Active)  { painter->drawPixmap(0, 0, c.at(m_colorNumber));  }
-    if (inputPort(8)->status() == Status::Active)  { painter->drawPixmap(0, 0, g2.at(m_colorNumber)); }
-    if (inputPort(9)->status() == Status::Active)  { painter->drawPixmap(0, 0, h.at(m_colorNumber));  }
-    if (inputPort(10)->status() == Status::Active) { painter->drawPixmap(0, 0, j.at(m_colorNumber));  }
-    if (inputPort(11)->status() == Status::Active) { painter->drawPixmap(0, 0, k.at(m_colorNumber));  }
-    if (inputPort(12)->status() == Status::Active) { painter->drawPixmap(0, 0, l.at(m_colorNumber));  }
-    if (inputPort(13)->status() == Status::Active) { painter->drawPixmap(0, 0, m.at(m_colorNumber));  }
-    if (inputPort(14)->status() == Status::Active) { painter->drawPixmap(0, 0, n.at(m_colorNumber));  }
+    const QRectF body(0, 0, 64, 64);
+    if (inputPort(0)->status() == Status::Active)  { g1.at(m_colorNumber)->render(painter, body); }
+    if (inputPort(1)->status() == Status::Active)  { f.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(2)->status() == Status::Active)  { e.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(3)->status() == Status::Active)  { d.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(4)->status() == Status::Active)  { a.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(5)->status() == Status::Active)  { b.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(6)->status() == Status::Active)  { dp.at(m_colorNumber)->render(painter, body); }
+    if (inputPort(7)->status() == Status::Active)  { c.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(8)->status() == Status::Active)  { g2.at(m_colorNumber)->render(painter, body); }
+    if (inputPort(9)->status() == Status::Active)  { h.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(10)->status() == Status::Active) { j.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(11)->status() == Status::Active) { k.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(12)->status() == Status::Active) { l.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(13)->status() == Status::Active) { m.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(14)->status() == Status::Active) { n.at(m_colorNumber)->render(painter, body);  }
 }
 
 void Display14::setColor(const QString &color)

--- a/App/Element/GraphicElements/Display14.h
+++ b/App/Element/GraphicElements/Display14.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include "App/Element/GraphicElement.h"
+
+class QSvgRenderer;
 
 /**
  * \class Display14
@@ -60,6 +64,7 @@ private:
     // --- Members ---
 
     QString m_color = "Red";
-    QVector<QPixmap> bkg, a, b, c, d, e, f, g1, g2, h, j, k, l, m, n, dp;
+    QVector<QPixmap> bkg;
+    QVector<std::shared_ptr<QSvgRenderer>> a, b, c, d, e, f, g1, g2, h, j, k, l, m, n, dp;
     int m_colorNumber = 1;
 };

--- a/App/Element/GraphicElements/Display16.cpp
+++ b/App/Element/GraphicElements/Display16.cpp
@@ -4,6 +4,7 @@
 #include "App/Element/GraphicElements/Display16.h"
 
 #include <QPainter>
+#include <QSvgRenderer>
 
 #include "App/Element/ElementFactory.h"
 #include "App/Element/ElementInfo.h"
@@ -67,23 +68,23 @@ struct ElementInfo<Display16> {
 Display16::Display16(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display16, parent)
 {
-    a1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(1));
-    a2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(2));
-    b  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(3));
-    c  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(4));
-    d1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(5));
-    d2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(6));
-    e  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(7));
-    f  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(8));
-    g1 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(9));
-    g2 = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(10));
-    h  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(11));
-    j  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(12));
-    k  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(13));
-    l  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(14));
-    m  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(15));
-    n  = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(16));
-    dp = Display7::cachedSegmentColors(m_appearance.defaultAppearances().at(17));
+    a1 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(1));
+    a2 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(2));
+    b  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(3));
+    c  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(4));
+    d1 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(5));
+    d2 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(6));
+    e  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(7));
+    f  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(8));
+    g1 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(9));
+    g2 = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(10));
+    h  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(11));
+    j  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(12));
+    k  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(13));
+    l  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(14));
+    m  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(15));
+    n  = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(16));
+    dp = Display7::cachedSegmentRenderers(m_appearance.defaultAppearances().at(17));
 
     Display16::updatePortsProperties();
 }
@@ -130,26 +131,28 @@ void Display16::updatePortsProperties()
 
 void Display16::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-    // Base class draws the off-state background; active segments are overlaid on top
+    // Base class draws the off-state background; active segments are overlaid as vector
+    // renders on top, crisp at any zoom.
     GraphicElement::paint(painter, option, widget);
 
-    if (inputPort( 0)->status() == Status::Active) { painter->drawPixmap(0, 0, g1.at(m_colorNumber)); }
-    if (inputPort( 1)->status() == Status::Active) { painter->drawPixmap(0, 0, f.at(m_colorNumber));  }
-    if (inputPort( 2)->status() == Status::Active) { painter->drawPixmap(0, 0, e.at(m_colorNumber));  }
-    if (inputPort( 3)->status() == Status::Active) { painter->drawPixmap(0, 0, d1.at(m_colorNumber)); }
-    if (inputPort( 4)->status() == Status::Active) { painter->drawPixmap(0, 0, d2.at(m_colorNumber)); }
-    if (inputPort( 5)->status() == Status::Active) { painter->drawPixmap(0, 0, a1.at(m_colorNumber)); }
-    if (inputPort( 6)->status() == Status::Active) { painter->drawPixmap(0, 0, a2.at(m_colorNumber)); }
-    if (inputPort( 7)->status() == Status::Active) { painter->drawPixmap(0, 0, b.at(m_colorNumber));  }
-    if (inputPort( 8)->status() == Status::Active) { painter->drawPixmap(0, 0, dp.at(m_colorNumber)); }
-    if (inputPort( 9)->status() == Status::Active) { painter->drawPixmap(0, 0, c.at(m_colorNumber));  }
-    if (inputPort(10)->status() == Status::Active) { painter->drawPixmap(0, 0, g2.at(m_colorNumber)); }
-    if (inputPort(11)->status() == Status::Active) { painter->drawPixmap(0, 0, h.at(m_colorNumber));  }
-    if (inputPort(12)->status() == Status::Active) { painter->drawPixmap(0, 0, j.at(m_colorNumber));  }
-    if (inputPort(13)->status() == Status::Active) { painter->drawPixmap(0, 0, k.at(m_colorNumber));  }
-    if (inputPort(14)->status() == Status::Active) { painter->drawPixmap(0, 0, l.at(m_colorNumber));  }
-    if (inputPort(15)->status() == Status::Active) { painter->drawPixmap(0, 0, m.at(m_colorNumber));  }
-    if (inputPort(16)->status() == Status::Active) { painter->drawPixmap(0, 0, n.at(m_colorNumber));  }
+    const QRectF body(0, 0, 64, 64);
+    if (inputPort( 0)->status() == Status::Active) { g1.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 1)->status() == Status::Active) { f.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort( 2)->status() == Status::Active) { e.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort( 3)->status() == Status::Active) { d1.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 4)->status() == Status::Active) { d2.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 5)->status() == Status::Active) { a1.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 6)->status() == Status::Active) { a2.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 7)->status() == Status::Active) { b.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort( 8)->status() == Status::Active) { dp.at(m_colorNumber)->render(painter, body); }
+    if (inputPort( 9)->status() == Status::Active) { c.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(10)->status() == Status::Active) { g2.at(m_colorNumber)->render(painter, body); }
+    if (inputPort(11)->status() == Status::Active) { h.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(12)->status() == Status::Active) { j.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(13)->status() == Status::Active) { k.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(14)->status() == Status::Active) { l.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(15)->status() == Status::Active) { m.at(m_colorNumber)->render(painter, body);  }
+    if (inputPort(16)->status() == Status::Active) { n.at(m_colorNumber)->render(painter, body);  }
 }
 
 void Display16::setColor(const QString &color)

--- a/App/Element/GraphicElements/Display16.h
+++ b/App/Element/GraphicElements/Display16.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
+#include <memory>
+
 #include "App/Element/GraphicElement.h"
+
+class QSvgRenderer;
 
 /**
  * \class Display16
@@ -60,6 +64,7 @@ private:
     // --- Members ---
 
     QString m_color = "Red";
-    QVector<QPixmap> bkg, a1, a2, b, c, d1, d2, e, f, g1, g2, h, j, k, l, m, n, dp;
+    QVector<QPixmap> bkg;
+    QVector<std::shared_ptr<QSvgRenderer>> a1, a2, b, c, d1, d2, e, f, g1, g2, h, j, k, l, m, n, dp;
     int m_colorNumber = 1;
 };

--- a/App/Element/GraphicElements/Display7.cpp
+++ b/App/Element/GraphicElements/Display7.cpp
@@ -4,9 +4,11 @@
 #include "App/Element/GraphicElements/Display7.h"
 
 #include <QCoreApplication>
+#include <QFile>
 #include <QHash>
 #include <QPainter>
-#include <QPixmap>
+#include <QRegularExpression>
+#include <QSvgRenderer>
 #include <QThread>
 
 #include "App/Core/Common.h"
@@ -16,6 +18,21 @@
 #include "App/IO/SerializationContext.h"
 #include "App/IO/VersionInfo.h"
 #include "App/Wiring/Port.h"
+
+namespace {
+
+/// Substitutes every solid fill color in \a svgBytes with \a color, leaving each shape's own
+/// fill-opacity untouched -- the segment SVGs are solid-filled single shapes, so this reproduces
+/// the White/Red/Green/Blue/Purple variants the old per-pixel channel remap produced.
+QByteArray recoloredSegmentSvg(const QByteArray &svgBytes, const QColor &color)
+{
+    static const QRegularExpression fillHex(QStringLiteral("fill:#[0-9a-fA-F]{6}"));
+    QString svg = QString::fromUtf8(svgBytes);
+    svg.replace(fillHex, QStringLiteral("fill:%1").arg(color.name()));
+    return svg.toUtf8();
+}
+
+} // namespace
 
 template<>
 struct ElementInfo<Display7> {
@@ -62,72 +79,45 @@ struct ElementInfo<Display7> {
 Display7::Display7(QGraphicsItem *parent)
     : GraphicElement(ElementType::Display7, parent)
 {
-    a  = cachedSegmentColors(m_appearance.defaultAppearances().at(1));
-    b  = cachedSegmentColors(m_appearance.defaultAppearances().at(2));
-    c  = cachedSegmentColors(m_appearance.defaultAppearances().at(3));
-    d  = cachedSegmentColors(m_appearance.defaultAppearances().at(4));
-    e  = cachedSegmentColors(m_appearance.defaultAppearances().at(5));
-    f  = cachedSegmentColors(m_appearance.defaultAppearances().at(6));
-    g  = cachedSegmentColors(m_appearance.defaultAppearances().at(7));
-    dp = cachedSegmentColors(m_appearance.defaultAppearances().at(8));
+    a  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(1));
+    b  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(2));
+    c  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(3));
+    d  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(4));
+    e  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(5));
+    f  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(6));
+    g  = cachedSegmentRenderers(m_appearance.defaultAppearances().at(7));
+    dp = cachedSegmentRenderers(m_appearance.defaultAppearances().at(8));
 
     Display7::updatePortsProperties();
 }
 
-QVector<QPixmap> Display7::cachedSegmentColors(const QString &resourcePath)
+QVector<std::shared_ptr<QSvgRenderer>> Display7::cachedSegmentRenderers(const QString &resourcePath)
 {
     Q_ASSERT(QCoreApplication::instance()->thread() == QThread::currentThread());
 
-    static QHash<QString, QVector<QPixmap>> cache;
+    static QHash<QString, QVector<std::shared_ptr<QSvgRenderer>>> cache;
 
     auto it = cache.find(resourcePath);
     if (it != cache.end()) {
         return *it;
     }
 
-    QVector<QPixmap> colors(5, QPixmap(resourcePath));
-    convertAllColors(colors);
-    cache.insert(resourcePath, colors);
-    return colors;
-}
+    QFile file(resourcePath);
+    const QByteArray svgBytes = file.open(QIODevice::ReadOnly) ? file.readAll() : QByteArray();
 
-void Display7::convertAllColors(QVector<QPixmap> &pixmaps)
-{
-    // All five slots start with the same source image; recolor each one by
-    // selectively passing or zeroing the R/G/B channels:
-    //   0 = White  (R+G+B), 1 = Red (R only), 2 = Green (G only),
-    //   3 = Blue   (B only), 4 = Purple (R+B)
-    QImage tmp(pixmaps.at(0).toImage());
-    pixmaps[0] = convertColor(tmp, true, true, true);
-    pixmaps[1] = convertColor(tmp, true, false, false);
-    pixmaps[2] = convertColor(tmp, false, true, false);
-    pixmaps[3] = convertColor(tmp, false, false, true);
-    pixmaps[4] = convertColor(tmp, true, false, true);
-}
+    // Index order matches colorNameToIndex(): 0=White, 1=Red, 2=Green, 3=Blue, 4=Purple
+    static const QColor colors[] = {
+        QColor(255, 255, 255), QColor(255, 0, 0), QColor(0, 255, 0), QColor(0, 0, 255), QColor(255, 0, 255)
+    };
 
-QPixmap Display7::convertColor(const QImage &source, const bool red, const bool green, const bool blue)
-{
-    QImage target(source);
-
-    for (int y = 0; y < target.height(); ++y) {
-        for (int x = 0; x < target.width(); ++x) {
-            // The source SVG uses grayscale: red channel encodes pixel brightness.
-            // Reuse that brightness value for the enabled channels and set alpha
-            // equal to brightness so transparent backgrounds remain transparent.
-            // Uses the pixel()/setPixel() accessors instead of a raw scanLine()
-            // cast to QRgb* — scanLine() returns uchar*, and reinterpret_cast to
-            // the 4-byte-aligned QRgb is a -Wcast-align violation on armhf/riscv64
-            // (issue #453). Called only a handful of times total (cached), so the
-            // per-pixel accessor cost is irrelevant here.
-            const int value = qRed(target.pixel(x, y));
-            target.setPixel(x, y, qRgba(red   ? value : 0,
-                                         green ? value : 0,
-                                         blue  ? value : 0,
-                                         value));
-        }
+    QVector<std::shared_ptr<QSvgRenderer>> renderers;
+    renderers.reserve(5);
+    for (const QColor &color : colors) {
+        renderers.append(std::make_shared<QSvgRenderer>(recoloredSegmentSvg(svgBytes, color)));
     }
 
-    return QPixmap::fromImage(target);
+    cache.insert(resourcePath, renderers);
+    return renderers;
 }
 
 void Display7::refresh()
@@ -163,18 +153,19 @@ void Display7::updatePortsProperties()
 void Display7::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     // The base class draws the background (off-state SVG).
-    // Active segments are painted on top by overlaying the pre-rendered colored pixmaps.
-    // All segment pixmaps are the same dimensions as the background, so they composite correctly.
+    // Active segments are painted on top as vector renders, crisp at any zoom.
+    // All segment renderers share the background's 64x64 box, so they composite correctly.
     GraphicElement::paint(painter, option, widget);
 
-    if (auto *port = inputPort(0); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, g.at(m_colorNumber));  }
-    if (auto *port = inputPort(1); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, f.at(m_colorNumber));  }
-    if (auto *port = inputPort(2); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, e.at(m_colorNumber));  }
-    if (auto *port = inputPort(3); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, d.at(m_colorNumber));  }
-    if (auto *port = inputPort(4); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, a.at(m_colorNumber));  }
-    if (auto *port = inputPort(5); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, b.at(m_colorNumber));  }
-    if (auto *port = inputPort(6); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, dp.at(m_colorNumber)); }
-    if (auto *port = inputPort(7); port && port->status() == Status::Active) { painter->drawPixmap(0, 0, c.at(m_colorNumber));  }
+    const QRectF body(0, 0, 64, 64);
+    if (auto *port = inputPort(0); port && port->status() == Status::Active) { g.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(1); port && port->status() == Status::Active) { f.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(2); port && port->status() == Status::Active) { e.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(3); port && port->status() == Status::Active) { d.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(4); port && port->status() == Status::Active) { a.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(5); port && port->status() == Status::Active) { b.at(m_colorNumber)->render(painter, body);  }
+    if (auto *port = inputPort(6); port && port->status() == Status::Active) { dp.at(m_colorNumber)->render(painter, body); }
+    if (auto *port = inputPort(7); port && port->status() == Status::Active) { c.at(m_colorNumber)->render(painter, body);  }
 }
 
 void Display7::setColor(const QString &color)

--- a/App/Element/GraphicElements/Display7.h
+++ b/App/Element/GraphicElements/Display7.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
+#include <memory>
+
 #include "App/Element/GraphicElement.h"
 
 class Port;
+class QSvgRenderer;
 
 /**
  * \class Display7
@@ -30,17 +33,10 @@ public:
 
     // --- Color utilities ---
 
-    /// Returns a recolored copy of \a source using the given channel flags.
-    static QPixmap convertColor(const QImage &source, const bool red, const bool green, const bool blue);
-
-    /**
-     * \brief Fills \a pixmaps with red, green, and blue variants derived from the first entry.
-     * \param pixmaps Vector of source pixmaps; expanded in-place with color variants.
-     */
-    static void convertAllColors(QVector<QPixmap> &pixmaps);
-
-    /// Returns cached 5-color variants for the segment at \a resourcePath.
-    static QVector<QPixmap> cachedSegmentColors(const QString &resourcePath);
+    /// Returns cached White/Red/Green/Blue/Purple vector renderers for the segment SVG at
+    /// \a resourcePath (index order matches colorNameToIndex()), so lit segments stay crisp
+    /// at any zoom instead of blitting a fixed-resolution pixmap.
+    static QVector<std::shared_ptr<QSvgRenderer>> cachedSegmentRenderers(const QString &resourcePath);
 
     // --- Color State ---
 
@@ -76,6 +72,6 @@ private:
     // --- Members ---
 
     QString m_color = "Red";
-    QVector<QPixmap> a, b, c, d, e, f, g, dp;
+    QVector<std::shared_ptr<QSvgRenderer>> a, b, c, d, e, f, g, dp;
     int m_colorNumber = 1;
 };

--- a/App/Element/GraphicElements/InputRotary.cpp
+++ b/App/Element/GraphicElements/InputRotary.cpp
@@ -5,6 +5,7 @@
 
 #include <QGraphicsSceneMouseEvent>
 #include <QPainter>
+#include <QSvgRenderer>
 
 #include "App/Element/ElementFactory.h"
 #include "App/Element/ElementInfo.h"
@@ -51,7 +52,6 @@ InputRotary::InputRotary(QGraphicsItem *parent)
     : GraphicElementInput(ElementType::InputRotary, parent)
 {
     m_rotary = m_appearance.defaultAppearances().at(0);
-    m_arrow  = m_appearance.defaultAppearances().at(1);
 
     setLocked(false);
 
@@ -180,6 +180,16 @@ void InputRotary::updatePortsProperties()
     InputRotary::refresh();
 }
 
+/// Shared, lazily-constructed vector renderer for the active-position arrow -- drawn directly in
+/// paint() so it stays crisp at any zoom instead of blitting a fixed-resolution pixmap. The arrow
+/// asset is a fixed built-in (never user-customizable, unlike the dial face), so one renderer
+/// suffices for every InputRotary instance. GUI-thread only, like pixmapCache().
+static QSvgRenderer &rotaryArrowRenderer()
+{
+    static QSvgRenderer renderer(QStringLiteral(":/Components/Input/rotary_arrow.svg"));
+    return renderer;
+}
+
 void InputRotary::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     GraphicElement::paint(painter, option, widget);
@@ -212,13 +222,13 @@ void InputRotary::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
             continue;
         }
 
-        // Overlay the arrow pixmap at the same rotation as the active mark
+        // Overlay the arrow at the same rotation as the active mark
         painter->save();
 
         painter->translate(center.x(), center.y());
         painter->rotate(angle);
         painter->translate(-center.x(), -center.y());
-        painter->drawPixmap(0, 0, m_arrow);
+        rotaryArrowRenderer().render(painter, QRectF(0, 0, 64, 64));
 
         painter->restore();
     }

--- a/App/Element/GraphicElements/InputRotary.h
+++ b/App/Element/GraphicElements/InputRotary.h
@@ -87,7 +87,6 @@ protected:
 private:
     // --- Members ---
 
-    QPixmap m_arrow;
     QPixmap m_rotary;
     int m_currentPort = 0;
 };

--- a/App/Element/GraphicElements/Mux.cpp
+++ b/App/Element/GraphicElements/Mux.cpp
@@ -93,13 +93,25 @@ QRectF Mux::boundingRect() const
 
 void Mux::generatePixmap()
 {
+    // The body is drawn as vectors in drawBody()/paint(); m_pixmap is kept only so the base
+    // pixmapCenter()/boundingRect() have the right size (its image content is never displayed).
     const int height = static_cast<int>(renderBodyBounds().height());
 
-    QPixmap tempPixmap(64, height);
-    tempPixmap.fill(Qt::transparent);
+    QPixmap sizingPixmap(64, height);
+    sizingPixmap.fill(Qt::transparent);
+    m_appearance.setRenderPixmap(sizingPixmap);
+    update();
+}
 
-    QPainter painter(&tempPixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
+void Mux::drawBody(QPainter *painter)
+{
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing);
+    // boundingRect()'s top-left may be negative when ports extend past the 64×64 body; align the
+    // local origin with it so the body lands exactly where the old rasterised pixmap was blitted.
+    painter->translate(boundingRect().topLeft());
+
+    const int height = pixmap().rect().height();
 
     // Trapezoid body: wider on left (input side), narrower on right (output side)
     const int bodyTop = 8;
@@ -107,19 +119,19 @@ void Mux::generatePixmap()
     const int rightInset = 8; // fixed inset for the narrower right side
 
     // Outer dark shape
-    painter.setBrush(QColor(38, 38, 38));
-    painter.setPen(QPen(QColor(38, 38, 38), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter->setBrush(QColor(38, 38, 38));
+    painter->setPen(QPen(QColor(38, 38, 38), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 
     QPolygonF outer;
     outer << QPointF(22, bodyTop)
           << QPointF(22, bodyBottom)
           << QPointF(42, bodyBottom - rightInset)
           << QPointF(42, bodyTop + rightInset);
-    painter.drawPolygon(outer);
+    painter->drawPolygon(outer);
 
     // Inner white fill
-    painter.setBrush(QColor(252, 252, 252));
-    painter.setPen(QPen(QColor(252, 252, 252), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter->setBrush(QColor(252, 252, 252));
+    painter->setPen(QPen(QColor(252, 252, 252), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 
     const int fillInset = 4;
     QPolygonF inner;
@@ -127,9 +139,9 @@ void Mux::generatePixmap()
           << QPointF(22 + fillInset, bodyBottom - fillInset)
           << QPointF(42 - fillInset, bodyBottom - rightInset - fillInset + 2)
           << QPointF(42 - fillInset, bodyTop + rightInset + fillInset - 2);
-    painter.drawPolygon(inner);
+    painter->drawPolygon(inner);
 
-    m_appearance.setRenderPixmap(tempPixmap);
+    painter->restore();
 }
 
 void Mux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -145,7 +157,8 @@ void Mux::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
         painter->restore();
     }
 
-    painter->drawPixmap(boundingRect().topLeft(), pixmap());
+    // Draw the body as vectors (crisp at any zoom) rather than blitting a fixed-resolution pixmap.
+    drawBody(painter);
 }
 
 void Mux::updateLogic()

--- a/App/Element/GraphicElements/Mux.h
+++ b/App/Element/GraphicElements/Mux.h
@@ -43,6 +43,10 @@ public:
 private:
     void generatePixmap();
 
+    /// Draws the trapezoid body straight onto \a painter as vectors, so it stays crisp at any
+    /// zoom instead of blitting a fixed-resolution pixmap.
+    void drawBody(QPainter *painter);
+
     /**
      * \brief Returns the minimum select-line count for a Mux with \a totalInputs ports.
      * \details Finds the smallest k such that 2^k >= totalInputs - k, so that

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -51,6 +51,7 @@
 #include "App/Exercise/ExerciseEngine.h"
 #include "App/Exercise/ExerciseOverlay.h"
 #include "App/IO/RecentFiles.h"
+#include "App/Scene/Commands.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/ICRegistry.h"
 #include "App/Scene/Workspace.h"
@@ -1572,8 +1573,9 @@ void MainWindow::clickTarget(const QString &id)
         scene->clearSelection();
         auto *sw = ElementFactory::buildElement(ElementType::InputSwitch);
         sw->setPos(0, 0);
-        scene->addItem(sw);
-        sw->setSelected(true);
+        // AddItemsCommand registers the element with the scene's Simulation
+        // (setCircuitUpdateRequired() in redo()) and selects it for us.
+        scene->receiveCommand(new AddItemsCommand({sw}, scene));
     }
     else if (id == "setupWaveformDemo") {
         if (!currentTab()) {
@@ -1589,24 +1591,24 @@ void MainWindow::clickTarget(const QString &id)
         clock2->setPos(-160,  60);
         gate->setPos(0, 0);
         led->setPos(160, 0);
-        scene->addItem(clock1);
-        scene->addItem(clock2);
-        scene->addItem(gate);
-        scene->addItem(led);
+
         auto *conn1 = new Connection();
         conn1->setStartPort(clock1->outputPort(0));
         conn1->setEndPort(gate->inputPort(0));
-        scene->addItem(conn1);
-        conn1->updatePath();
         auto *conn2 = new Connection();
         conn2->setStartPort(clock2->outputPort(0));
         conn2->setEndPort(gate->inputPort(1));
-        scene->addItem(conn2);
-        conn2->updatePath();
         auto *conn3 = new Connection();
         conn3->setStartPort(gate->outputPort(0));
         conn3->setEndPort(led->inputPort(0));
-        scene->addItem(conn3);
+
+        // AddItemsCommand auto-discovers conn1..conn3 via port traversal (loadList())
+        // and registers all 7 items with the scene's Simulation, fixing the
+        // frozen-clock bug that raw scene->addItem() caused.
+        scene->receiveCommand(new AddItemsCommand({clock1, clock2, gate, led}, scene));
+
+        conn1->updatePath();
+        conn2->updatePath();
         conn3->updatePath();
     }
 }

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -1385,6 +1385,11 @@ void MainWindow::startExercise(const QString &resourcePath)
     delete m_exerciseOverlay;
     m_exerciseOverlay = new ExerciseOverlay(m_exerciseEngine, currentTab());
 
+    // m_exerciseEngine outlives any single exercise run, so a prior startExercise() call's
+    // click-handling connection (below) must be dropped before reconnecting, or replaying an
+    // exercise fires accumulated handlers once per past run.
+    disconnect(m_exerciseEngine, &ExerciseEngine::stepChanged, this, nullptr);
+
     // Must precede stepChanged→onStepChanged so actions run before the overlay updates.
     connect(m_exerciseEngine, &ExerciseEngine::stepChanged, this,
             [this](int, int, const ExerciseStep &step) {
@@ -1458,6 +1463,11 @@ void MainWindow::startTour(const QString &resourcePath)
     m_tourOverlay->setTargetResolver([this](const QString &id) {
         return resolveTourTarget(id);
     });
+
+    // m_tourEngine outlives any single tour run, so a prior startTour() call's click-handling
+    // connection (below) must be dropped before reconnecting, or replaying a tour fires
+    // accumulated handlers once per past run.
+    disconnect(m_tourEngine, &TourEngine::stepChanged, this, nullptr);
 
     // Must be connected before stepChanged→onStepChanged so click executes before
     // resolveTourTarget computes widget rects.

--- a/App/Wiring/Port.cpp
+++ b/App/Wiring/Port.cpp
@@ -31,6 +31,15 @@ QPainterPath Port::shape() const
     return path;
 }
 
+QRectF Port::boundingRect() const
+{
+    // The default QGraphicsPathItem bound is pen-exact (zero slack beyond the stroke), which
+    // gives DeviceCoordinateCache's device-pixel tile no room to antialias the edge -- at high
+    // zoom the pen's edge gets a hard clip instead of a soft fade. 1 local unit of margin (the
+    // port glyph is only ~10 units across) fixes that without perceptibly growing the glyph.
+    return QGraphicsPathItem::boundingRect().adjusted(-1, -1, 1, 1);
+}
+
 const QList<Connection *> &Port::connections() const
 {
     return m_connections;

--- a/App/Wiring/Port.h
+++ b/App/Wiring/Port.h
@@ -45,6 +45,10 @@ public:
     /// \reimp Hit-testing uses the full ±kRadius square regardless of the painted glyph.
     QPainterPath shape() const override;
 
+    /// \reimp Pads the default pen-exact bound by a small margin so DeviceCoordinateCache
+    /// has room to antialias the stroke edge instead of clipping it (visible at high zoom).
+    QRectF boundingRect() const override;
+
     // --- Lifecycle ---
 
     /// Constructs the port with optional \a parent item.


### PR DESCRIPTION
## Summary

- **Crisp rendering at high zoom**: `Mux`/`Demux`/`Display7`/`Display14`/`Display16`/`InputRotary` were baking their body/overlays into fixed-resolution `QPixmap`s and blitting them, so they blurred when zoomed in — same class of bug already fixed for `IC`/`TruthTable` in `70c7a910b`. Switched them to draw directly (or via cached, recolored `QSvgRenderer`s) so they stay crisp at any zoom. Ports/geometry/simulation logic unchanged.
- **Port hover-ring clipping at high zoom**: `Port` had no `boundingRect()` override, so `DeviceCoordinateCache` sized its device-pixel tile with zero antialiasing margin, hard-clipping the hover ring's edge at high zoom. Padded the bound by 1 local unit; hit-testing is unaffected (`Port::shape()` is independent).
- **Tour demo Clocks froze after closing BewavedDolphin**: the tour's `setupWaveformDemo`/`setupElementEditorDemo` steps added demo elements via raw `scene->addItem()`, bypassing `Scene::setCircuitUpdateRequired()`. This left the demo Clocks out of `Simulation`'s cached topology — they never ticked, and no amount of Play/Pause toggling could revive them. Routed both through the same `AddItemsCommand` path every other element-add call site uses, which also makes the demo circuit undoable.
- **Replaying a tour/exercise duplicated its demo circuit**: `startTour()`/`startExercise()` connected a new `stepChanged` handler on the long-lived `m_tourEngine`/`m_exerciseEngine` every call without disconnecting the previous one, so each replay fired one accumulated click-handler per past run — silently stacking duplicate copies of any Scene-mutating demo circuit. Added the missing `disconnect()`.

## Test plan

- [x] `cmake --build --preset debug` — clean build
- [x] `TestSimulation` (39/39), `TestTourEngine` (7/7), `TestExerciseEngine` (8/8) — all pass
- [x] `TestMainWindowGui` (137/137, 1 pre-existing unrelated environment-only skip) — all pass
- [ ] Manual: run the "wiRedPanda Interface Tour" to the waveform step, close BewavedDolphin, confirm the demo Clocks keep animating; replay the tour and confirm the demo circuit isn't duplicated