### PR TITLE
build(win): define NOMINMAX project-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,13 @@ add_compile_definitions(
     QT_MESSAGELOGCONTEXT
 )
 
+if(WIN32)
+    # windows.h defines min/max function-like macros that break std::min/std::max and
+    # std::numeric_limits<>::min/max in any TU it reaches (Main.cpp includes it directly;
+    # the Sentry SDK headers pull it into unity batches on release builds).
+    add_compile_definitions(NOMINMAX)
+endif()
+
 # MCP Server - disabled on tagged release CI builds, enabled on development branches.
 # Coverage builds are CI-only instrumentation artifacts that specifically exist to
 # measure MCP/Server coverage (see MCP/Client/run_tests.py in coverage.yml), so always


### PR DESCRIPTION
## Summary
Both Windows jobs of the 5.2.0-rc1 release Deploy failed at `LabeledSlider.cpp:115` with `error C4003: not enough arguments for function-like macro invocation 'min'`: in Sentry-enabled builds, `sentry.h` pulls `windows.h` — and its `min`/`max` macros — into the unity batches, breaking `std::numeric_limits<int>::min()`.

Push CI can't catch this class of failure (no Sentry SDK present), so instead of parenthesizing the one call, define `NOMINMAX` project-wide on Windows and remove the macros at the source.

The vulnerable line landed on July 13 (d62c7f1fb); this RC was the first Sentry-enabled Windows compile since.

## Test plan
- Linux/macOS unaffected (`WIN32`-guarded).
- Regular Windows CI jobs exercise the definition on this PR.
- The real gate is the release Deploy's `sentry-crashpad` build — verified by recreating the 5.2.0-rc1 pre-release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)