### PR TITLE
Fix large-circuit sluggishness: rendering and simulation performance overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /.ninja_deps
 /.ninja_log
 
+# Profiling output (perf.data, callgrind.out.*, reports)
+/Scripts/profiling-out/
+
 # AppImage build artifacts
 /AppDir/
 /appimage-build/

--- a/App/Element/ElementAppearance.cpp
+++ b/App/Element/ElementAppearance.cpp
@@ -7,8 +7,10 @@
 #include <cmath>
 #include <memory>
 
+#include <QDateTime>
 #include <QFile>
 #include <QFileInfo>
+#include <QHash>
 #include <QPainter>
 #include <QPen>
 #include <QPixmapCache>
@@ -155,6 +157,54 @@ QPixmap orientedSvgPixmap(const QString &resolvedPath, const qreal angle, const 
 
     QPixmapCache::insert(key, pixmap);
     return pixmap;
+}
+
+/// Returns the vector QSvgRenderer for the SVG at \a resolvedPath, with baked <text> labels
+/// counter-oriented for the current rotation \a angle and flip when applicable — shared across
+/// every ElementAppearance that resolves to the same (path, mtime, angle, flip), since parsing an
+/// SVG's XML (and any inline CSS) is the dominant cost of populating a scene with many
+/// identically-appearanced elements (thousands of AND/OR/... gates all point at the same handful
+/// of bundled icon files). Never evicted: the key space is bounded by the app's finite set of
+/// distinct icon paths x orientation variants, not by circuit size — same reasoning as the
+/// existing icLogoRenderer()/truthTableLogoRenderer() function-local statics (see ICRenderer.cpp,
+/// TruthTable.cpp). Returns nullptr on any read/parse failure so callers fall back to the raster
+/// pixmap, exactly as an invalid renderer did before this was cached.
+std::shared_ptr<QSvgRenderer> sharedSvgRenderer(const QString &resolvedPath, const qreal angle, const bool flipX, const bool flipY)
+{
+    static QHash<QString, std::shared_ptr<QSvgRenderer>> cache;
+
+    const qreal canonAngle = std::fmod(std::fmod(angle, 360.0) + 360.0, 360.0);
+    // mtime keeps this in step with QPixmap::load()'s own QPixmapCache keying (see setPixmap()
+    // below) so a user-edited custom SVG appearance still picks up on next load.
+    const QDateTime mtime = QFileInfo(resolvedPath).lastModified();
+    const QString key = resolvedPath + QLatin1Char('|')
+        + QString::number(mtime.toMSecsSinceEpoch()) + QLatin1Char('|')
+        + QString::number(canonAngle) + QLatin1Char('|')
+        + (flipX ? QLatin1Char('1') : QLatin1Char('0'))
+        + (flipY ? QLatin1Char('1') : QLatin1Char('0'));
+
+    if (const auto it = cache.constFind(key); it != cache.constEnd()) {
+        return it.value();
+    }
+
+    QFile file(resolvedPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        cache.insert(key, nullptr);
+        return nullptr;
+    }
+    QByteArray svg = file.readAll();
+
+    const bool oriented = angle != 0.0 || flipX || flipY;
+    if (oriented && svg.contains("<text")) {
+        svg = orientSvgTextNodes(svg, canonAngle, flipX, flipY);
+    }
+
+    auto renderer = std::make_shared<QSvgRenderer>(svg);
+    if (!renderer->isValid()) {
+        renderer.reset();
+    }
+    cache.insert(key, renderer);
+    return renderer;
 }
 
 } // namespace
@@ -340,24 +390,18 @@ void ElementAppearance::rebuildSvgRenderer()
         return;
     }
 
-    QFile file(m_resolvedPixmapPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        m_svgRenderer.reset();
-        return;
-    }
-    QByteArray svg = file.readAll();
-
     // Counter-orient each <text> while rotated/flipped so pin labels stay upright — the same
     // correction orientedSvgPixmap() bakes into the rasterised variant. Gated on rotatesGraphic()
     // because a non-rotatable element never transforms its graphic, so its text stays as authored.
+    // Zeroing angle/flip when not oriented also means every unoriented element (the vast majority)
+    // shares one sharedSvgRenderer() cache entry regardless of its nominal rotation/flip state.
     const bool oriented = m_owner->rotatesGraphic()
         && (m_owner->isFlippedX() || m_owner->isFlippedY() || (m_owner->rotation() != 0.0));
-    if (oriented && svg.contains("<text")) {
-        svg = orientSvgTextNodes(svg, m_owner->rotation(), m_owner->isFlippedX(), m_owner->isFlippedY());
-    }
 
-    auto renderer = std::make_unique<QSvgRenderer>(svg);
-    m_svgRenderer = renderer->isValid() ? std::move(renderer) : nullptr;
+    m_svgRenderer = sharedSvgRenderer(m_resolvedPixmapPath,
+                                       oriented ? m_owner->rotation() : 0.0,
+                                       oriented && m_owner->isFlippedX(),
+                                       oriented && m_owner->isFlippedY());
 }
 
 void ElementAppearance::setAppearance(const bool defaultAppearance, const QString &fileName)

--- a/App/Element/ElementAppearance.h
+++ b/App/Element/ElementAppearance.h
@@ -133,7 +133,7 @@ private:
     QPixmap m_pixmap;     ///< Currently displayed pixmap.
     QPixmap m_basePixmap; ///< Upright, unflipped pixmap; m_pixmap is derived from this.
     bool m_hasCustomRenderPixmap = false; ///< True while m_pixmap is a procedural render pixmap, not derived from m_basePixmap.
-    std::unique_ptr<QSvgRenderer> m_svgRenderer; ///< Vector renderer for the current SVG appearance (null for raster).
+    std::shared_ptr<QSvgRenderer> m_svgRenderer; ///< Vector renderer for the current SVG appearance (null for raster); shared with every other element resolving to the same path/orientation, see sharedSvgRenderer() in the .cpp.
 
     QString m_pixmapPath;         ///< Resource/file path of the default pixmap (from metadata).
     QString m_currentPixmapPath;  ///< Path last requested via setPixmap() (change guard).

--- a/App/Element/ElementSimState.h
+++ b/App/Element/ElementSimState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <QVector>
 
 #include "App/Core/Enums.h"
@@ -98,7 +100,15 @@ public:
     /// from current outputs and routes subsequent setOutputValue() calls to it.
     void beginDeferredCommit()
     {
-        m_staged = m_outputs;
+        // Element-wise copy into persistent storage, deliberately NOT `m_staged =
+        // m_outputs`: assignment CoW-shares the two buffers, so every staged write and
+        // every commit write into m_outputs pays a detach (malloc + deep copy) -- per
+        // sequential element, per simulation tick, even when nothing changed. The copy
+        // keeps both buffers owned and the whole tick allocation-free. The resize is a
+        // no-op in steady state (initVectors() sizes m_staged); it only guards a
+        // mid-run port-count change.
+        m_staged.resize(m_outputs.size());
+        std::copy(m_outputs.cbegin(), m_outputs.cend(), m_staged.begin());
         m_deferCommit = true;
     }
 

--- a/App/Scene/ConnectionManager.cpp
+++ b/App/Scene/ConnectionManager.cpp
@@ -103,7 +103,9 @@ void ConnectionManager::startFromInput(InputPort *endPort)
 void ConnectionManager::tryComplete(const QPointF &scenePos)
 {
     auto *connection = editedConnection();
-    auto *port = qgraphicsitem_cast<Port *>(m_scene->itemAt(scenePos));
+    // Same lookup as updateHover(), so the wire lands on the port whose hover
+    // highlight the user is currently seeing.
+    auto *port = m_scene->portAt(scenePos);
 
     if (!port || !connection) {
         return;
@@ -210,7 +212,10 @@ void ConnectionManager::updateEditedEnd(const QPointF &scenePos)
 
 void ConnectionManager::updateHover(const QPointF &scenePos)
 {
-    auto *port = qgraphicsitem_cast<Port *>(m_scene->itemAt(scenePos));
+    // Runs on every mouse move: portAt() is the cheap bounding-box lookup -- itemAt()'s
+    // shape-exact queries would re-stroke and clip every wire near the cursor just to
+    // discard them here.
+    auto *port = m_scene->portAt(scenePos);
     auto *hoverPort_ = hoverPort();
 
     // Only tear down and rebuild the hover state when the port under the cursor

--- a/App/Scene/GraphicsView.cpp
+++ b/App/Scene/GraphicsView.cpp
@@ -12,6 +12,7 @@
 #include <QScrollBar>
 
 #include "App/Core/SentryHelpers.h"
+#include "App/Scene/Scene.h"
 
 namespace {
 // Zoom step ladder (factor 1.25 per step). The range is deliberately asymmetric: elements
@@ -216,6 +217,8 @@ void GraphicsView::zoomToFit()
         for (auto *item : selected) {
             target |= item->sceneBoundingRect();
         }
+    } else if (auto *scene_ = qobject_cast<Scene *>(scene())) {
+        target = scene_->cachedItemsBoundingRect();
     } else {
         target = scene()->itemsBoundingRect();
     }

--- a/App/Scene/GraphicsView.cpp
+++ b/App/Scene/GraphicsView.cpp
@@ -7,6 +7,7 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QElapsedTimer>
 #include <QGraphicsItem>
 #include <QKeyEvent>
 #include <QScrollBar>
@@ -45,6 +46,20 @@ GraphicsView::GraphicsView(QWidget *parent)
     setViewportUpdateMode(QGraphicsView::MinimalViewportUpdate);
 
     setCacheMode(QGraphicsView::CacheBackground);
+}
+
+void GraphicsView::paintEvent(QPaintEvent *event)
+{
+    // Time the pass so Scene can adapt wire antialiasing to the measured paint workload
+    // (see Scene's wire-antialiasing accessors).
+    QElapsedTimer timer;
+    timer.start();
+
+    QGraphicsView::paintEvent(event);
+
+    if (auto *scene_ = qobject_cast<Scene *>(scene())) {
+        scene_->recordWirePaintPass(timer.nsecsElapsed());
+    }
 }
 
 bool GraphicsView::canZoomIn() const

--- a/App/Scene/GraphicsView.h
+++ b/App/Scene/GraphicsView.h
@@ -66,6 +66,10 @@ protected:
     // --- Event handlers ---
 
     /// \reimp
+    /// \reimp Times each pass and feeds Scene::recordWirePaintPass() so wire
+    /// antialiasing can adapt to the measured paint workload (see Scene).
+    void paintEvent(QPaintEvent *event) override;
+
     void keyPressEvent(QKeyEvent *event) override;
     /// \reimp
     void keyReleaseEvent(QKeyEvent *event) override;

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -286,6 +286,7 @@ void Scene::setPropertyUpdateRequired()
     update();
 
     m_autosaveRequired = true;
+    m_itemsBoundingRectDirty = true;
 }
 
 const QVector<GraphicElement *> Scene::visibleElements() const
@@ -446,9 +447,26 @@ void Scene::receiveCommand(QUndoCommand *cmd)
     update();
 }
 
