### PR TITLE
Fix the GUI-test flake root causes and run the suite on every CI platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,33 @@ jobs:
       run: |
         ctest --preset release -V -L gui -FS non_gui_complete
 
+    # Trial runs of the gui suite off-Linux, non-blocking while they build a
+    # track record (promote to blocking once proven stable; see the polling
+    # AutoDismisser test hardening that unblocked this). macOS pins the
+    # offscreen platform: the historical hang class was native-cocoa modal
+    # activation timing. Windows tries the native platform first — its
+    # runners already run the widget-creating non-gui suite natively and
+    # green. Separate steps on purpose: a ternary env expression could set
+    # QT_QPA_PLATFORM to "" (set-but-empty), which makes Qt load no platform.
+    - name: Test (GUI, offscreen, trial)
+      if: runner.os == 'macOS'
+      timeout-minutes: 10
+      continue-on-error: true
+      env:
+        QT_FORCE_STDERR_LOGGING: 1
+        QT_QPA_PLATFORM: offscreen
+      run: |
+        ctest --preset release -V -L gui -FS non_gui_complete
+
+    - name: Test (GUI, native, trial)
+      if: runner.os == 'Windows'
+      timeout-minutes: 10
+      continue-on-error: true
+      env:
+        QT_FORCE_STDERR_LOGGING: 1
+      run: |
+        ctest --preset release -V -L gui -FS non_gui_complete
+
     - name: Smoke-test cmake --install
       shell: bash
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,6 +50,14 @@ jobs:
       run: |
         ctest --preset coverage -V -LE gui
 
+    # Same headless environment that runs green in build.yml; also lifts
+    # coverage of the MainWindow/dialog/BeWavedDolphin UI paths that only
+    # these four classes exercise.
+    - name: Test (GUI, headless)
+      timeout-minutes: 10
+      run: |
+        ctest --preset coverage -V -L gui -FS non_gui_complete
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -106,6 +106,21 @@ jobs:
       run: |
         ctest --preset ${{ matrix.sanitizer }} -V -LE gui
 
+    # The gui suite under sanitizers is where teardown-order UAFs (the
+    # WIREDPANDA-HC / MainWindow-destruction class of intermittent segfault)
+    # become deterministic instead of once-a-month. Non-blocking while it
+    # accumulates a track record; promote to blocking once proven stable.
+    - name: Test (GUI, headless)
+      timeout-minutes: 15
+      continue-on-error: true
+      env:
+        QT_FORCE_STDERR_LOGGING: 1
+        ASAN_OPTIONS: abort_on_error=1:halt_on_error=1
+        LSAN_OPTIONS: suppressions=${{ github.workspace }}/Tests/lsan_suppressions.txt
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: |
+        ctest --preset ${{ matrix.sanitizer }} -V -L gui -FS non_gui_complete
+
     - name: Upload build artifacts on failure
       if: failure()
       uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,10 +1090,13 @@ foreach(TEST ${ALL_TESTS})
     set_tests_properties(${TEST} PROPERTIES FIXTURES_SETUP "non_gui_complete")
 endforeach()
 foreach(TEST ${GUI_TESTS})
+    # QTEST_FUNCTION_TIMEOUT: a hung dialog exec() costs 60s instead of Qt
+    # Test's default 5-minute watchdog — the historical GUI-flake failure mode.
     set_tests_properties(${TEST} PROPERTIES
         LABELS "gui"
         FIXTURES_REQUIRED "non_gui_complete"
-        RESOURCE_LOCK "gui_display")
+        RESOURCE_LOCK "gui_display"
+        ENVIRONMENT "QTEST_FUNCTION_TIMEOUT=60000")
 endforeach()
 
 # ========= DOCUMENTATION ===================================

--- a/Tests/Common/TestUtils.cpp
+++ b/Tests/Common/TestUtils.cpp
@@ -5,6 +5,7 @@
 
 #include <limits>
 
+#include <QAbstractButton>
 #include <QGraphicsScene>
 #include <QPainter>
 #include <QRandomGenerator>
