### PR TITLE
fix(build): guard SSL-error QDebug streaming for QT_NO_SSL builds

### DIFF
--- a/App/Core/UpdateChecker.cpp
+++ b/App/Core/UpdateChecker.cpp
@@ -69,7 +69,15 @@ UpdateChecker::UpdateChecker(QObject *parent)
     : QObject(parent)
 {
     connect(&m_network, &QNetworkAccessManager::sslErrors, this, [](QNetworkReply *reply, const QList<QSslError> &errors) {
+        // QSslError collapses to an empty dummy class (no errorString(), no QDebug streaming)
+        // when Qt is built with QT_NO_SSL -- the case for every Qt-for-WebAssembly build, since
+        // WASM has no native TLS backend and routes network access through the browser instead.
+#ifndef QT_NO_SSL
         qWarning() << "UpdateChecker: SSL errors, aborting reply:" << errors;
+#else
+        Q_UNUSED(errors);
+        qWarning() << "UpdateChecker: SSL errors, aborting reply";
+#endif
         reply->abort();
     });
 }

--- a/App/UI/UpdateController.cpp
+++ b/App/UI/UpdateController.cpp
@@ -105,7 +105,15 @@ void UpdateController::downloadUpdate(const QString &latestVersion, const QUrl &
 
     auto *network = new QNetworkAccessManager(this);
     connect(network, &QNetworkAccessManager::sslErrors, this, [](QNetworkReply *reply, const QList<QSslError> &errors) {
+        // QSslError collapses to an empty dummy class (no errorString(), no QDebug streaming)
+        // when Qt is built with QT_NO_SSL -- the case for every Qt-for-WebAssembly build, since
+        // WASM has no native TLS backend and routes network access through the browser instead.
+#ifndef QT_NO_SSL
         qWarning() << "MainWindow::downloadUpdate: SSL errors, aborting reply:" << errors;
+#else
+        Q_UNUSED(errors);
+        qWarning() << "MainWindow::downloadUpdate: SSL errors, aborting reply";
+#endif
         reply->abort();
     });
 


### PR DESCRIPTION
## Summary
The `wasm` branch fast-forward to 5.2.0 failed CI: `App/UI/UpdateController.cpp:108` and `App/Core/UpdateChecker.cpp:71` both stream `const QList<QSslError> &errors` directly into `qWarning()`. That requires `QDebug operator<<(QDebug, const QSslError&)`, which Qt's own header (`qsslerror.h`) only declares `#ifndef QT_NO_SSL` -- outside that guard, `QSslError` is literally `class QSslError {};`, an empty dummy kept around only so moc has a complete type. Every Qt-for-WebAssembly build sets `QT_NO_SSL` (no native TLS backend; WASM routes network access through the browser's fetch/XHR instead), so this compiled fine on every desktop CI job (all of which have real SSL support) and only breaks on `wasm.yml`'s Emscripten/Qt-WASM build -- which only runs when something is pushed to the `wasm` branch, i.e. at release time, so nothing caught it until now.

Guards both call sites with `#ifndef QT_NO_SSL` (matching Qt's own convention), keeping the full diagnostic on every platform that has it and falling back to a plain message on WASM. `reply->abort()` still always runs.

## Test plan
- `ctest --preset debug`: 192/192 passing (desktop behavior unchanged -- SSL is present, so the `#ifndef QT_NO_SSL` branch is what actually compiles and runs there).
- Real gate is `wasm.yml`'s Emscripten build, which only runs on push to `wasm` -- verified by re-fast-forwarding `wasm` to master after this merges and watching that run go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)