+QRectF Scene::cachedItemsBoundingRect() const
+{
+    // A live drag needs the item bounds to track the dragged element's currently-changing
+    // position (see resizeScene()'s isDraggingElement() branch) -- a cached value would
+    // stop the scene rect from expanding to follow it mid-drag.
+    if (m_interaction.isDraggingElement()) {
+        return itemsBoundingRect();
+    }
+
+    if (m_itemsBoundingRectDirty) {
+        m_cachedItemsBoundingRect = itemsBoundingRect();
+        m_itemsBoundingRectDirty = false;
+    }
+
+    return m_cachedItemsBoundingRect;
+}
+
 void Scene::resizeScene()
 {
-    const auto bounds = itemsBoundingRect();
+    const auto bounds = cachedItemsBoundingRect();
 
     if (m_interaction.isDraggingElement()) {
         // While dragging, only expand the scene rect (union with current rect).

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -612,6 +612,26 @@ void Scene::restoreWireAntialiasing()
     update();
 }
 
+namespace {
+/// Any *changed* scene rect makes Qt's BSP index unindex and re-insert every item in the
+/// scene (QGraphicsSceneBspTreeIndex::updateSceneRect() -> resetIndex()) -- tens of
+/// milliseconds on large circuits; only a bit-identical rect is a no-op. Snapping the rect
+/// outward to this grid makes consecutive interaction steps (mouse moves of an edge drag,
+/// zoom wheel notches) produce identical rects, turning per-event full re-indexes into at
+/// most one per 256 scene units of actual growth or shrink. The scene rect's only
+/// observable effect is scrollbar range, which already carries a 100-unit margin.
+constexpr qreal kSceneRectQuantum = 256.0;
+
+QRectF quantizeOutward(const QRectF &rect)
+{
+    const qreal left = std::floor(rect.left() / kSceneRectQuantum) * kSceneRectQuantum;
+    const qreal top = std::floor(rect.top() / kSceneRectQuantum) * kSceneRectQuantum;
+    const qreal right = std::ceil(rect.right() / kSceneRectQuantum) * kSceneRectQuantum;
+    const qreal bottom = std::ceil(rect.bottom() / kSceneRectQuantum) * kSceneRectQuantum;
+    return QRectF(QPointF(left, top), QPointF(right, bottom));
+}
+} // namespace
+
 void Scene::resizeScene()
 {
     const auto bounds = cachedItemsBoundingRect();
@@ -620,7 +640,7 @@ void Scene::resizeScene()
         // While dragging, only expand the scene rect (union with current rect).
         // Never shrink during drag — shrinking shifts the viewport origin and
         // causes jarring visual jumps as the scene rect chases the items.
-        setSceneRect(sceneRect().united(bounds));
+        setSceneRect(quantizeOutward(sceneRect().united(bounds)));
     } else {
         // Tighten to item bounds, but ensure the scene rect stays larger than the
         // viewport. When the scene rect is smaller than (or barely larger than) the
@@ -640,11 +660,11 @@ void Scene::resizeScene()
             // drift — saving/restoring scrollbar values avoids the rounding.
             const int hVal = view->horizontalScrollBar()->value();
             const int vVal = view->verticalScrollBar()->value();
-            setSceneRect(tightRect);
+            setSceneRect(quantizeOutward(tightRect));
             view->horizontalScrollBar()->setValue(hVal);
             view->verticalScrollBar()->setValue(vVal);
         } else {
-            setSceneRect(tightRect);
+            setSceneRect(quantizeOutward(tightRect));
         }
     }
 }

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -477,6 +477,46 @@ QList<QGraphicsItem *> Scene::itemsAt(const QPointF pos) const
     return items(rect.normalized());
 }
 
+Port *Scene::portAt(const QPointF pos) const
+{
+    // Port-only fast path for per-mouse-move consumers (hover feedback, wire completion,
+    // port tooltips). itemAt()'s generic queries use Qt::IntersectsItemShape, which
+    // exact-shape-tests every element and wire whose bounding box overlaps -- for wires
+    // that means re-stroking and clipping Bézier curves, and their fat bounding boxes
+    // collect dozens of candidates near a wire bundle. A bounding-box query skips all of
+    // that, and ports themselves are cheap to test exactly (shape() is a fixed square).
+    //
+    // Same 9x9 hit area as itemsAt(). An exactly-hit port wins over a merely-nearby one,
+    // like itemAt()'s two-phase lookup; among nearby-only ports acceptance is by bounding
+    // box rather than shape-vs-rect -- a difference of at most the ~1 unit of bounding-box
+    // padding, well inside the deliberate 4 px slop.
+    const QRectF rect(pos - QPointF(4, 4), QSize(9, 9));
+    const auto candidates = items(rect.normalized(), Qt::IntersectsItemBoundingRect);
+
+    Port *nearby = nullptr;
+
+    for (auto *item : candidates) { // default order: topmost first
+        if (item->type() != Port::Type) {
+            continue;
+        }
+
+        // static_cast, not qgraphicsitem_cast: the type() check above already proves the
+        // downcast, and the maybe-null result of qgraphicsitem_cast trips
+        // -Wnull-dereference at -O3 on the immediate dereference below.
+        auto *port = static_cast<Port *>(item);
+
+        if (port->shape().contains(port->mapFromScene(pos))) {
+            return port;
+        }
+
+        if (!nearby) {
+            nearby = port;
+        }
+    }
+
+    return nearby;
+}
+
 void Scene::receiveCommand(QUndoCommand *cmd)
 {
     sentryBreadcrumb("command", QStringLiteral("Command: %1").arg(cmd->text()));
@@ -1312,7 +1352,7 @@ void Scene::helpEvent(QGraphicsSceneHelpEvent *event)
     // delay). If the cursor is over a port, show its own label plus its connected peers'
     // labels in situ instead of the native tooltip, so they all appear together at the
     // same wake-up delay a tooltip would use. Other items keep their native tooltip.
-    if (auto *port = qgraphicsitem_cast<Port *>(itemAt(event->scenePos()))) {
+    if (auto *port = portAt(event->scenePos())) {
         m_connectionManager.showHoverLabels(port);
         return;
     }

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -36,6 +36,36 @@
 #include "App/Scene/GraphicsView.h"
 #include "App/Wiring/Connection.h"
 
+namespace {
+// Adaptive wire antialiasing constants (see the Scene.h accessor block for the design).
+// All are time-based or dimensionless, so their meaning is machine-independent.
+
+/// A paint pass slower than this hurts interactivity (~3 dropped frames at 60 Hz).
+constexpr qint64 kWireAaBudgetNs = 50'000'000;
+
+/// Consecutive over-budget passes required to degrade -- a one-off compositor stall or
+/// background-load spike never flips quality.
+constexpr int kWireAaDebouncePasses = 2;
+
+/// No paint pass for this long means the current gesture / repaint burst is over.
+constexpr qint64 kWireAaPassIdleMs = 300;
+
+/// No wire status flip for this long means the simulation-driven storm is over. Must span
+/// the quiet gap between clock edges (flips arrive in per-edge bursts): 3 s covers clocks
+/// down to ~0.17 Hz, far below typical educational frequencies.
+constexpr qint64 kWireAaFlipIdleMs = 3000;
+
+/// Conservative upper bound on how much more an antialiased pass costs than a plain one
+/// (measured ~5.5x on a wire-dominated scene). Deep headroom is budget / this, so a pass
+/// restored from deep headroom fits the budget by construction and can't re-trip the
+/// degrade -- the property that keeps a binary quality knob from oscillating.
+constexpr qint64 kWireAaWorstCaseRatio = 10;
+
+/// Consecutive deep-headroom passes required for the sustained-headroom restore
+/// (~170 ms of simulation-driven passes at 60 Hz).
+constexpr int kWireAaHeadroomRestorePasses = 10;
+} // namespace
+
 Scene::Scene(QObject *parent)
     : QGraphicsScene(parent)
     , m_simulation(this, this)
@@ -67,6 +97,13 @@ Scene::Scene(QObject *parent)
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged, this, &Scene::updateTheme);
     // Emit autosave signal only after each undo-stack index change (not on every internal state update)
     connect(&m_undoStack,              &QUndoStack::indexChanged,   this, &Scene::checkUpdateRequest);
+
+    // Primary restore path for adaptive wire antialiasing: the timeout re-checks both
+    // activity timestamps and restores only once their windows have truly elapsed.
+    m_wireAaIdleTimer.setSingleShot(true);
+    connect(&m_wireAaIdleTimer, &QTimer::timeout, this, [this] { checkWireIdleRestore(); });
+    m_wireFlipTimer.start();
+    m_wirePassTimer.start();
 }
 
 void Scene::checkUpdateRequest()
@@ -462,6 +499,77 @@ QRectF Scene::cachedItemsBoundingRect() const
     }
 
     return m_cachedItemsBoundingRect;
+}
+
+bool Scene::wireAntialiasingEnabled() const
+{
+    return m_wireAntialiasing;
+}
+
+void Scene::recordWirePaintPass(const qint64 elapsedNs)
+{
+    m_wirePassTimer.restart();
+
+    if (m_wireAntialiasing) {
+        if (elapsedNs > kWireAaBudgetNs) {
+            if (++m_wireAaSlowPasses >= kWireAaDebouncePasses) {
+                m_wireAntialiasing = false;
+                m_wireAaSlowPasses = 0;
+                m_wireAaHeadroomPasses = 0;
+                m_wireAaIdleTimer.start(static_cast<int>(kWireAaPassIdleMs));
+            }
+        } else {
+            m_wireAaSlowPasses = 0;
+        }
+        return;
+    }
+
+    // Degraded: sustained deep headroom is the only in-storm way back to full quality;
+    // the idle path is handled by checkWireIdleRestore() re-arming itself.
+    if (elapsedNs < kWireAaBudgetNs / kWireAaWorstCaseRatio) {
+        if (++m_wireAaHeadroomPasses >= kWireAaHeadroomRestorePasses) {
+            restoreWireAntialiasing();
+        }
+    } else {
+        m_wireAaHeadroomPasses = 0;
+    }
+}
+
+void Scene::noteWireActivity()
+{
+    m_wireFlipTimer.restart();
+}
+
+void Scene::checkWireIdleRestore()
+{
+    const qint64 passRemainingMs = kWireAaPassIdleMs - m_wirePassTimer.elapsed();
+    const qint64 flipRemainingMs = kWireAaFlipIdleMs - m_wireFlipTimer.elapsed();
+    const qint64 remainingMs = qMax(passRemainingMs, flipRemainingMs);
+
+    if (remainingMs <= 0) {
+        restoreWireAntialiasing();
+        return;
+    }
+
+    // Still active: re-arm for the remainder of the longer window (deadline pattern --
+    // avoids restarting a timer on every one of the thousands of flips per second).
+    m_wireAaIdleTimer.start(static_cast<int>(remainingMs));
+}
+
+void Scene::restoreWireAntialiasing()
+{
+    m_wireAaIdleTimer.stop();
+    m_wireAaSlowPasses = 0;
+    m_wireAaHeadroomPasses = 0;
+
+    if (m_wireAntialiasing) {
+        return;
+    }
+
+    m_wireAntialiasing = true;
+    // Refinement repaint: without it the wires would stay visually jagged until the next
+    // naturally-occurring repaint, which on an idle view may never come.
+    update();
 }
 
 void Scene::resizeScene()

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -9,11 +9,13 @@
 
 #include <optional>
 