@@ -27,10 +28,17 @@ namespace TestUtils {
 void setupTestEnvironment()
 {
 #ifdef Q_OS_LINUX
-    qputenv("QT_QPA_PLATFORM", "offscreen");
+    // Default to headless, but never clobber an explicit choice — CI workflows
+    // and developers set QT_QPA_PLATFORM to pick the platform per-OS (e.g.
+    // xcb to exercise native window-activation timing locally).
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
     // Disable input method plugins — ibus daemon is single-threaded and serializes
     // parallel test startup, causing 8 processes to take 4s instead of 0.06s.
-    qputenv("QT_IM_MODULES", "none");
+    if (!qEnvironmentVariableIsSet("QT_IM_MODULES")) {
+        qputenv("QT_IM_MODULES", "none");
+    }
 #endif
     // Redirect QSettings to a per-process temporary directory. Settings uses
     // IniFormat/UserScope, so without this every test that touches Settings::
@@ -198,6 +206,88 @@ bool pixmapHasInk(const QPixmap &pixmap)
         }
     }
     return false;
+}
+
+bool waitFor(const std::function<bool()> &pred, int timeoutMs)
+{
+    return QTest::qWaitFor(pred, timeoutMs);
+}
+
+AutoDismisser::AutoDismisser(std::function<bool(QWidget *)> handler)
+{
+    // Scan all top-level widgets rather than only activeModalWidget():
+    // window activation is asynchronous on native platforms (macOS), so a
+    // dialog can be visible and modal-blocking before it becomes "active".
+    // Each handler applies its own widget filter — QMessageBox::about(), for
+    // example, is shown NON-modal on native macOS, so a blanket modality
+    // check here would skip it.
+    m_timer.setInterval(10);
+    QObject::connect(&m_timer, &QTimer::timeout, &m_timer, [this, handler = std::move(handler)] {
+        const auto widgets = QApplication::topLevelWidgets();
+        for (QWidget *w : widgets) {
+            if (w->isVisible() && handler(w)) {
+                ++m_dismissCount;
+            }
+        }
+    });
+    m_timer.start();
+}
+
+AutoDismisser AutoDismisser::closeAnyModal()
+{
+    return AutoDismisser([](QWidget *w) {
+        // Message boxes included regardless of modality (macOS About boxes);
+        // anything else only when it's actually modal-blocking.
+        if (w->isModal() || qobject_cast<QMessageBox *>(w)) {
+            w->close();
+            return true;
+        }
+        return false;
+    });
+}
+
+AutoDismisser AutoDismisser::acceptMessageBox()
+{
+    return AutoDismisser([](QWidget *w) {
+        if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
+            msgBox->accept();
+            return true;
+        }
+        return false;
+    });
+}
+
+AutoDismisser AutoDismisser::clickMessageBoxButton(const QString &text)
+{
+    return AutoDismisser([text](QWidget *w) {
+        auto *msgBox = qobject_cast<QMessageBox *>(w);
+        if (!msgBox) {
+            return false;
+        }
+        const auto buttons = msgBox->buttons();
+        for (auto *btn : buttons) {
+            if (btn->text() == text) {
+                btn->click();
+                return true;
+            }
+        }
+        return false;
+    });
+}
+
+AutoDismisser AutoDismisser::answerMessageBox(QMessageBox::StandardButton answer)
+{
+    return AutoDismisser([answer](QWidget *w) {
+        auto *msgBox = qobject_cast<QMessageBox *>(w);
+        if (!msgBox) {
+            return false;
+        }
+        if (auto *btn = msgBox->button(answer)) {
+            btn->click();
+            return true;
+        }
+        return false;
+    });
 }
 
 QImage renderElementForComparison(QGraphicsScene *scene, GraphicElement *elm, QPoint &centerOut)

--- a/Tests/Common/TestUtils.h
+++ b/Tests/Common/TestUtils.h
@@ -3,13 +3,16 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include <QApplication>
 #include <QImage>
+#include <QMessageBox>
 #include <QPixmap>
 #include <QPoint>
 #include <QTest>
+#include <QTimer>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
 #  define QVERIFY_THROWS(exType, ...) QVERIFY_THROWS_EXCEPTION(exType, __VA_ARGS__)
