### PR TITLE
Stop forcing Open dialog into ./Examples on unsaved tabs

### DIFF
--- a/App/UI/WorkspaceManager.cpp
+++ b/App/UI/WorkspaceManager.cpp
@@ -389,8 +389,7 @@ void WorkspaceManager::openFile()
         };
         QFileDialog::getOpenFileContent("Panda files (*.panda)", fileContentReady);
     #else
-        const QString path = currentFile().exists() ? "" : "./Examples";
-        const QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Open File"), path, tr("Panda files") + " (*.panda)");
+        const QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Open File"), QString(), tr("Panda files") + " (*.panda)");
 
         if (fileName.isEmpty()) {
             return;


### PR DESCRIPTION
## Summary
- The Open File dialog used to reset to `./Examples` whenever the active tab was unsaved (e.g. right after startup), overriding Qt's native remembered last-visited directory.
- Now that the Examples menu lists bundled circuits directly, that fallback is redundant, so the dialog always uses the empty starting directory and lets Qt remember the last-visited folder.

## Test plan
- [x] Builds cleanly (`cmake --build --preset debug --target wiredpanda`)
- [ ] Manual: fresh start → File > Open no longer jumps to `Examples/`; open a file, then File > Open again → starts in that file's folder