+#include <QElapsedTimer>
 #include <QGraphicsScene>
 #include <QHash>
 #include <QMap>
 #include <QMimeData>
 #include <QPoint>
+#include <QTimer>
 #include <QUndoCommand>
 #include <QVersionNumber>
 
@@ -71,6 +73,51 @@ public:
     /// the cache during an active element drag, where the live (uncached) value is required:
     /// see resizeScene()'s isDraggingElement() branch.
     [[nodiscard]] QRectF cachedItemsBoundingRect() const;
+
+    // --- Adaptive wire antialiasing ---
+    //
+    // Antialiased wire strokes cost ~5x the raster time of plain ones, and on a large clocked
+    // circuit the simulation recolours wires across the whole viewport continuously -- each
+    // repaint pass re-strokes every visible wire, pinning the GUI thread. Quality adapts with
+    // the standard split used for binary quality knobs elsewhere (game-engine dynamic
+    // resolution scaling degrades on the measured frame-time budget; browsers, GIS canvases
+    // and EDA tools restore full quality when the activity causing the load stops):
+    //
+    //  1. Degrade: wire antialiasing turns off when the measured pass time stays over budget
+    //     (debounced, so a one-off compositor stall or load spike never triggers).
+    //  2. Restore on idle: antialiasing returns (plus one refinement repaint, free by
+    //     definition on an idle view) once BOTH activity streams have gone quiet -- paint
+    //     passes for a short window (an interaction gesture ended), and wire status flips
+    //     for a longer window (clock-driven flips arrive in bursts at each clock edge, so
+    //     the window must span inter-edge gaps -- seconds for slow educational clocks --
+    //     or the restore fires inside a gap and quality oscillates with the clock).
+    //     Neither stream alone suffices: pass cadence is bursty mid-storm, and flips stop
+    //     entirely on combinational circuits whose simulation still runs.
+    //  3. Restore on sustained deep headroom: a light workload that never goes idle (small
+    //     region in view while the simulation runs) restores once passes stay under
+    //     budget / worst-case-AA-ratio, which bounds the restored antialiased pass to within
+    //     budget by construction.
+    //
+    // Restoration deliberately never keys on the degraded renderer merely being "fast enough":
+    // with a binary knob that measured speed is a consequence of the decision itself and
+    // oscillates quality at the pass rate. Only wires change quality -- elements, ports and
+    // text keep the view's render hints.
+
+    /// \c true while wires should stroke with antialiasing; Connection::paint() consults this.
+    [[nodiscard]] bool wireAntialiasingEnabled() const;
+
+    /// Feeds one measured view paint pass (GraphicsView::paintEvent times its base call).
+    /// MinimapWidget's off-view scene renders never reach this, so they can't skew decisions.
+    void recordWirePaintPass(qint64 elapsedNs);
+
+    /// Marks wire activity for idle detection; Connection::setStatus() calls this on every
+    /// real status change. Cheap (timestamp restart), safe at simulation flip rates.
+    void noteWireActivity();
+
+    /// Restores wire antialiasing and schedules the refinement repaint. Invoked by the idle
+    /// timer and the sustained-headroom path; public so a pass-free quality reset is possible
+    /// (and directly drivable from tests).
+    void restoreWireAntialiasing();
 
     // --- Per-Scene Element Registry ---
 
@@ -468,6 +515,21 @@ private:
     // positional edit already funnels through.
     mutable QRectF m_cachedItemsBoundingRect;
     mutable bool m_itemsBoundingRectDirty = true;
+
+    // Adaptive wire antialiasing (see the public accessors' comment): consecutive-pass
+    // counters for the debounced degrade and the sustained-headroom restore; the idle
+    // timer's timeout re-checks m_wireActivityTimer (deadline pattern) and either
+    // restores or re-arms for the remaining window, so per-flip timer restarts are
+    // never needed.
+    bool m_wireAntialiasing = true;
+    int m_wireAaSlowPasses = 0;
+    int m_wireAaHeadroomPasses = 0;
+    QTimer m_wireAaIdleTimer;
+    QElapsedTimer m_wireFlipTimer;
+    QElapsedTimer m_wirePassTimer;
+
+    /// Idle-timer target: restores if the activity window truly elapsed, else re-arms.
+    void checkWireIdleRestore();
 
     // Drag-and-drop payload decoding (delegated to SceneDropHandler)
     SceneDropHandler m_dropHandler = SceneDropHandler(this);

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -64,6 +64,14 @@ public:
     /// Tightens the scene rect to item bounds while preserving the viewport position.
     void resizeScene();
 
+    /// Returns itemsBoundingRect(), cached and invalidated on structural/positional edits
+    /// (see setPropertyUpdateRequired()) — an O(total items) call this project's zoom/pan/
+    /// scroll paths (resizeScene(), MinimapWidget) would otherwise redo on every step even
+    /// though panning/zooming never changes which items exist or where they are. Bypasses
+    /// the cache during an active element drag, where the live (uncached) value is required:
+    /// see resizeScene()'s isDraggingElement() branch.
+    [[nodiscard]] QRectF cachedItemsBoundingRect() const;
+
     // --- Per-Scene Element Registry ---
 
     /// Returns the item registered under \a id, or nullptr if not found.
@@ -454,6 +462,12 @@ private:
     // item's visibility out of sync with the current show-wires/show-gates toggles;
     // reapplied lazily in drawBackground() (see its comment) rather than eagerly.
     bool m_visibilityDirty = false;
+
+    // Backing cache for cachedItemsBoundingRect(); mutable since the accessor is const.
+    // Set dirty by setPropertyUpdateRequired(), the same chokepoint every structural/
+    // positional edit already funnels through.
+    mutable QRectF m_cachedItemsBoundingRect;
+    mutable bool m_itemsBoundingRectDirty = true;
 
     // Drag-and-drop payload decoding (delegated to SceneDropHandler)
     SceneDropHandler m_dropHandler = SceneDropHandler(this);

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -234,6 +234,11 @@ public:
     /// Returns the topmost item at \a pos, prioritising ports over elements.
     QGraphicsItem *itemAt(QPointF pos) const;
 
+    /// Returns the topmost port within itemsAt()'s hit area of \a pos, or nullptr.
+    /// Bounding-box-based fast path for per-mouse-move consumers -- unlike itemAt(), never
+    /// exact-shape-tests wires or elements (see the implementation comment).
+    [[nodiscard]] Port *portAt(QPointF pos) const;
+
     /// Returns the last known mouse position in scene coordinates.
     [[nodiscard]] QPointF mousePos() const { return m_interaction.lastMousePos(); }
 

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -369,26 +369,13 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
         throw PANDACEPTION("Error opening file: %1", saveFile.errorString());
     }
 
-    // Set scene rect with same logic as resizeScene() to avoid viewport jump on element selection.
-    // Tighten to item bounds with margins and visible viewport to ensure consistent scrollbar behavior.
-    auto bounds = m_scene.itemsBoundingRect();
-    auto tightRect = bounds;
-    const auto viewList = m_scene.views();
-    if (!viewList.isEmpty()) {
-        auto *view = viewList.first();
-        constexpr qreal margin = 100.0;
-        const auto visibleScene = view->mapToScene(view->viewport()->rect()).boundingRect()
-                                     .adjusted(-margin, -margin, margin, margin);
-        tightRect = tightRect.united(visibleScene);
-
-        const int hVal = view->horizontalScrollBar()->value();
-        const int vVal = view->verticalScrollBar()->value();
-        m_scene.setSceneRect(tightRect);
-        view->horizontalScrollBar()->setValue(hVal);
-        view->verticalScrollBar()->setValue(vVal);
-    } else {
-        m_scene.setSceneRect(tightRect);
-    }
+    // Re-tighten the scene rect (avoids a viewport jump on element selection). Must go
+    // through resizeScene() rather than a local computation: producing even a slightly
+    // different rect than resizeScene()'s (quantized) one would ping-pong the scene rect
+    // between two values across edit/autosave cycles, and every change makes Qt's BSP
+    // index re-insert all items. No drag can be in progress during a save, so this takes
+    // the same tighten branch the interactive callers use.
+    m_scene.resizeScene();
 
     QDataStream stream(&saveFile);
     Serialization::writePandaHeader(stream);

--- a/App/Simulation/Simulation.cpp
+++ b/App/Simulation/Simulation.cpp
@@ -94,6 +94,44 @@ void Simulation::update()
         }
     }
 
+    // Advance the visual throttle on every tick (skipped or not) so the phase 3-4
+    // cadence stays time-based. Non-interactive callers (tests, BeWavedDolphin's
+    // throttle disabler) flush on every tick, as before.
+    const bool visualsDue = !(m_visualThrottleEnabled && Application::interactiveMode)
+                            || (++m_visualTickCount >= m_visualTickInterval);
+    if (visualsDue) {
+        m_visualTickCount = 0;
+    }
+
+    // Skip provably-idle ticks. A completed sweep whose settle passes converged is a
+    // fixed point of the deterministic element functions; it can only be left by a
+    // clock flip, an input-element change (both flagged through setOutputValue()'s
+    // change detection -- user toggles included, they write the same way), or a
+    // structural edit (restart() clears m_atFixedPoint). Everything else recomputes
+    // bit-identical outputs 1000x/s, which on large clocked circuits is almost every
+    // tick. The flags are cleared as they are read so one flip triggers one sweep.
+    bool sourceChanged = false;
+    for (auto *clock : clocks) {
+        if (clock && clock->outputChanged()) {
+            sourceChanged = true;
+            clock->clearOutputChanged();
+        }
+    }
+    for (auto *inputElm : inputs) {
+        if (inputElm && inputElm->outputChanged()) {
+            sourceChanged = true;
+            inputElm->clearOutputChanged();
+        }
+    }
+
+    if (!sourceChanged && m_atFixedPoint) {
+        if (visualsDue && m_visualsDirty) {
+            pushVisualStatuses(elements, outputs);
+            m_visualsDirty = false;
+        }
+        return;
+    }
+
     // Phase 2: update all GraphicElements in topological order.
     //
     // Synchronous sequential elements (flip-flops, latches — ElementGroup::Memory,
@@ -110,9 +148,13 @@ void Simulation::update()
         }
     }
 
+    // A plain topological sweep reaches its fixed point in one pass by construction;
+    // only feedback settling can fail to converge (oscillating circuits).
+    bool sweepConverged = true;
+
     if (m_simHasFeedbackElements) {
         // Use iterative settling for circuits with feedback loops.
-        updateWithIterativeSettling(elements);
+        sweepConverged = updateWithIterativeSettling(elements);
     } else {
         // Phase 2: update all logic elements in topologically sorted order so
         // every gate sees its inputs before computing its output.
@@ -158,19 +200,30 @@ void Simulation::update()
             if (!changed) {
                 break;
             }
+            if (pass == maxPasses - 1) {
+                // Exhausted the budget while still changing: not a fixed point.
+                sweepConverged = false;
+            }
         }
     }
 
