### PR TITLE
Toolbar/minimap theming fixes + updater rescue for pre-5.1.3 clients

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,12 +285,31 @@ jobs:
         APPIMAGE_EXTRACT_AND_RUN=1 VERSION=$VERSION \
           ./appimagetool appimage
 
-        mv wiRedPanda-*-${ARCH_TRIPLE}.AppImage wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage
+        # x86_64's arch token sits right before the extension instead of right after "Linux-"
+        # like arm64's does: GitHub's Releases API returns assets alphabetically sorted, and
+        # pre-5.1.3 updater builds picked the first ".AppImage" match with no arch check at all
+        # -- "arm64" < "x86_64" alphabetically, so those old clients always grabbed the arm64
+        # build regardless of the user's actual CPU. This ordering flips who wins that blind
+        # pick to x86_64 (the far larger population); isMatchingReleaseAsset() still finds
+        # either file correctly for already-fixed clients since it's a substring match,
+        # position-independent.
+        if [ "${{ matrix.arch }}" = "x86_64" ]; then
+          APPIMAGE_NAME="wiRedPanda-$VERSION-Linux-Qt${{ matrix.qt }}-x86_64.AppImage"
+        else
+          APPIMAGE_NAME="wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage"
+        fi
+        mv wiRedPanda-*-${ARCH_TRIPLE}.AppImage "$APPIMAGE_NAME"
 
     - name: Validate Ubuntu Release Artifacts
       if: runner.os == 'Linux'
       run: |
-        APPIMAGE_FILE="wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage"
+        # Same asymmetric x86_64-vs-arm64 naming as the build step above (see the comment
+        # there) -- must be reconstructed identically since it's not passed between steps.
+        if [ "${{ matrix.arch }}" = "x86_64" ]; then
+          APPIMAGE_FILE="wiRedPanda-$VERSION-Linux-Qt${{ matrix.qt }}-x86_64.AppImage"
+        else
+          APPIMAGE_FILE="wiRedPanda-$VERSION-Linux-${{ matrix.arch }}-Qt${{ matrix.qt }}.AppImage"
+        fi
 
         if [ ! -f "$APPIMAGE_FILE" ]; then
           echo "Error: AppImage not found"
@@ -492,13 +511,29 @@ jobs:
 
         # Create the ZIP from the clean directory
         cd ..
-        Compress-Archive -Path wiredpanda-$env:VERSION -DestinationPath wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip
+        # x86_64's arch token sits right before the extension instead of right after
+        # "Windows-" like arm64's does -- see the matching Linux comment above for why
+        # (GitHub's alphabetically-sorted Releases API assets + pre-5.1.3 updater builds
+        # blindly grabbing the first match). Reconstructed identically in the validate
+        # step below since it's not passed between steps.
+        if ("${{ matrix.arch }}" -eq "x86_64") {
+          $zipName = "wiRedPanda-$env:VERSION-Windows-Qt${{ matrix.qt }}-Portable-x86_64.zip"
+        } else {
+          $zipName = "wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip"
+        }
+        Compress-Archive -Path wiredpanda-$env:VERSION -DestinationPath $zipName
 
     - name: Validate Windows Release Artifacts
       if: runner.os == 'Windows'
       run: |
+        if ("${{ matrix.arch }}" -eq "x86_64") {
+          $zipName = "wiRedPanda-$env:VERSION-Windows-Qt${{ matrix.qt }}-Portable-x86_64.zip"
+        } else {
+          $zipName = "wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip"
+        }
+
         # Verify ZIP file exists
-        if (!(Test-Path "build-sentry-crashpad/wiRedPanda-$env:VERSION-Windows-${{ matrix.arch }}-Qt${{ matrix.qt }}-Portable.zip")) {
+        if (!(Test-Path "build-sentry-crashpad/$zipName")) {
           Write-Error "Error: Windows ZIP file not found"
           exit 1
         }

--- a/App/Core/ThemeManager.cpp
+++ b/App/Core/ThemeManager.cpp
@@ -4,6 +4,7 @@
 #include "App/Core/ThemeManager.h"
 
 #include <QCoreApplication>
+#include <QFont>
 #include <QStyleHints>
 #include <QThread>
 
@@ -263,8 +264,18 @@ void ThemeAttributes::setTheme(const Theme theme)
     // Force a consistent tooltip style on both themes; without this, Windows/Linux
     // style sheets would show platform-default tooltips that are illegible on dark
     // backgrounds.  The #2a82da background matches QPalette::Highlight above.
+    //
+    // Toolbar button labels are shrunk here too, relative to the app's default font size.
+    // This has to live in the same setStyleSheet() call rather than a one-off setFont() on
+    // the toolbar/buttons: applying (or re-applying) an app-wide style sheet re-polishes
+    // every widget, which silently resets any font set directly via QWidget::setFont() --
+    // and setTheme() re-runs this on every theme switch, including the async system
+    // colour-scheme change QStyleHints::colorSchemeChanged delivers a moment after startup.
     if (Application::instance()) {
-        Application::instance()->setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }");
+        const qreal toolBarFontPt = Application::instance()->font().pointSizeF() * 0.75;
+        Application::instance()->setStyleSheet(
+            QStringLiteral("QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }"
+                           "QToolBar QToolButton { font-size: %1pt; }").arg(toolBarFontPt));
     }
 #endif
 