@@ -199,6 +202,57 @@ void initElm(GraphicElement &elm);
  * @brief True if any pixel of @a pixmap has non-zero alpha (i.e. paint() drew something)
  */
 bool pixmapHasInk(const QPixmap &pixmap);
+
+/**
+ * @brief Waits (pumping the event loop) until @a pred returns true or @a timeoutMs elapses.
+ *
+ * Thin wrapper over QTest::qWaitFor. Preferred over the QTRY_* macros, whose
+ * Qt 6.9 chrono-default internals trip this project's -Werror=conversion.
+ */
+bool waitFor(const std::function<bool()> &pred, int timeoutMs = 5000);
+
+/**
+ * @brief RAII poller that dismisses modal dialogs/message boxes for as long as it lives.
+ *
+ * Replaces the one-shot `QTimer::singleShot(0, ...)` + `activeModalWidget()`
+ * dismissal pattern, which silently no-ops when the dialog isn't active yet —
+ * leaving the dialog's exec() loop blocked until Qt Test's function watchdog
+ * kills the binary (the TestDialogs hang on the Intel macOS runner). A
+ * repeating timer polls every 10 ms and scans QApplication::topLevelWidgets()
+ * for visible modal widgets, so it neither depends on window-activation timing
+ * (asynchronous on native macOS) nor on being scheduled after the dialog opens.
+ *
+ * dismissCount() lets tests assert the dialog actually appeared:
+ *
+ *     TestUtils::AutoDismisser dismisser = TestUtils::AutoDismisser::closeAnyModal();
+ *     triggerActionThatShowsDialog();
+ *     QTRY_VERIFY(dismisser.dismissCount() >= 1);   // when the dialog is mandatory
+ */
+class AutoDismisser
+{
+public:
+    /// @param handler Called for each visible modal widget found; return true if handled
+    ///                (counts toward dismissCount()).
+    explicit AutoDismisser(std::function<bool(QWidget *)> handler);
+
+    /// Number of widgets the handler reported as handled so far.
+    int dismissCount() const { return m_dismissCount; }
+
+    // --- Convenience factories ---
+
+    /// Dismisses any visible modal widget via close().
+    static AutoDismisser closeAnyModal();
+    /// Accepts any visible modal QMessageBox.
+    static AutoDismisser acceptMessageBox();
+    /// Clicks the button with the given text on any visible modal QMessageBox.
+    static AutoDismisser clickMessageBoxButton(const QString &text);
+    /// Clicks the given standard button on any visible modal QMessageBox.
+    static AutoDismisser answerMessageBox(QMessageBox::StandardButton answer);
+
+private:
+    QTimer m_timer;
+    int m_dismissCount = 0;
+};
 
 /**
  * @brief Renders @a elm's scene footprint into an image; @a centerOut receives the centre of

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -52,24 +52,6 @@
 using ICTestHelpers::readFile;
 using ICTestHelpers::embedIC;
 
-// Named (not plain "static") to avoid colliding with same-named helpers from other test
-// files under the project's Unity build, which merges multiple .cpp files per translation unit.
-namespace TestICInlineHelpers {
-
-/// Schedules auto-close of the next visible QMessageBox that appears.
-void autoCloseNextMessageBox()
-{
-    QTimer::singleShot(0, [] {
-        if (auto *w = QApplication::activeModalWidget()) {
-            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
-                msgBox->accept();
-            }
-        }
-    });
-}
-
-} // namespace TestICInlineHelpers
-
 // ---------------------------------------------------------------------------
 // Test Harness
 // ---------------------------------------------------------------------------
@@ -1223,10 +1205,15 @@ void TestICInline::testBlobNameCollisionDuringRename()
 
     const int countBefore = ws.scene()->undoStack()->count();
 
-    // Try to rename "type_alpha" to the already-taken "type_beta"
+    // Try to rename "type_alpha" to the already-taken "type_beta". The
+    // dismisser is scoped to this rename only: the follow-up rename below must
+    // NOT show a dialog, and a still-alive dismisser would silently eat one.
     lineEdit->setText("type_beta");
-    TestICInlineHelpers::autoCloseNextMessageBox();
-    emit lineEdit->editingFinished();
+    {
+        auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
+        emit lineEdit->editingFinished();
+        QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The name-collision rejection dialog must have appeared");
+    }
 
     // Rejected: no command pushed, both ICs and both blobs unchanged
     QCOMPARE(ws.scene()->undoStack()->count(), countBefore);

--- a/Tests/Integration/TestMainWindowGui.cpp
+++ b/Tests/Integration/TestMainWindowGui.cpp
@@ -155,33 +155,11 @@ static void wheelZoom(GraphicsView *view, int delta)
     QApplication::sendEvent(view->viewport(), &wheel);
 }
 
-/// Schedules auto-close of the next visible QMessageBox that appears.
-static void autoCloseNextMessageBox()
-{
-    QTimer::singleShot(0, [] {
-        if (auto *w = QApplication::activeModalWidget()) {
-            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
-                msgBox->accept();
-            }
-        }
-    });
-}
-
-static void clickNextMessageBoxButton(const QString &text)
-{
-    QTimer::singleShot(0, [text] {
-        if (auto *w = QApplication::activeModalWidget()) {
-            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
-                for (auto *btn : msgBox->buttons()) {
-                    if (btn->text() == text) {
-                        btn->click();
-                        return;
-                    }
-                }
-            }
-        }
-    });
-}
+// Modal dialogs are auto-dismissed via TestUtils::AutoDismisser — a polling
+// RAII helper each test owns for the duration of the dialog-raising action.
+// (The former one-shot singleShot(0)/activeModalWidget helpers silently
+// no-op'd when the dialog wasn't active yet, leaving exec() blocked until
+// Qt Test's function watchdog killed the binary.)
 
 } // namespace MainWindowGuiHelpers
 
@@ -410,10 +388,11 @@ void TestMainWindowGui::testSaveAsConflictBlocksSave()
     ScopedFileDialogStub guard;
     guard.stub.saveResult = {path1, "Panda files (*.panda)"};
 
-    autoCloseNextMessageBox(); // dismiss conflict dialog with OK
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox(); // dismiss conflict dialog with OK
     QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier | Qt::ShiftModifier);
 
     // Save was blocked: active tab is still path2.
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The Save As conflict dialog must have appeared");
     QCOMPARE(window->currentFile().absoluteFilePath(), QFileInfo(path2).absoluteFilePath());
 }
 
@@ -434,10 +413,11 @@ void TestMainWindowGui::testSaveAsConflictSwitchToTab()
     ScopedFileDialogStub guard;
     guard.stub.saveResult = {path1, "Panda files (*.panda)"};
 
-    clickNextMessageBoxButton("Switch to Tab");
+    auto dismisser = TestUtils::AutoDismisser::clickMessageBoxButton("Switch to Tab");
     QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier | Qt::ShiftModifier);
 
     // "Switch to Tab" was clicked: the tab for path1 is now active.
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The Save As conflict dialog must have appeared");
     QCOMPARE(window->currentFile().absoluteFilePath(), QFileInfo(path1).absoluteFilePath());
 }
 
@@ -1110,22 +1090,21 @@ void TestMainWindowGui::testExitViaKeyboard()
     window->setAttribute(Qt::WA_DeleteOnClose, false);
     QVERIFY(window->isVisible());
 
-    // closeEvent shows "Are you sure?" even with no unsaved changes.
-    // Accept any QMessageBox that appears during the close sequence.
-    auto dismissDialogs = [] {
-        if (auto *w = QApplication::activeModalWidget()) {
-            if (auto *msgBox = qobject_cast<QMessageBox *>(w)) {
-                if (auto *btn = msgBox->button(QMessageBox::Yes)) { btn->click(); return; }
-                if (auto *btn = msgBox->button(QMessageBox::No)) { btn->click(); return; }
-                if (auto *btn = msgBox->button(QMessageBox::NoToAll)) { btn->click(); return; }
-                msgBox->accept();
-            }
+    // closeEvent shows "Are you sure?" even with no unsaved changes; the close
+    // sequence can chain several confirmation boxes. The polling dismisser
+    // answers each one for as long as it's alive (defensive — how many appear
+    // depends on the close path taken).
+    TestUtils::AutoDismisser dismisser([](QWidget *w) {
+        auto *msgBox = qobject_cast<QMessageBox *>(w);
+        if (!msgBox) {
+            return false;
         }
-    };
-    // Schedule multiple dismiss attempts to handle chained dialogs
-    QTimer::singleShot(0, dismissDialogs);
-    QTimer::singleShot(100, dismissDialogs);
-    QTimer::singleShot(200, dismissDialogs);
+        if (auto *btn = msgBox->button(QMessageBox::Yes)) { btn->click(); return true; }
+        if (auto *btn = msgBox->button(QMessageBox::No)) { btn->click(); return true; }
+        if (auto *btn = msgBox->button(QMessageBox::NoToAll)) { btn->click(); return true; }
+        msgBox->accept();
+        return true;
+    });
 
     QTest::keyClick(window.get(), Qt::Key_Q, Qt::ControlModifier);
 
@@ -1222,21 +1201,23 @@ void TestMainWindowGui::testLanguageChange()
 void TestMainWindowGui::testAboutDialog()
 {
     std::unique_ptr<MainWindow> window(createMW());
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
 
     auto *action = window->findChild<QAction *>("actionAbout");
     QVERIFY(action);
     action->trigger();
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The About dialog must have appeared");
 }
 
 void TestMainWindowGui::testAboutQtDialog()
 {
     std::unique_ptr<MainWindow> window(createMW());
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
 
     auto *action = window->findChild<QAction *>("actionAboutQt");
     QVERIFY(action);
     action->trigger();
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The About Qt dialog must have appeared");
 }
 
 void TestMainWindowGui::testShortcutsDialog()
@@ -1258,10 +1239,11 @@ void TestMainWindowGui::testShortcutsDialog()
     QVERIFY(!html.contains("beWaveDolphin"));
 
     // Triggering the action still opens (and closes) the dialog without crashing.
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     auto *action = window->findChild<QAction *>("actionShortcutsAndTips");
     QVERIFY2(action, "actionShortcutsAndTips not found");
     action->trigger();
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The shortcuts dialog must have appeared");
 }
 
 void TestMainWindowGui::testPaletteDoubleClickAddsElement()
@@ -1703,8 +1685,9 @@ void TestMainWindowGui::testMakeSelfContainedWithFileICs()
     guard.stub.saveResult = {savePath, "Panda files (*.panda)"};
     QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier);
 
-    // Trigger makeSelfContained
-    autoCloseNextMessageBox();
+    // Trigger makeSelfContained (defensive dismisser: the assertions below are
+    // about the embedding outcome, not the success dialog)
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     auto *action = window->findChild<QAction *>("actionMakeSelfContained");
     QVERIFY(action);
     action->trigger();
@@ -1757,7 +1740,7 @@ void TestMainWindowGui::testMakeSelfContainedMixedScene()
     QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier);
 
     // makeSelfContained should only convert the file-backed IC
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     auto *action = window->findChild<QAction *>("actionMakeSelfContained");
     action->trigger();
 
@@ -1795,7 +1778,7 @@ void TestMainWindowGui::testMakeSelfContainedLabelsPreserved()
     guard.stub.saveResult = {savePath, "Panda files (*.panda)"};
     QTest::keyClick(window.get(), Qt::Key_S, Qt::ControlModifier);
 
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     auto *action = window->findChild<QAction *>("actionMakeSelfContained");
     action->trigger();
 
@@ -1837,13 +1820,14 @@ void TestMainWindowGui::testMakeSelfContainedPartialDoesNotClaimSuccess()
     // ...whose source file then disappears, so the embed loop hits a read error and breaks.
     QVERIFY(QFile::remove(icPath));
 
-    autoCloseNextMessageBox(); // the "Could not read IC file" warning
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox(); // the "Could not read IC file" warning
     auto *action = window->findChild<QAction *>("actionMakeSelfContained");
     QVERIFY(action);
     action->trigger();
     QCoreApplication::processEvents();
 
     // The IC stayed file-based, and no "self-contained" success claim was shown.
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The read-error warning must have appeared");
     QVERIFY2(!ic->isEmbedded(), "IC should not be embedded after a read error");
     auto *statusBar = window->findChild<QStatusBar *>();
     QVERIFY(statusBar);
@@ -1869,7 +1853,7 @@ void TestMainWindowGui::testMakeSelfContainedPromptsToSaveWhenUnsaved()
     // lets the operation proceed rather than aborting.
     ScopedFileDialogStub guard;
     guard.stub.saveResult = {m_fixtureDir + "/save_prompt_test.panda", "Panda files (*.panda)"};
-    clickNextMessageBoxButton(QStringLiteral("Save"));
+    auto dismisser = TestUtils::AutoDismisser::clickMessageBoxButton(QStringLiteral("Save"));
 
     auto *action = window->findChild<QAction *>("actionMakeSelfContained");
     QVERIFY(action);
@@ -1877,6 +1861,7 @@ void TestMainWindowGui::testMakeSelfContainedPromptsToSaveWhenUnsaved()
     QCoreApplication::processEvents();
 
     // The save happened and the operation went through (IC embedded).
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The Save-now prompt must have appeared");
     QVERIFY2(!scene->contextDir().isEmpty(), "the Save-now prompt should have saved the project");
     QVERIFY2(ic->isEmbedded(), "make-self-contained should proceed after saving");
 
@@ -3153,11 +3138,10 @@ void TestMainWindowGui::testAboutThisVersionDialog()
     auto *action = window->findChild<QAction *>("actionAboutThisVersion");
     QVERIFY2(action, "actionAboutThisVersion not found");
 
-    autoCloseNextMessageBox();
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     action->trigger();
 
-    // If we reached here without blocking, the dialog was auto-closed successfully
-    QVERIFY(true);
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The About This Version dialog must have appeared");
 }
 
 void TestMainWindowGui::testOpenExample()
@@ -3220,8 +3204,9 @@ void TestMainWindowGui::testMakeSelfContained()
     QVERIFY2(action, "actionMakeSelfContained not found");
 
     // On an empty unsaved project, makeSelfContained should show a warning
-    // or do nothing (no file-backed ICs). Auto-close any message box.
-    autoCloseNextMessageBox();
+    // or do nothing (no file-backed ICs) — the dismisser is defensive, no
+    // dismissCount assertion.
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
     action->trigger();
 
     // Should not crash; scene still functional
@@ -3678,35 +3663,21 @@ void TestMainWindowGui::testWaveformOnEmptySceneShowsWarningHQ()
     QVERIFY2(window->currentTab()->scene()->elements().isEmpty(),
              "Fresh tab must have an empty scene to reproduce WIREDPANDA-HQ");
 
-    // Poll-and-dismiss any QMessageBox that appears — guardedSlot's
-    // handleException shows a warning/critical dialog once it catches the
-    // PANDACEPTION. A singleShot(0) won't work — it fires before the queued
-    // action trigger runs, so it sees no dialog and we hang on QDialog::exec.
-    QTimer dismissTimer;
-    dismissTimer.setInterval(50);
-    QObject::connect(&dismissTimer, &QTimer::timeout, []() {
-        const auto widgets = QApplication::topLevelWidgets();
-        for (QWidget *w : widgets) {
-            if (auto *box = qobject_cast<QMessageBox *>(w)) {
-                if (box->isVisible()) {
-                    box->done(QMessageBox::Ok);
-                }
-            }
-        }
-    });
-    dismissTimer.start();
+    // Poll-and-dismiss the QMessageBox guardedSlot's handleException shows
+    // once it catches the PANDACEPTION. A one-shot singleShot(0) can't work
+    // here — it fires before the queued action trigger runs, so it would see
+    // no dialog and hang on QDialog::exec.
+    auto dismisser = TestUtils::AutoDismisser::acceptMessageBox();
 
     auto *action = window->findChild<QAction *>("actionWaveform");
     QVERIFY(action);
     QMetaObject::invokeMethod(action, "trigger", Qt::QueuedConnection);
-    QTest::qWait(500);
 
-    dismissTimer.stop();
-
-    // Reaching this line means: no abort — guardedSlot caught the
-    // PANDACEPTION and handleException showed (and this test dismissed) a
+    // The dialog appearing (and being dismissed) IS the pass condition: no
+    // abort — guardedSlot caught the PANDACEPTION and handleException showed a
     // dialog instead of letting it escape to std::terminate. On macOS, a
     // SIGABRT here is the WIREDPANDA-HQ signature.
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"handleException's dialog must have appeared");
     QVERIFY(window->isVisible());
 
     Application::interactiveMode = prevInteractive;

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -797,13 +797,12 @@ void TestBewavedDolphinGui::testAboutDialog()
     auto ws = createAndCircuit();
     std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
 
-    QTimer::singleShot(0, [] {
-        if (auto *w = QApplication::activeModalWidget()) w->close();
-    });
+    auto dismisser = TestUtils::AutoDismisser::closeAnyModal();
 
     auto *action = dolphin->findChild<QAction *>("actionAbout");
     QVERIFY(action);
     action->trigger();
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The About dialog must have appeared");
 }
 
 void TestBewavedDolphinGui::testAboutQtDialog()
@@ -811,13 +810,12 @@ void TestBewavedDolphinGui::testAboutQtDialog()
     auto ws = createAndCircuit();
     std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
 
-    QTimer::singleShot(0, [] {
-        if (auto *w = QApplication::activeModalWidget()) w->close();
-    });
+    auto dismisser = TestUtils::AutoDismisser::closeAnyModal();
 
     auto *action = dolphin->findChild<QAction *>("actionAboutQt");
     QVERIFY(action);
     action->trigger();
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The About Qt dialog must have appeared");
 }
 
 // ===========================================================================

--- a/Tests/Unit/Ui/TestDialogs.cpp
+++ b/Tests/Unit/Ui/TestDialogs.cpp
@@ -219,8 +219,8 @@ struct EditorFixture {
     }
 
     // Set the label field without triggering apply(), then emit textChanged
-    // to fire apply() exactly once.  Place dismissNextDialog() before this
-    // call when a rejection dialog is expected.
+    // to fire apply() exactly once.  Construct a TestUtils::AutoDismisser
+    // before this call when a rejection dialog is expected.
     void changeLabel(const QString &text)
     {
         { QSignalBlocker b(labelEdit); labelEdit->setText(text); }
@@ -234,15 +234,6 @@ struct EditorFixture {
         modeCombo->setCurrentIndex(static_cast<int>(mode));
     }
 
-    // Schedule auto-close of the next modal dialog so tests don't block.
-    static void dismissNextDialog()
-    {
-        QTimer::singleShot(0, [] {
-            if (auto *w = QApplication::activeModalWidget()) {
-                w->close();
-            }
-        });
-    }
 };
 
 void TestDialogs::testElementEditorRejectsDuplicateTxLabel()
@@ -254,9 +245,10 @@ void TestDialogs::testElementEditorRejectsDuplicateTxLabel()
     Q_UNUSED(nodeA)
 
     f.select(nodeB);
-    EditorFixture::dismissNextDialog();
+    auto dismisser = TestUtils::AutoDismisser::closeAnyModal();
     f.changeLabel("CLOCK"); // collision — dialog shown and dismissed
 
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The duplicate-label rejection dialog must have appeared");
     QCOMPARE(nodeB->label(), QStringLiteral("DATA")); // must be unchanged
 }
 
@@ -286,9 +278,10 @@ void TestDialogs::testElementEditorRejectsModeChangeToDuplicateTx()
     f.workspace.scene()->addItem(nodeB);
 
     f.select(nodeB);
-    EditorFixture::dismissNextDialog();
+    auto dismisser = TestUtils::AutoDismisser::closeAnyModal();
     f.changeMode(WirelessMode::Tx); // would collide — rejected
 
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The duplicate-Tx rejection dialog must have appeared");
     QCOMPARE(nodeB->wirelessMode(), WirelessMode::None);
 }
 

--- a/Tests/Unit/Ui/TestTrashButton.cpp
+++ b/Tests/Unit/Ui/TestTrashButton.cpp
@@ -48,17 +48,6 @@ QByteArray makeIcDragPayload()
     return itemData;
 }
 
-// Schedules a click on the next modal QMessageBox's Yes/No button once TrashButton::dropEvent()
-// enters its confirmation dialog's nested event loop.
-void answerNextConfirmationDialog(QMessageBox::StandardButton answer)
-{
-    QTimer::singleShot(0, [answer] {
-        if (auto *msgBox = qobject_cast<QMessageBox *>(QApplication::activeModalWidget())) {
-            msgBox->button(answer)->click();
-        }
-    });
-}
-
 } // namespace
 
 void TestTrashButton::testDragEnterEvent()
@@ -87,11 +76,12 @@ void TestTrashButton::testDropEvent()
     QMimeData mimeData;
     mimeData.setData(MimeType::DragDrop, makeIcDragPayload());
 
-    answerNextConfirmationDialog(QMessageBox::Yes);
+    auto dismisser = TestUtils::AutoDismisser::answerMessageBox(QMessageBox::Yes);
 
     QDropEvent dropEvent(QPointF(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
     button.dropEvent(&dropEvent);
 
+    QVERIFY2(TestUtils::waitFor([&] { return dismisser.dismissCount() >= 1; }),"The delete-confirmation dialog must have appeared");
     QCOMPARE(removeFileSpy.count(), 1);
     QCOMPARE(removeFileSpy.constFirst().at(0).toString(), QStringLiteral("some_ic"));
     QCOMPARE(removeEmbeddedSpy.count(), 0);


### PR DESCRIPTION
## Summary

The four gui-labeled test classes (`TestMainWindowGui`, `TestBewavedDolphinGui`, `TestDialogs`, `TestFileDialogProvider`) have been excluded from CI (`-LE gui`) since they were ported, because of intermittent failures. Investigation traced the flakiness to a concrete root cause and this PR removes it, then extends CI coverage accordingly.

### Root cause: the one-shot modal-dismissal race

Dialog-raising tests dismissed their modals with `QTimer::singleShot(0, ...)` + `QApplication::activeModalWidget()`. When the dialog isn't the active modal widget at the exact moment the timer fires — which happens under queued action triggers, and on native macOS where window activation is asynchronous — the lambda silently no-ops and the dialog's `exec()` loop blocks until Qt Test's 5-minute watchdog kills the binary. This is the documented hang that got TestDialogs skipped (85ce8a7bb), and the same race `TestMainWindowGui`'s waveform-crash test already worked around locally with a polling timer. Two of the racy sites (`TestTrashButton`, `TestICInline`) aren't even gui-labeled and run in every CI job today.

### Changes

- **`TestUtils::AutoDismisser`**: an RAII 10 ms poller over `QApplication::topLevelWidgets()` (activation-independent) that dismisses via per-factory handlers and **counts dismissals**, so tests assert the dialog actually appeared instead of silently racing past it. All 12+ racy sites migrated; the 4 direct-object dismissals (`singleShot(0, &dialog, &QDialog::reject)`) are not racy and stay.
- **`TestUtils::setupTestEnvironment`** no longer clobbers a pre-set `QT_QPA_PLATFORM`/`QT_IM_MODULES`, so workflows and developers can pick the platform per-OS.
- **`QTEST_FUNCTION_TIMEOUT=60000`** on the gui tests: a hang now costs 60 s of a 10-minute step budget, not 5 minutes.
- **CI**: gui suite added to sanitizers (non-blocking — makes teardown-order UAFs deterministic ASan findings instead of once-a-month mysteries), coverage (blocking), and trial steps on macOS (offscreen) and Windows (native), both `continue-on-error` while they build a track record.

### Verification

- Full ctest suite green locally, plus **20 consecutive offscreen runs** of all four gui classes with the new mandatory-dialog assertions — zero failures.
- First CI run of this branch: **every GUI step green on every platform, first attempt** — 5 Linux jobs (blocking), 2 macOS trials, 3 Windows trials (native platform, no offscreen needed), and both sanitizer (asan/ubsan) gui runs clean.

### Follow-up (separate PR, after a soak period)

Promote the three trial steps to blocking once a week of runs stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)