-    // Visual updates only need to run at display-refresh rate (~5 fps),
-    // not at simulation rate (1000 Hz).  Skip phases 3-4 on most ticks
-    // to avoid dirtying QGraphicsItems that will be overwritten before
-    // the next repaint.  In non-interactive (test) mode, always update
-    // so that tests see immediate visual state after each step.
-    if (m_visualThrottleEnabled && Application::interactiveMode && ++m_visualTickCount < m_visualTickInterval) {
-        return;
-    }
-    m_visualTickCount = 0;
+    // This sweep's result is a fixed point unless a settle pass ran out of budget while
+    // still changing (an oscillating feedback circuit, which must keep sweeping).
+    m_atFixedPoint = sweepConverged;
+    m_visualsDirty = true;
 
+    // Visual updates only need to run at display-refresh rate, not at simulation
+    // rate (1000 Hz) — skipping most ticks avoids dirtying QGraphicsItems that would
+    // be overwritten before the next repaint. In non-interactive (test) mode every
+    // tick flushes so tests see immediate visual state after each step.
+    if (visualsDue) {
+        pushVisualStatuses(elements, outputs);
+        m_visualsDirty = false;
+    }
+}
+
+void Simulation::pushVisualStatuses(const QVector<GraphicElement *> &elements, const QVector<GraphicElement *> &outputs)
+{
     // Phase 3: push computed logic values onto all output port visuals.
     // Iterating elements (not connections) ensures unconnected output ports
     // (e.g. -Q of a flip-flop with no wire attached) are also updated.
@@ -238,6 +291,10 @@ void Simulation::restart()
     // element we've already freed faults on its vtable read. Drop every
     // reference so the next tick's initialize() can rebuild them cleanly.
     m_initialized = false;
+    // A structural edit invalidates the fixed point: the next tick must sweep, and its
+    // visuals must flush even if the throttle boundary lands on a later skipped tick.
+    m_atFixedPoint = false;
+    m_visualsDirty = true;
     m_sortedElements.clear();
     m_sequentialElements.clear();
     m_clocks.clear();
@@ -306,13 +363,15 @@ bool Simulation::isUserMuted() const
     return m_userMuted;
 }
 
-void Simulation::updateWithIterativeSettling(const QVector<GraphicElement *> &elements)
+bool Simulation::updateWithIterativeSettling(const QVector<GraphicElement *> &elements)
 {
-    if (!iterativeSettle(elements) && !m_convergenceWarned) {
+    const bool converged = iterativeSettle(elements);
+    if (!converged && !m_convergenceWarned) {
         m_convergenceWarned = true;
         qDebug() << "Feedback circuit did not converge after 10 iterations";
         emit simulationWarning(tr("Warning: feedback circuit did not converge — the circuit may be oscillating."));
     }
+    return converged;
 }
 
 bool Simulation::initialize()

--- a/App/Simulation/Simulation.h
+++ b/App/Simulation/Simulation.h
@@ -145,8 +145,12 @@ private:
 
     static void updatePort(InputPort *port);
     static void updatePort(OutputPort *port);
-    void updateWithIterativeSettling(const QVector<GraphicElement *> &elements);
+    /// Returns \c true when the feedback circuit converged within the iteration budget.
+    bool updateWithIterativeSettling(const QVector<GraphicElement *> &elements);
     void sortSimElements(const QVector<GraphicElement *> &elements);
+
+    /// Phases 3-4: pushes computed logic values onto port/output-element visuals.
+    void pushVisualStatuses(const QVector<GraphicElement *> &elements, const QVector<GraphicElement *> &outputs);
 
     /// Recursively appends every ElementGroup::Memory element in \a elements
     /// (descending into ICs) to m_sequentialElements. These get non-blocking
@@ -169,6 +173,17 @@ private:
     bool m_initialized = false;
     bool m_convergenceWarned = false;
     bool m_userMuted = false;
+
+    /// \c true after a completed sweep whose settle passes converged: outputs are a fixed
+    /// point of the (deterministic) element functions, so a tick where no clock and no
+    /// input element changed is a provable no-op and update() skips the sweep entirely.
+    /// Cleared by restart() (structural edits) and by any non-converging settle
+    /// (oscillating feedback must keep sweeping).
+    bool m_atFixedPoint = false;
+
+    /// Set by every sweep; lets a skipped tick know the throttled visual phases still
+    /// owe a flush (the display-rate boundary may land on a skipped tick).
+    bool m_visualsDirty = true;
 
     // --- Members: Visual refresh throttle ---
 

--- a/App/UI/MinimapWidget.cpp
+++ b/App/UI/MinimapWidget.cpp
@@ -192,7 +192,7 @@ bool MinimapWidget::computeTransform(QRectF &srcOut, double &scaleOut, double &d
     // Scene always contains a permanent (near-zero) rubber-band selection-rect item, so
     // itemsBoundingRect() never reports invalid/empty here in practice -- the final early return
     // exists only as a defensive guard for a Scene that isn't fully constructed the usual way.
-    QRectF src = m_scene->sceneRect().united(m_scene->itemsBoundingRect());
+    QRectF src = m_scene->sceneRect().united(m_scene->cachedItemsBoundingRect());
     if (m_view && m_view->viewport())
         src = src.united(m_view->mapToScene(m_view->viewport()->rect()).boundingRect());
     if (!src.isValid() || src.isEmpty())
@@ -315,7 +315,7 @@ void MinimapWidget::applyResize(const QPoint &globalPos)
     // content, same fallback chain as computeTransform() (itemsBoundingRect, then
     // sceneRect), so a resize while empty/degenerate still has a sane 1:1 ratio.
     const auto sceneAspectRatio = [this]() -> double {
-        QRectF src = m_scene ? m_scene->itemsBoundingRect() : QRectF();
+        QRectF src = m_scene ? m_scene->cachedItemsBoundingRect() : QRectF();
         if (!src.isValid() || src.isEmpty())
             src = m_scene ? m_scene->sceneRect() : QRectF();
         if (!src.isValid() || src.width() <= 0.0 || src.height() <= 0.0)

--- a/App/Wiring/Connection.cpp
+++ b/App/Wiring/Connection.cpp
@@ -210,10 +210,23 @@ void Connection::applyStatusPen()
     // other wires are thinner (3 px) to reduce visual clutter during simulation.
     // Unknown (undriven) wires use a distinct gray from Error (red).
     switch (m_status) {
-    case Status::Unknown:  setPen(QPen(m_unknownColor,  3)); break;
-    case Status::Inactive: setPen(QPen(m_inactiveColor, 3)); break;
-    case Status::Active:   setPen(QPen(m_activeColor,   3)); break;
-    case Status::Error:    setPen(QPen(m_errorColor,    5)); break;
+    case Status::Unknown:  m_statusPen = QPen(m_unknownColor,  3); break;
+    case Status::Inactive: m_statusPen = QPen(m_inactiveColor, 3); break;
+    case Status::Active:   m_statusPen = QPen(m_activeColor,   3); break;
+    case Status::Error:    m_statusPen = QPen(m_errorColor,    5); break;
+    }
+
+    // paint() draws with m_statusPen, not the item's own pen() -- boundingRect() is a fixed
+    // margin independent of pen width (see its own comment), so calling the real setPen()
+    // here would pay for a BSP-tree re-index (prepareGeometryChange()) on every status colour
+    // change for no actual geometry benefit. The one exception is width: shape()'s default
+    // hit-testing *does* stroke the path using the item's real pen width, so the real setPen()
+    // still runs whenever the width actually changes (Error <-> non-Error) to keep an
+    // Error-status wire's (wider) click target accurate.
+    if (!qFuzzyCompare(m_statusPen.widthF(), pen().widthF())) {
+        setPen(m_statusPen);
+    } else {
+        update();
     }
 }
 
@@ -248,8 +261,8 @@ void Connection::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
     }
 
     // When the wire itself is selected (clicked), switch to the selection colour;
-    // otherwise use the status-driven pen set by setStatus()
-    painter->setPen(isSelected() ? QPen(m_selectedColor, 5) : pen());
+    // otherwise use the status-driven pen set by setStatus() via applyStatusPen()
+    painter->setPen(isSelected() ? QPen(m_selectedColor, 5) : m_statusPen);
     painter->drawPath(path());
 }
 

--- a/App/Wiring/Connection.cpp
+++ b/App/Wiring/Connection.cpp
@@ -13,6 +13,7 @@
 
 #include "App/Core/Application.h"
 #include "App/Core/ThemeManager.h"
+#include "App/Scene/Scene.h"
 #include "App/Wiring/ConnectionSerializer.h"
 #include "App/Wiring/Port.h"
 
@@ -199,6 +200,13 @@ void Connection::setStatus(const Status status)
     }
 
     m_status = status;
+
+    // Feed idle detection for adaptive wire antialiasing: a stream of status changes IS
+    // the simulation repaint storm, and it stops exactly when the simulation does.
+    if (auto *scene_ = qobject_cast<Scene *>(scene())) {
+        scene_->noteWireActivity();
+    }
+
     applyStatusPen();
 
     // Propagate to the destination port so its fill colour also reflects the signal state