--- a/App/UI/MinimapWidget.cpp
+++ b/App/UI/MinimapWidget.cpp
@@ -11,6 +11,7 @@
 #include <QScrollBar>
 #include <QTimer>
 
+#include "App/Core/ThemeManager.h"
 #include "App/Scene/GraphicsView.h"
 #include "App/Scene/Scene.h"
 
@@ -35,6 +36,12 @@ MinimapWidget::MinimapWidget(Scene *scene, GraphicsView *view, QWidget *parent)
     if (m_scene) {
         connect(m_scene, &Scene::circuitHasChanged, this, &MinimapWidget::invalidateCache);
     }
+
+    // The thumbnail is a cached render of the scene (see paintEvent()/m_cache), so a theme
+    // switch -- which recolors the scene's background/dots/elements in place, the same way
+    // Scene::updateTheme() does for the main view -- leaves the cached pixmap showing the old
+    // theme's colors until the next real circuit edit. Invalidate it here too.
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged, this, &MinimapWidget::invalidateCache);
 
     if (m_view) {
         connect(m_view, &GraphicsView::zoomChanged, this, &MinimapWidget::updateOverlay);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # explicit cmake_policy(SET) needed.
 cmake_minimum_required(VERSION 3.27...3.31)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.16) # for nlohmann/json
-project(wiredpanda VERSION 5.2.0 LANGUAGES CXX)
+project(wiredpanda VERSION 5.2.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Tests/Unit/Ui/TestMinimapWidget.cpp
+++ b/Tests/Unit/Ui/TestMinimapWidget.cpp
@@ -5,6 +5,7 @@
 
 #include <QGraphicsRectItem>
 
+#include "App/Core/ThemeManager.h"
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
 #include "App/UI/MinimapWidget.h"
@@ -327,4 +328,22 @@ void TestMinimapWidget::testHoverStateOverInteriorClearsHighlightAndCursor()
     QCOMPARE(minimap.m_hoverResizeMode, MinimapWidget::ResizeMode::None);
     QVERIFY(!minimap.m_hoverMoveHandle);
     QCOMPARE(minimap.cursor().shape(), Qt::ArrowCursor);
+}
+
+void TestMinimapWidget::testThemeChangeInvalidatesCache()
+{
+    WorkSpace workspace;
+    MinimapWidget minimap(workspace.scene(), workspace.view());
+
+    // Simulate a cache that's already up to date, then a theme switch delivered the way
+    // ThemeManager actually delivers it -- not by calling invalidateCache() directly, which
+    // would trivially pass without proving the theme-change connection itself exists.
+    minimap.m_cacheDirty = false;
+    QVERIFY(!minimap.m_throttle.isActive());
+
+    ThemeManager::instance().themeChanged();
+
+    // invalidateCache() (like circuitHasChanged()) goes through the throttle timer rather
+    // than flipping m_cacheDirty immediately; the timer being started confirms the slot ran.
+    QVERIFY(minimap.m_throttle.isActive());
 }

--- a/Tests/Unit/Ui/TestMinimapWidget.h
+++ b/Tests/Unit/Ui/TestMinimapWidget.h
@@ -36,4 +36,7 @@ private slots:
     void testHoverStateOverCornerSetsResizeCursorAndHighlight();
     void testHoverStateOverMoveStripSetsOpenHandCursorAndHighlight();
     void testHoverStateOverInteriorClearsHighlightAndCursor();
+
+    // Theme
+    void testThemeChangeInvalidatesCache();
 };


### PR DESCRIPTION
## Summary
- Shrink the toolbar's under-icon label text (75% of the app's default font size), applied via ThemeManager's app-wide stylesheet since a plain `setFont()` gets wiped out by every theme repolish.
- Refresh the minimap's cached scene thumbnail on theme switches — it was only invalidated on circuit edits, so it kept showing stale colors after a light/dark toggle.
- Reorder Linux/Windows release asset naming so the x86_64 build sorts first alphabetically in GitHub's Releases API response. Rescues x86_64 users still on 5.1.0-5.1.2, whose updater picks the first `.AppImage`/`.zip` match with no arch check and was always grabbing arm64. Already-fixed (5.1.3+) clients are unaffected since `isMatchingReleaseAsset()` matches by substring, not position.
- Bump version to 5.2.1.

## Test plan
- [x] `TestThemeManager` (21/21 pass)
- [x] `TestMinimapWidget` (23/23 pass, incl. new `testThemeChangeInvalidatesCache` regression test — confirmed it fails without the fix)
- [x] `TestMainWindowGui` (138/138 pass, incl. `testThemeSwitching`)
- [x] `TestUpdateChecker` (6/6 pass, matcher logic untouched)
- [x] Manually simulated both the pre-fix and post-fix updater matching logic against the new asset filenames to confirm old clients land on x86_64 and already-fixed clients still match either arch correctly
- [x] Empirically confirmed GitHub's Releases API sorts assets by filename (not upload time) using real `created_at` timestamps across 3 published releases
- [x] Full local rebuild after version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