@@ -253,6 +261,15 @@ void Connection::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
 {
     Q_UNUSED(widget)
     Q_UNUSED(option)
+
+    // Adaptive quality (see Scene's wire-antialiasing accessors): while measured paint
+    // passes are too slow for interactivity, drop this wire's antialiasing -- never force
+    // it on, so a global choice like Fast Mode still wins. The painter state is
+    // saved/restored around each item's paint by QGraphicsView (the DontSavePainterState
+    // optimization flag is not set), so the hint can't leak into other items.
+    if (auto *scene_ = qobject_cast<Scene *>(scene()); scene_ && !scene_->wireAntialiasingEnabled()) {
+        painter->setRenderHint(QPainter::Antialiasing, false);
+    }
 
     // Highlight is drawn as a wider blue halo beneath the normal wire, so users can
     // easily see which wires belong to a selected element

--- a/App/Wiring/Connection.cpp
+++ b/App/Wiring/Connection.cpp
@@ -89,13 +89,20 @@ void Connection::setEndPort(InputPort *port)
 
 void Connection::updatePosFromPorts()
 {
-    if (m_startPort) {
-        m_startPos = m_startPort->scenePos();
+    const QPointF newStartPos = m_startPort ? m_startPort->scenePos() : m_startPos;
+    const QPointF newEndPos = m_endPort ? m_endPort->scenePos() : m_endPos;
+
+    // Skip the Bézier rebuild -- and the QPainterPath comparison setPath() does internally
+    // to decide whether a repaint is even needed -- when neither endpoint actually moved.
+    // Some callers (bulk commands, deserialization) refresh connections without knowing in
+    // advance which ones were actually affected; QPointF equality is exact and cheap, so
+    // this turns those into a no-op instead of a full path rebuild + Qt's own comparison.
+    if (newStartPos == m_startPos && newEndPos == m_endPos) {
+        return;
     }
 
-    if (m_endPort) {
-        m_endPos = m_endPort->scenePos();
-    }
+    m_startPos = newStartPos;
+    m_endPos = newEndPos;
 
     updatePath();
 }

--- a/App/Wiring/Connection.cpp
+++ b/App/Wiring/Connection.cpp
@@ -8,7 +8,9 @@
 
 #include <QGraphicsSceneMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPen>
+#include <QPolygonF>
 #include <QStyleOptionGraphicsItem>
 
 #include "App/Core/Application.h"
@@ -138,6 +140,7 @@ void Connection::updatePath()
     path.cubicTo(ctr1, ctr2, m_endPos);
 
     setPath(path);
+    m_shapeDirty = true;
 }
 
 OutputPort *Connection::startPort() const
@@ -236,6 +239,8 @@ void Connection::applyStatusPen()
     // Error-status wire's (wider) click target accurate.
     if (!qFuzzyCompare(m_statusPen.widthF(), pen().widthF())) {
         setPen(m_statusPen);
+        // The real pen's width sets shape()'s stroke tolerance -- rebuild the cached shape.
+        m_shapeDirty = true;
     } else {
         update();
     }
@@ -319,6 +324,35 @@ QRectF Connection::boundingRect() const
     // Expand beyond the path's tight bounding box by 10 px on all sides to ensure
     // the thick selection outline and highlight halo are fully covered during repaints
     return path().boundingRect().adjusted(-10, -10, 10, 10);
+}
+
+QPainterPath Connection::shape() const
+{
+    if (m_shapeDirty) {
+        // Same stroke semantics as Qt's default (qt_graphicsItem_shapeFromPath): the real
+        // pen's width sets the click tolerance along the wire -- which is why the real
+        // setPen() still runs on Error<->normal width transitions (see applyStatusPen()).
+        // Stroking a flattened (polygonal) copy instead of the raw Bézier keeps later
+        // intersects()/contains() tests on line segments; the flattening error is
+        // sub-pixel, far inside the stroke tolerance.
+        QPainterPathStroker stroker;
+        stroker.setWidth(qMax(pen().widthF(), 0.00000001));
+        stroker.setCapStyle(pen().capStyle());
+        stroker.setJoinStyle(pen().joinStyle());
+        stroker.setMiterLimit(pen().miterLimit());
+
+        // toSubpathPolygons() keeps open subpaths open -- toFillPolygon() would close the
+        // polyline back to its start, adding a phantom straight segment to the hit area.
+        QPainterPath flattened;
+        for (const QPolygonF &polygon : path().toSubpathPolygons()) {
+            flattened.addPolygon(polygon);
+        }
+
+        m_cachedShape = stroker.createStroke(flattened);
+        m_shapeDirty = false;
+    }
+
+    return m_cachedShape;
 }
 
 bool Connection::sceneEvent(QEvent *event)

--- a/App/Wiring/Connection.cpp
+++ b/App/Wiring/Connection.cpp
@@ -20,7 +20,10 @@ Connection::Connection(QGraphicsItem *parent)
     : QGraphicsPathItem(parent)
 {
     setFlag(QGraphicsItem::ItemIsSelectable);
-    setCacheMode(QGraphicsItem::DeviceCoordinateCache);
+    // Deliberately NOT DeviceCoordinateCache (the default NoCache stays): a wire is a thin
+    // stroke crossing a huge, mostly-empty bounding box, so a device-cache tile costs a
+    // bbox-sized pixmap clear + blend on every status colour change -- vastly more than just
+    // re-stroking the path -- and multi-MB tiles for long wires thrash the global QPixmapCache.
     // Draw wires behind elements so port dots and element bodies always render on top
     setZValue(-1);
 

--- a/App/Wiring/Connection.h
+++ b/App/Wiring/Connection.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <QGraphicsPathItem>
+#include <QPen>
 
 #include "App/Core/Enums.h"
 #include "App/Core/ItemWithId.h"
@@ -73,6 +74,8 @@ public:
     bool highLight();
     /// Enables or disables connection highlighting.
     void setHighLight(const bool highLight);
+    /// Returns the pen paint() draws the wire with for its current status.
+    QPen statusPen() const { return m_statusPen; }
 
     // --- Geometric properties ---
 
@@ -137,4 +140,9 @@ private:
 
     Status m_status = Status::Unknown;
     bool m_highLight = false;
+
+    /// Pen paint() actually draws with, kept separate from the item's own QGraphicsPathItem
+    /// pen -- see applyStatusPen() for why (avoids an unneeded BSP-tree re-index on every
+    /// status colour change).
+    QPen m_statusPen;
 };

--- a/App/Wiring/Connection.h
+++ b/App/Wiring/Connection.h
@@ -81,6 +81,11 @@ public:
 
     /// \reimp
     QRectF boundingRect() const override;
+    /// \reimp Cached, flattened stroke of the wire path -- the QGraphicsPathItem default
+    /// re-strokes the Bézier on every call and keeps its cubics, making every shape-exact
+    /// hit test (clicks, rubber-band selection) pay for stroking plus recursive curve
+    /// subdivision. Invalidated when the path or the real pen width changes.
+    QPainterPath shape() const override;
     /// Returns the current angle of the bezier midpoint in radians.
     double angle();
     /// Recomputes the bezier control points from the current start/end positions.
@@ -145,4 +150,8 @@ private:
     /// pen -- see applyStatusPen() for why (avoids an unneeded BSP-tree re-index on every
     /// status colour change).
     QPen m_statusPen;
+
+    /// Backing cache for shape(); mutable since the override is const.
+    mutable QPainterPath m_cachedShape;
+    mutable bool m_shapeDirty = true;
 };

--- a/App/Wiring/Port.cpp
+++ b/App/Wiring/Port.cpp
@@ -6,6 +6,7 @@
 
 #include "App/Wiring/Port.h"
 
+#include <QPainter>
 #include <QPen>
 
 #include "App/Core/ThemeManager.h"
@@ -38,6 +39,19 @@ QRectF Port::boundingRect() const
     // zoom the pen's edge gets a hard clip instead of a soft fade. 1 local unit of margin (the
     // port glyph is only ~10 units across) fixes that without perceptibly growing the glyph.
     return QGraphicsPathItem::boundingRect().adjusted(-1, -1, 1, 1);
+}
+
+void Port::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+    Q_UNUSED(option)
+    Q_UNUSED(widget)
+
+    // Mirrors QGraphicsPathItem's default paint exactly, except the pen comes from
+    // m_currentPen (see updateTheme()) instead of the item's own, real pen() -- the brush
+    // is unaffected, still the item's real (and cheap to update) brush().
+    painter->setPen(m_currentPen);
+    painter->setBrush(brush());
+    painter->drawPath(path());
 }
 
 const QList<Connection *> &Port::connections() const
@@ -210,28 +224,37 @@ void Port::updateTheme()
 {
     const auto &theme = ThemeManager::attributes();
 
+    // m_currentPen (drawn by paint()) is set directly instead of going through the item's
+    // own setPen() -- boundingRect() pads a pen-exact bound (see its own comment) but all
+    // four status pens below share the same implicit default width (theme.m_port*Pen are
+    // bare QColor, converted to QPen here), so the value never actually changes and the
+    // real setPen() would only pay for an unneeded BSP-tree re-index (prepareGeometryChange()).
+    // shape() already uses a fixed hit-area independent of pen width, so unlike Connection
+    // there's no hit-testing reason to ever fall back to the item's real pen either.
     switch (m_status) {
     case Status::Unknown: {
-        setPen(theme.m_portUnknownPen);
+        m_currentPen = theme.m_portUnknownPen;
         setCurrentBrush(theme.m_portUnknownBrush);
         break;
     }
     case Status::Inactive: {
-        setPen(theme.m_portInactivePen);
+        m_currentPen = theme.m_portInactivePen;
         setCurrentBrush(theme.m_portInactiveBrush);
         break;
     }
     case Status::Active: {
-        setPen(theme.m_portActivePen);
+        m_currentPen = theme.m_portActivePen;
         setCurrentBrush(theme.m_portActiveBrush);
         break;
     }
     case Status::Error: {
-        setPen(theme.m_portErrorPen);
+        m_currentPen = theme.m_portErrorPen;
         setCurrentBrush(theme.m_portErrorBrush);
         break;
     }
     }
+
+    update();
 }
 
 void Port::drainConnections(bool isInput)

--- a/App/Wiring/Port.h
+++ b/App/Wiring/Port.h
@@ -16,6 +16,7 @@
 
 #include <QBrush>
 #include <QGraphicsPathItem>
+#include <QPen>
 
 #include "App/Core/Enums.h"
 
@@ -48,6 +49,10 @@ public:
     /// \reimp Pads the default pen-exact bound by a small margin so DeviceCoordinateCache
     /// has room to antialias the stroke edge instead of clipping it (visible at high zoom).
     QRectF boundingRect() const override;
+
+    /// \reimp Draws with m_currentPen instead of the item's own pen() -- see updateTheme()
+    /// for why -- otherwise identical to the default QGraphicsPathItem paint.
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
     // --- Lifecycle ---
 
@@ -138,6 +143,9 @@ public:
      */
     void setCurrentBrush(const QBrush &currentBrush);
 
+    /// Returns the pen paint() draws the port outline with for its current status.
+    QPen currentPen() const { return m_currentPen; }
+
     /**
      * \brief Sets the status applied when the port has no connection.
      * \param defaultStatus Default status value.
@@ -194,6 +202,11 @@ protected:
 
     GraphicElement *m_graphicElement = nullptr;
     QBrush m_currentBrush;
+    /// Pen paint() actually draws the outline with, kept separate from the item's own
+    /// QGraphicsPathItem pen -- see updateTheme() for why (avoids an unneeded BSP-tree
+    /// re-index on every status colour change; all four status pens share the same width,
+    /// so unlike Connection this never needs to fall back to the item's real pen).
+    QPen m_currentPen;
     QList<Connection *> m_connections;
     QString m_name;
     Status m_defaultStatus = Status::Unknown;

--- a/Scripts/profile_load.sh
+++ b/Scripts/profile_load.sh
@@ -3,21 +3,37 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Profiles wiredpanda opening a .panda file, using either callgrind or perf.
-# Usage: Scripts/profile_load.sh <callgrind|perf> <file.panda> [seconds] [offscreen]
+# Usage: Scripts/profile_load.sh <callgrind|perf|callgrind-attach|perf-attach> <file.panda> [seconds] [offscreen] [settle_seconds]
 #
-#   seconds   - how long to let the app run before it's sent SIGTERM (default 20)
-#   offscreen - pass any value to run with QT_QPA_PLATFORM=offscreen, isolating
-#               simulation/logic cost from paint cost (default: real display)
+#   seconds        - callgrind/perf: how long to let the app run before SIGTERM (default 20)
+#                     *-attach: how long to record once attached (default 10)
+#   offscreen      - pass any value to run with QT_QPA_PLATFORM=offscreen, isolating
+#                     simulation/logic cost from paint cost (default: real display)
+#   settle_seconds - *-attach only: how long to let the app load+settle, unprofiled,
+#                     before attaching (default 10; measured empirically per fixture —
+#                     e.g. ~8s for a 20k-element circuit with simulation paused via
+#                     File > Play/Pause, since a running simulation keeps the process
+#                     busy and would otherwise mask when loading actually finished)
+#
+# callgrind/perf profile from process launch (load included). callgrind-attach/
+# perf-attach instead run the app unprofiled until it settles, then start
+# recording — isolating steady-state/rendering cost from one-time load cost:
+#   - perf-attach: perf can attach to an already-running process directly.
+#   - callgrind-attach: valgrind can't attach to an unmodified running process, so
+#     it's launched with --instr-atstart=no (near-native speed until toggled) and
+#     callgrind_control -i on/off starts/stops instrumentation around the window.
 #
 # Builds against build-relwithdebinfo/wiredpanda (cmake --preset relwithdebinfo).
 # Output is written under Scripts/profiling-out/, not to stdout.
 
 set -euo pipefail
 
-TOOL="${1:?usage: $0 <callgrind|perf> <file.panda> [seconds] [offscreen]}"
-PANDA_FILE="${2:?usage: $0 <callgrind|perf> <file.panda> [seconds] [offscreen]}"
-SECONDS_TO_RUN="${3:-20}"
+USAGE="usage: $0 <callgrind|perf|callgrind-attach|perf-attach> <file.panda> [seconds] [offscreen] [settle_seconds]"
+TOOL="${1:?$USAGE}"
+PANDA_FILE="${2:?$USAGE}"
+SECONDS_TO_RUN="${3:-}"
 OFFSCREEN="${4:-}"
+SETTLE_SECONDS="${5:-10}"
 
 BINARY="build-relwithdebinfo/wiredpanda"
 OUT_DIR="Scripts/profiling-out"
@@ -43,9 +59,10 @@ STAMP="$(basename "$PANDA_FILE" .panda)_$$"
 
 case "$TOOL" in
     callgrind)
+        RUN_SECONDS="${SECONDS_TO_RUN:-20}"
         OUT_FILE="$OUT_DIR/callgrind.out.$STAMP"
-        echo "Recording callgrind to $OUT_FILE (running ${SECONDS_TO_RUN}s)..."
-        timeout --signal=TERM "$SECONDS_TO_RUN" "${ENV_ARGS[@]}" \
+        echo "Recording callgrind to $OUT_FILE (running ${RUN_SECONDS}s)..."
+        timeout --signal=TERM "$RUN_SECONDS" "${ENV_ARGS[@]}" \
             valgrind --tool=callgrind --callgrind-out-file="$OUT_FILE" \
             "$BINARY" "$PANDA_FILE" || true
         echo "Done. Annotate with: callgrind_annotate --auto=yes $OUT_FILE | head -80"
@@ -57,15 +74,62 @@ case "$TOOL" in
         # time can take minutes. DEBUGINFOD_URLS is unset because this host
         # has it pointed at debuginfod.ubuntu.com, and perf report stalls
         # trying to reach it for every system library without local symbols.
+        RUN_SECONDS="${SECONDS_TO_RUN:-20}"
         OUT_FILE="$OUT_DIR/perf.data.$STAMP"
-        echo "Recording perf to $OUT_FILE (running ${SECONDS_TO_RUN}s)..."
-        timeout --signal=TERM "$SECONDS_TO_RUN" "${ENV_ARGS[@]}" \
+        echo "Recording perf to $OUT_FILE (running ${RUN_SECONDS}s)..."
+        timeout --signal=TERM "$RUN_SECONDS" "${ENV_ARGS[@]}" \
             env -u DEBUGINFOD_URLS perf record -F 99 --call-graph dwarf -o "$OUT_FILE" -- \
             "$BINARY" "$PANDA_FILE" || true
         echo "Done. Report with: env -u DEBUGINFOD_URLS perf report --stdio -g -i $OUT_FILE > report.txt"
         ;;
+    perf-attach)
+        # Launches unprofiled, lets it load+settle, then attaches perf to the
+        # already-running process — isolating steady-state/rendering cost
+        # from one-time load cost (unlike plain 'perf', which profiles from
+        # process launch and so includes loading).
+        RUN_SECONDS="${SECONDS_TO_RUN:-10}"
+        OUT_FILE="$OUT_DIR/perf.data.$STAMP"
+        echo "Launching app, settling for ${SETTLE_SECONDS}s before attaching..."
+        "${ENV_ARGS[@]}" "$BINARY" "$PANDA_FILE" &
+        APP_PID=$!
+        sleep "$SETTLE_SECONDS"
+        if ! kill -0 "$APP_PID" 2>/dev/null; then
+            echo "App exited during the settle window" >&2
+            exit 1
+        fi
+        echo "Attaching perf to PID $APP_PID for ${RUN_SECONDS}s..."
+        timeout --signal=TERM "$RUN_SECONDS" \
+            env -u DEBUGINFOD_URLS perf record -F 99 --call-graph dwarf -p "$APP_PID" -o "$OUT_FILE" || true
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+        echo "Done. Report with: env -u DEBUGINFOD_URLS perf report --stdio -g -i $OUT_FILE > report.txt"
+        ;;
+    callgrind-attach)
+        # valgrind can't attach to an unmodified running process, so instead:
+        # launch with --instr-atstart=no (runs at near-native speed until
+        # toggled), let it load+settle, then callgrind_control -i on/off
+        # brackets the recording window around steady-state activity only.
+        RUN_SECONDS="${SECONDS_TO_RUN:-10}"
+        OUT_FILE="$OUT_DIR/callgrind.out.$STAMP"
+        echo "Launching app under callgrind (instrumentation off), settling for ${SETTLE_SECONDS}s..."
+        "${ENV_ARGS[@]}" valgrind --tool=callgrind --instr-atstart=no --callgrind-out-file="$OUT_FILE" \
+            "$BINARY" "$PANDA_FILE" &
+        VALGRIND_PID=$!
+        sleep "$SETTLE_SECONDS"
+        if ! kill -0 "$VALGRIND_PID" 2>/dev/null; then
+            echo "App exited during the settle window" >&2
+            exit 1
+        fi
+        echo "Turning on instrumentation for ${RUN_SECONDS}s..."
+        callgrind_control -i on "$VALGRIND_PID"
+        sleep "$RUN_SECONDS"
+        callgrind_control -i off "$VALGRIND_PID"
+        kill "$VALGRIND_PID" 2>/dev/null || true
+        wait "$VALGRIND_PID" 2>/dev/null || true
+        echo "Done. Annotate with: callgrind_annotate --auto=yes $OUT_FILE | head -80"
+        ;;
     *)
-        echo "Unknown tool '$TOOL' - expected 'callgrind' or 'perf'" >&2
+        echo "Unknown tool '$TOOL' - expected 'callgrind', 'perf', 'callgrind-attach', or 'perf-attach'" >&2
         exit 1
         ;;
 esac

--- a/Scripts/profile_load.sh
+++ b/Scripts/profile_load.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2015 - 2026, GIBIS-Unifesp and the wiRedPanda contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Profiles wiredpanda opening a .panda file, using either callgrind or perf.
+# Usage: Scripts/profile_load.sh <callgrind|perf> <file.panda> [seconds] [offscreen]
+#
+#   seconds   - how long to let the app run before it's sent SIGTERM (default 20)
+#   offscreen - pass any value to run with QT_QPA_PLATFORM=offscreen, isolating
+#               simulation/logic cost from paint cost (default: real display)
+#
+# Builds against build-relwithdebinfo/wiredpanda (cmake --preset relwithdebinfo).
+# Output is written under Scripts/profiling-out/, not to stdout.
+
+set -euo pipefail
+
+TOOL="${1:?usage: $0 <callgrind|perf> <file.panda> [seconds] [offscreen]}"
+PANDA_FILE="${2:?usage: $0 <callgrind|perf> <file.panda> [seconds] [offscreen]}"
+SECONDS_TO_RUN="${3:-20}"
+OFFSCREEN="${4:-}"
+
+BINARY="build-relwithdebinfo/wiredpanda"
+OUT_DIR="Scripts/profiling-out"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "Missing $BINARY - build it first: cmake --build --preset relwithdebinfo" >&2
+    exit 1
+fi
+
+if [[ ! -f "$PANDA_FILE" ]]; then
+    echo "No such file: $PANDA_FILE" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+ENV_ARGS=()
+if [[ -n "$OFFSCREEN" ]]; then
+    ENV_ARGS+=(env QT_QPA_PLATFORM=offscreen)
+fi
+
+STAMP="$(basename "$PANDA_FILE" .panda)_$$"
+
+case "$TOOL" in
+    callgrind)
+        OUT_FILE="$OUT_DIR/callgrind.out.$STAMP"
+        echo "Recording callgrind to $OUT_FILE (running ${SECONDS_TO_RUN}s)..."
+        timeout --signal=TERM "$SECONDS_TO_RUN" "${ENV_ARGS[@]}" \
+            valgrind --tool=callgrind --callgrind-out-file="$OUT_FILE" \
+            "$BINARY" "$PANDA_FILE" || true
+        echo "Done. Annotate with: callgrind_annotate --auto=yes $OUT_FILE | head -80"
+        ;;
+    perf)
+        # -F 99 caps the sample rate (the standard rate for callgraph
+        # profiling): perf's default (~2000Hz) produces so many DWARF stack
+        # dumps over a multi-second run that unwinding them all at report
+        # time can take minutes. DEBUGINFOD_URLS is unset because this host
+        # has it pointed at debuginfod.ubuntu.com, and perf report stalls
+        # trying to reach it for every system library without local symbols.
+        OUT_FILE="$OUT_DIR/perf.data.$STAMP"
+        echo "Recording perf to $OUT_FILE (running ${SECONDS_TO_RUN}s)..."
+        timeout --signal=TERM "$SECONDS_TO_RUN" "${ENV_ARGS[@]}" \
+            env -u DEBUGINFOD_URLS perf record -F 99 --call-graph dwarf -o "$OUT_FILE" -- \
+            "$BINARY" "$PANDA_FILE" || true
+        echo "Done. Report with: env -u DEBUGINFOD_URLS perf report --stdio -g -i $OUT_FILE > report.txt"
+        ;;
+    *)
+        echo "Unknown tool '$TOOL' - expected 'callgrind' or 'perf'" >&2
+        exit 1
+        ;;
+esac

--- a/Tests/Unit/Scene/TestScene.cpp
+++ b/Tests/Unit/Scene/TestScene.cpp
@@ -1799,3 +1799,31 @@ void TestScene::testWireAntialiasingDegradesOnSlowPassesAndRestores()
     scene->recordWirePaintPass(60 * kMs);
     QVERIFY(scene->wireAntialiasingEnabled());
 }
+
+void TestScene::testPortAtFindsPortsOnly()
+{
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+
+    auto *andGate = ElementFactory::buildElement(ElementType::And);
+    andGate->setPos(100, 100);
+    scene->addItem(andGate);
+
+    auto *inputPort = static_cast<Port *>(andGate->inputPort(0));
+    const QPointF portPos = inputPort->scenePos();
+
+    // Exact hit on the port's origin.
+    QCOMPARE(scene->portAt(portPos), inputPort);
+
+    // Within the port's own ±5 hit square.
+    QCOMPARE(scene->portAt(portPos + QPointF(3, 3)), inputPort);
+
+    // Just outside the square but within the 4 px slop: the nearby phase finds it.
+    QCOMPARE(scene->portAt(portPos + QPointF(8, 0)), inputPort);
+
+    // The element body's centre is far from any port: elements are never returned.
+    QVERIFY(!scene->portAt(andGate->sceneBoundingRect().center()));
+
+    // Empty canvas.
+    QVERIFY(!scene->portAt(QPointF(-500, -500)));
+}

--- a/Tests/Unit/Scene/TestScene.cpp
+++ b/Tests/Unit/Scene/TestScene.cpp
@@ -1740,3 +1740,62 @@ void TestScene::testMuteSilencesAllAudioOutputElements()
     QVERIFY(!buzzerAudio->isMuted());
     QVERIFY(!audioBoxAudio->isMuted());
 }
+
+void TestScene::testWireAntialiasingDegradesOnSlowPassesAndRestores()
+{
+    constexpr qint64 kMs = 1'000'000; // recordWirePaintPass takes nanoseconds
+
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+
+    // Full quality by default.
+    QVERIFY(scene->wireAntialiasingEnabled());
+
+    // One over-budget pass is not enough (debounce: a lone stall must not degrade)...
+    scene->recordWirePaintPass(60 * kMs);
+    QVERIFY(scene->wireAntialiasingEnabled());
+
+    // ...and an in-budget pass in between resets the streak.
+    scene->recordWirePaintPass(5 * kMs);
+    scene->recordWirePaintPass(60 * kMs);
+    QVERIFY(scene->wireAntialiasingEnabled());
+
+    // Two consecutive over-budget passes degrade.
+    scene->recordWirePaintPass(60 * kMs);
+    QVERIFY(!scene->wireAntialiasingEnabled());
+
+    // Anti-oscillation: degraded passes measuring well under budget -- but without deep
+    // headroom -- must never restore, no matter how many. (The degraded renderer being
+    // "fast enough" is a consequence of the degrade itself.)
+    for (int i = 0; i < 50; ++i) {
+        scene->recordWirePaintPass(20 * kMs);
+    }
+    QVERIFY(!scene->wireAntialiasingEnabled());
+
+    // A non-headroom pass resets a deep-headroom streak.
+    for (int i = 0; i < 9; ++i) {
+        scene->recordWirePaintPass(2 * kMs);
+    }
+    scene->recordWirePaintPass(20 * kMs);
+    for (int i = 0; i < 9; ++i) {
+        scene->recordWirePaintPass(2 * kMs);
+    }
+    QVERIFY(!scene->wireAntialiasingEnabled());
+
+    // Sustained deep headroom (10 consecutive passes under budget/worst-case-ratio)
+    // restores: the next antialiased pass fits the budget by construction.
+    scene->recordWirePaintPass(2 * kMs);
+    QVERIFY(scene->wireAntialiasingEnabled());
+
+    // Idle restore path: degrade again, then invoke the restore method as the idle
+    // timer's timeout would.
+    scene->recordWirePaintPass(60 * kMs);
+    scene->recordWirePaintPass(60 * kMs);
+    QVERIFY(!scene->wireAntialiasingEnabled());
+    scene->restoreWireAntialiasing();
+    QVERIFY(scene->wireAntialiasingEnabled());
+
+    // Restoring resets the debounce: a single slow pass afterwards does not re-degrade.
+    scene->recordWirePaintPass(60 * kMs);
+    QVERIFY(scene->wireAntialiasingEnabled());
+}

--- a/Tests/Unit/Scene/TestScene.cpp
+++ b/Tests/Unit/Scene/TestScene.cpp
@@ -1827,3 +1827,49 @@ void TestScene::testPortAtFindsPortsOnly()
     // Empty canvas.
     QVERIFY(!scene->portAt(QPointF(-500, -500)));
 }
+
+void TestScene::testResizeSceneQuantizesSceneRect()
+{
+    constexpr qreal quantum = 256.0;
+    const auto isQuantized = [](qreal edge) {
+        return qFuzzyIsNull(std::fmod(edge, quantum));
+    };
+
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+
+    auto *andGate = ElementFactory::buildElement(ElementType::And);
+    andGate->setPos(100, 100);
+    scene->addItem(andGate);
+
+    scene->resizeScene();
+    const QRectF rect = scene->sceneRect();
+    QVERIFY(rect.contains(scene->itemsBoundingRect()));
+    QVERIFY(isQuantized(rect.left()));
+    QVERIFY(isQuantized(rect.top()));
+    QVERIFY(isQuantized(rect.right()));
+    QVERIFY(isQuantized(rect.bottom()));
+
+    // A small move well inside the current chunk must leave the rect bit-identical --
+    // the exact-equality no-op in QGraphicsScene::setSceneRect() is what spares the
+    // full BSP re-index. Invalidate the bounds cache as a real MoveCommand would, so
+    // this exercises the quantization, not cache staleness.
+    andGate->setPos(110, 110);
+    scene->setPropertyUpdateRequired();
+    scene->resizeScene();
+    QCOMPARE(scene->sceneRect(), rect);
+
+    // Growth past the current rect expands it, still on quantized edges. A real move
+    // funnels through MoveCommand -> setPropertyUpdateRequired(), which dirties the
+    // cached items bounding rect resizeScene() reads -- mirror that here, since a bare
+    // setPos() bypasses the app's edit chokepoint.
+    andGate->setPos(rect.right() + 300, rect.bottom() + 300);
+    scene->setPropertyUpdateRequired();
+    scene->resizeScene();
+    const QRectF grown = scene->sceneRect();
+    QVERIFY(grown.contains(scene->itemsBoundingRect()));
+    QVERIFY(grown.right() > rect.right());
+    QVERIFY(grown.bottom() > rect.bottom());
+    QVERIFY(isQuantized(grown.right()));
+    QVERIFY(isQuantized(grown.bottom()));
+}

--- a/Tests/Unit/Scene/TestScene.h
+++ b/Tests/Unit/Scene/TestScene.h
@@ -109,4 +109,9 @@ private slots:
     // Scene::mute() must silence every AudioOutputElement subclass (Buzzer and AudioBox),
     // not just Buzzer -- otherwise an AudioBox keeps playing audibly through a simulation pause.
     void testMuteSilencesAllAudioOutputElements();
+
+    // Adaptive wire antialiasing: measured over-budget passes degrade (debounced), and
+    // quality returns only via idle or sustained deep headroom -- never because the
+    // degraded renderer merely measures "fast enough" (binary-knob oscillation).
+    void testWireAntialiasingDegradesOnSlowPassesAndRestores();
 };

--- a/Tests/Unit/Scene/TestScene.h
+++ b/Tests/Unit/Scene/TestScene.h
@@ -118,4 +118,8 @@ private slots:
     // portAt(): the bounding-box fast path used by hover/tooltip/wire-completion must
     // find ports (exactly and within the 4 px slop) and nothing else.
     void testPortAtFindsPortsOnly();
+
+    // resizeScene() quantizes the scene rect so small interaction steps yield
+    // bit-identical rects -- any changed rect makes Qt's BSP index re-insert every item.
+    void testResizeSceneQuantizesSceneRect();
 };

--- a/Tests/Unit/Scene/TestScene.h
+++ b/Tests/Unit/Scene/TestScene.h
@@ -114,4 +114,8 @@ private slots:
     // quality returns only via idle or sustained deep headroom -- never because the
     // degraded renderer merely measures "fast enough" (binary-knob oscillation).
     void testWireAntialiasingDegradesOnSlowPassesAndRestores();
+
+    // portAt(): the bounding-box fast path used by hover/tooltip/wire-completion must
+    // find ports (exactly and within the 4 px slop) and nothing else.
+    void testPortAtFindsPortsOnly();
 };

--- a/Tests/Unit/Scene/TestSceneUndoredo.cpp
+++ b/Tests/Unit/Scene/TestSceneUndoredo.cpp
@@ -373,6 +373,62 @@ void TestSceneUndoredo::testMidDragDeleteDoesNotCrash()
     QCOMPARE(scene.undoStack()->count(), 1);
 }
 
+void TestSceneUndoredo::testResizeSceneFollowsLiveDragBeyondCachedBounds()
+{
+    // Scene::cachedItemsBoundingRect() must bypass its cache during an active drag:
+    // resizeScene()'s expand-only branch needs the dragged element's live position to
+    // grow the scene rect and follow it, not a stale value from before the drag started.
+    Scene scene;
+
+    auto *elm = ElementFactory::buildElement(ElementType::And);
+    elm->setPos(0, 0);
+    scene.addItem(elm);
+    elm->setSelected(true);
+
+    // Warm the cache at the element's initial (small) position.
+    scene.resizeScene();
+    QVERIFY(!scene.sceneRect().contains(QPointF(5000, 5000)));
+
+    // Begin the drag.
+    const QPointF pressPos = elm->scenePos();
+    QGraphicsSceneMouseEvent pressEvent(QEvent::GraphicsSceneMousePress);
+    pressEvent.setScenePos(pressPos);
+    pressEvent.setButton(Qt::LeftButton);
+    pressEvent.setButtons(Qt::LeftButton);
+    QCoreApplication::sendEvent(&scene, &pressEvent);
+
+    // Drag it far beyond the cached bounds. resizeScene() runs before the base-class
+    // QGraphicsScene::mouseMoveEvent() actually moves the item for that same event (see
+    // SceneInteraction::mouseMove(), which calls resizeScene() and only then returns false
+    // so Scene::mouseMoveEvent() falls through to the base class) — so it's always one event
+    // behind, imperceptible during a real drag's stream of move events but requiring a second,
+    // zero-delta move here to let resizeScene() observe the position the first move landed on.
+    const QPointF farPos(5000, 5000);
+    QGraphicsSceneMouseEvent moveEvent(QEvent::GraphicsSceneMouseMove);
+    moveEvent.setScenePos(farPos);
+    moveEvent.setLastScenePos(pressPos);
+    moveEvent.setButton(Qt::LeftButton);
+    moveEvent.setButtons(Qt::LeftButton);
+    QCoreApplication::sendEvent(&scene, &moveEvent);
+
+    QGraphicsSceneMouseEvent settleMoveEvent(QEvent::GraphicsSceneMouseMove);
+    settleMoveEvent.setScenePos(farPos);
+    settleMoveEvent.setLastScenePos(farPos);
+    settleMoveEvent.setButton(Qt::LeftButton);
+    settleMoveEvent.setButtons(Qt::LeftButton);
+    QCoreApplication::sendEvent(&scene, &settleMoveEvent);
+
+    // resizeScene() must have grown to follow the live drag — with a stale cached
+    // bounds instead, the scene rect would still reflect the pre-drag position.
+    QVERIFY(scene.sceneRect().contains(elm->sceneBoundingRect()));
+
+    QGraphicsSceneMouseEvent releaseEvent(QEvent::GraphicsSceneMouseRelease);
+    releaseEvent.setScenePos(farPos);
+    releaseEvent.setButton(Qt::LeftButton);
+    releaseEvent.setButtons(Qt::NoButton);
+    QCoreApplication::sendEvent(&scene, &releaseEvent);
+}
+
 // ─── FlipCommand ──────────────────────────────────────────────────────────
 
 void TestSceneUndoredo::testFlipHorizontalUndoRedo()

--- a/Tests/Unit/Scene/TestSceneUndoredo.h
+++ b/Tests/Unit/Scene/TestSceneUndoredo.h
@@ -32,6 +32,7 @@ private slots:
     void testMoveSingleElement();
     void testMoveMultipleElements();
     void testMidDragDeleteDoesNotCrash(); // regression: WIREDPANDA-H9 / WIREDPANDA-EV
+    void testResizeSceneFollowsLiveDragBeyondCachedBounds();
 
     // FlipCommand
     void testFlipHorizontalUndoRedo();

--- a/Tests/Unit/Wiring/TestConnection.cpp
+++ b/Tests/Unit/Wiring/TestConnection.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "App/Core/Application.h"
+#include "App/Core/ThemeManager.h"
 #include "App/Element/GraphicElements/And.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Wiring/Connection.h"
@@ -82,4 +83,32 @@ void TestConnection::testConnectionDestruction()
 
     QVERIFY(outPort->connections().isEmpty());
     QVERIFY(inPort->connections().isEmpty());
+}
+
+void TestConnection::testConnectionStatusPenTracksColorAndWidth()
+{
+    // applyStatusPen() bypasses the item's own setPen() (and the BSP-tree re-index it
+    // triggers) whenever the pen width doesn't change, tracking colour via statusPen()
+    // instead -- this must still reflect the correct colour and width for every status,
+    // including the Error <-> non-Error transitions that exercise the real-setPen() branch.
+    const auto &theme = ThemeManager::attributes();
+    Connection connection;
+
+    connection.setStatus(Status::Active);
+    QCOMPARE(connection.statusPen().color(), theme.m_connectionActive);
+    QCOMPARE(connection.statusPen().widthF(), 3.0);
+
+    connection.setStatus(Status::Inactive);
+    QCOMPARE(connection.statusPen().color(), theme.m_connectionInactive);
+    QCOMPARE(connection.statusPen().widthF(), 3.0);
+
+    // Inactive -> Error: width grows 3 -> 5, the real setPen() must still run.
+    connection.setStatus(Status::Error);
+    QCOMPARE(connection.statusPen().color(), theme.m_connectionError);
+    QCOMPARE(connection.statusPen().widthF(), 5.0);
+
+    // Error -> Unknown: width shrinks back 5 -> 3, exercising the same branch in reverse.
+    connection.setStatus(Status::Unknown);
+    QCOMPARE(connection.statusPen().color(), theme.m_connectionUnknown);
+    QCOMPARE(connection.statusPen().widthF(), 3.0);
 }

--- a/Tests/Unit/Wiring/TestConnection.cpp
+++ b/Tests/Unit/Wiring/TestConnection.cpp
@@ -112,3 +112,35 @@ void TestConnection::testConnectionStatusPenTracksColorAndWidth()
     QCOMPARE(connection.statusPen().color(), theme.m_connectionUnknown);
     QCOMPARE(connection.statusPen().widthF(), 3.0);
 }
+
+void TestConnection::testShapeFollowsPathAndPenWidth()
+{
+    // shape() is cached (the QGraphicsPathItem default re-strokes the Bézier on every
+    // call) -- the cache must follow path geometry changes and real pen-width changes.
+    const bool prevRendering = Application::renderingEnabled;
+    Application::renderingEnabled = true; // updatePath() builds geometry only when rendering
+
+    Connection connection;
+    connection.setStartPos({0, 0});
+    connection.setEndPos({100, 0});
+    connection.updatePath();
+
+    // A point on the wire's midline is inside the stroke; a far-away point is not.
+    QVERIFY(connection.shape().contains(QPointF(50, 0)));
+    QVERIFY(!connection.shape().contains(QPointF(50, 30)));
+
+    // Moving an endpoint must invalidate the cache: the old midline no longer hits.
+    connection.setEndPos({100, 100});
+    connection.updatePath();
+    QVERIFY(!connection.shape().contains(QPointF(50, 0)));
+
+    // The default 3-wide stroke (~1.5 half-width) misses a point 2 px off-axis at the
+    // horizontal wire's start; the Error pen (width 5, half-width 2.5) must reach it.
+    connection.setEndPos({100, 0});
+    connection.updatePath();
+    QVERIFY(!connection.shape().contains(QPointF(2, 2)));
+    connection.setStatus(Status::Error);
+    QVERIFY(connection.shape().contains(QPointF(2, 2)));
+
+    Application::renderingEnabled = prevRendering;
+}

--- a/Tests/Unit/Wiring/TestConnection.h
+++ b/Tests/Unit/Wiring/TestConnection.h
@@ -16,4 +16,5 @@ private slots:
     void testConnectionHoverEffect();
     void testConnectionSelection();
     void testConnectionDestruction();
+    void testConnectionStatusPenTracksColorAndWidth();
 };

--- a/Tests/Unit/Wiring/TestConnection.h
+++ b/Tests/Unit/Wiring/TestConnection.h
@@ -17,4 +17,5 @@ private slots:
     void testConnectionSelection();
     void testConnectionDestruction();
     void testConnectionStatusPenTracksColorAndWidth();
+    void testShapeFollowsPathAndPenWidth();
 };

--- a/Tests/Unit/Wiring/TestPort.cpp
+++ b/Tests/Unit/Wiring/TestPort.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include "App/Core/ThemeManager.h"
 #include "App/Element/GraphicElements/Display7.h"
 #include "App/Wiring/Port.h"
 #include "Tests/Common/TestUtils.h"
@@ -41,4 +42,26 @@ void TestPort::testSetInputsReindexesPorts()
     for (int i = 0; i < display.inputSize(); ++i) {
         QCOMPARE(display.inputPort(i)->index(), i);
     }
+}
+
+void TestPort::testPortCurrentPenTracksStatusColor()
+{
+    // updateTheme() bypasses the item's own setPen() (and the BSP-tree re-index it
+    // triggers) for every status, tracking colour via currentPen() instead -- this must
+    // still reflect the correct colour for every status. OutputPort is always valid
+    // regardless of connection state, so its status can be driven directly.
+    const auto &theme = ThemeManager::attributes();
+    OutputPort port;
+
+    port.setStatus(Status::Active);
+    QCOMPARE(port.currentPen().color(), theme.m_portActivePen);
+
+    port.setStatus(Status::Inactive);
+    QCOMPARE(port.currentPen().color(), theme.m_portInactivePen);
+
+    port.setStatus(Status::Error);
+    QCOMPARE(port.currentPen().color(), theme.m_portErrorPen);
+
+    port.setStatus(Status::Unknown);
+    QCOMPARE(port.currentPen().color(), theme.m_portUnknownPen);
 }

--- a/Tests/Unit/Wiring/TestPort.h
+++ b/Tests/Unit/Wiring/TestPort.h
@@ -17,4 +17,6 @@ private slots:
 
     // Regression: F18 — setInputs must keep index() == vector position
     void testSetInputsReindexesPorts();
+
+    void testPortCurrentPenTracksStatusColor();
 };


### PR DESCRIPTION
## Summary

Ten performance fixes found via real profiling (`Scripts/profile_load.sh`, added here) of large circuits (2,000–20,000 elements), taking the worst case — a 2,000-element clocked circuit whose UI was effectively frozen — from ~870 ms antialiased paint passes at 1–2 fps and a saturated core down to ~40% of one core with ~165 ms worst-case passes.

### Rendering

- **Cache the per-element `QSvgRenderer`** by path+mtime+rotation+flip: thousands of elements share a handful of bundled icon files, so this collapses ~20,000 redundant SVG parses to a handful (hotspot ~23% → ~1.5%).
- **Cache `Scene::itemsBoundingRect()`** — was recomputed (O(all items)) on every pan/zoom/scroll step via `resizeScene()` and the minimap (~57% → ~6% of interactive samples). Bypasses itself during live element drags.
- **Skip `Connection` path rebuilds when endpoints didn't move** — bulk refresh paths triggered Bézier rebuilds plus Qt's internal path comparison for every wire.
- **Stop status-pen changes from re-indexing the BSP tree** — every wire/port status recolor paid `setPen()` → `prepareGeometryChange()` → full spatial re-index despite identical geometry; pens are now tracked separately and the real `setPen()` runs only on actual width changes (Error ↔ normal).
- **Stop device-caching wires** — a wire is a thin stroke crossing a huge, mostly-empty bounding box, so `DeviceCoordinateCache` tiles cost multi-megabyte clears + blends per status change and thrashed the global `QPixmapCache` (~50% of interaction CPU in cache bookkeeping alone).
- **Adapt wire antialiasing to the measured paint budget** — when passes stay over 50 ms, wires drop antialiasing (~5.5× cheaper strokes); quality restores when activity stops (idle) or passes show sustained deep headroom. Only wires change; elements/ports/text keep full quality, and Fast Mode still wins.
- **Cheapen hover hit-testing** — hover only ever needs a Port but paid exact Bézier intersection against every wire under the cursor on each mouse move; a bounding-box port lookup plus a cached, flattened `Connection::shape()` removes the per-move stroking/clipping (also helps rubber-band selection and wire clicks).
- **Quantize the scene rect** — any changed `sceneRect` makes Qt's BSP index re-insert every item (tens of ms); zoom steps and edge drags changed it per event. Snapping outward to a 256-unit grid makes consecutive steps bit-identical (7.6% → 2.3% of paint-pass time).

### Simulation

- **Make the deferred-commit tick path allocation-free** — `beginDeferredCommit()` CoW-shared the staging buffer, so every sequential element paid ≥1 malloc+free per 1 ms tick even when idle (~10% of CPU hiding in `Simulation::update`).
- **Skip provably-idle simulation ticks** — a completed, converged sweep is a fixed point of the deterministic element functions; ticks where no clock or input element changed now return early (clocks/inputs still polled every tick, oscillating feedback circuits never skip, throttled visual flushes preserved). Engine share: ~29% of CPU → under 1%; idle process CPU 86.6% → 40.0% of a core.

## Test plan
- [x] `ctest --preset debug` — full suite green (191/191) after every commit, including new targeted tests for each behavioral seam (drag cache bypass, status-pen tracking, adaptive-AA state machine, `portAt`, `Connection::shape()` cache, scene-rect quantization)
- [x] Before/after perf captures for every fix with real interactive use (not synthetic/offscreen); adversarial validation of each hypothesis before fixing
- [x] Manual smoke tests per fix: wire/port colors track simulation, Error wires stay thick and clickable, hover/tooltips/selection accurate, zoom/pan/drag smooth, pausing restores antialiased wires, switch toggles respond instantly, BeWavedDolphin waveforms unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
