### PR TITLE
fix(tests): make QDragEnterEvent construction work across Qt versions

### DIFF
--- a/Tests/Common/TestUtils.h
+++ b/Tests/Common/TestUtils.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include <QApplication>
+#include <QDragEnterEvent>
 #include <QImage>
 #include <QMessageBox>
 #include <QPixmap>
@@ -18,6 +19,27 @@
 #  define QVERIFY_THROWS(exType, ...) QVERIFY_THROWS_EXCEPTION(exType, __VA_ARGS__)
 #else
 #  define QVERIFY_THROWS(exType, ...) QVERIFY_EXCEPTION_THROWN(__VA_ARGS__, exType)
+#endif
+
+/// QDragEnterEvent's QPoint-taking constructor is deprecated in favour of a new QPointF-taking
+/// overload -- which doesn't exist on older Qt (confirmed against the actual installed headers:
+/// absent in 6.9.3, present -- and the QPoint overload deprecated -- in 6.12.0), so neither type
+/// works unmodified across the versions this project supports. The deprecation attribute names
+/// "6.16" as its target release, but that label doesn't track when the QPointF overload actually
+/// shipped in this toolchain, so the version gate below is pinned to the verified boundary
+/// instead of that label.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 12, 0)
+inline QDragEnterEvent makeDragEnterEvent(QPoint pos, Qt::DropActions actions, const QMimeData *data,
+                                           Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers)
+{
+    return QDragEnterEvent(QPointF(pos), actions, data, buttons, modifiers);
+}
+#else
+inline QDragEnterEvent makeDragEnterEvent(QPoint pos, Qt::DropActions actions, const QMimeData *data,
+                                           Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers)
+{
+    return QDragEnterEvent(pos, actions, data, buttons, modifiers);
+}
 #endif
 
 #include "App/Core/Common.h"

--- a/Tests/Integration/TestICInline.cpp
+++ b/Tests/Integration/TestICInline.cpp
@@ -3686,7 +3686,7 @@ void TestICInline::testICDropZoneMimeAcceptance()
     auto fileBasedMime = std::make_unique<QMimeData>();
     fileBasedMime->setData("application/x-wiredpanda-dragdrop", fileBasedData);
 
-    QDragEnterEvent enterFileBased(QPoint(10, 10), Qt::CopyAction, fileBasedMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterFileBased = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, fileBasedMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&embeddedZone, &enterFileBased);
     QVERIFY2(enterFileBased.isAccepted(), "Embedded zone should accept file-based IC drops");
 
@@ -3699,17 +3699,17 @@ void TestICInline::testICDropZoneMimeAcceptance()
     auto embeddedMime = std::make_unique<QMimeData>();
     embeddedMime->setData("application/x-wiredpanda-dragdrop", embeddedData);
 
-    QDragEnterEvent enterEmbedded(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEmbedded = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&embeddedZone, &enterEmbedded);
     QVERIFY2(!enterEmbedded.isAccepted(), "Embedded zone should reject embedded IC drops");
 
     ICDropZone fileZone(ICDropZone::Section::FileBased);
 
-    QDragEnterEvent enterEmbOnFile(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEmbOnFile = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&fileZone, &enterEmbOnFile);
     QVERIFY2(enterEmbOnFile.isAccepted(), "File-based zone should accept embedded IC drops");
 
-    QDragEnterEvent enterFileOnFile(QPoint(10, 10), Qt::CopyAction, fileBasedMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterFileOnFile = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, fileBasedMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&fileZone, &enterFileOnFile);
     QVERIFY2(!enterFileOnFile.isAccepted(), "File-based zone should reject file-based IC drops");
 }
@@ -3730,7 +3730,7 @@ void TestICInline::testICDropZoneWiredInUI()
     embeddedMime->setData("application/x-wiredpanda-dragdrop", embeddedData);
 
     QSignalSpy extractSpy(&fileZone, &ICDropZone::extractByBlobNameRequested);
-    QDragEnterEvent enterEvent(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEvent = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, embeddedMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&fileZone, &enterEvent);
     QVERIFY(enterEvent.isAccepted());
 
@@ -3750,7 +3750,7 @@ void TestICInline::testICDropZoneWiredInUI()
     fileMime->setData("application/x-wiredpanda-dragdrop", fileData);
 
     QSignalSpy embedSpy(&embeddedZone, &ICDropZone::embedByFileRequested);
-    QDragEnterEvent enterEvent2(QPoint(10, 10), Qt::CopyAction, fileMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEvent2 = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, fileMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&embeddedZone, &enterEvent2);
     QVERIFY(enterEvent2.isAccepted());
 
@@ -3776,7 +3776,7 @@ void TestICInline::testICDropZoneDropEventSignals()
         auto mime = std::make_unique<QMimeData>();
         mime->setData("application/x-wiredpanda-dragdrop", itemData);
 
-        QDragEnterEvent dragEnter(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
+        QDragEnterEvent dragEnter = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
         QCoreApplication::sendEvent(&embeddedZone, &dragEnter);
         QVERIFY(dragEnter.isAccepted());
 
@@ -3801,7 +3801,7 @@ void TestICInline::testICDropZoneDropEventSignals()
         auto mime = std::make_unique<QMimeData>();
         mime->setData("application/x-wiredpanda-dragdrop", itemData);
 
-        QDragEnterEvent dragEnter(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
+        QDragEnterEvent dragEnter = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
         QCoreApplication::sendEvent(&fileZone, &dragEnter);
         QVERIFY(dragEnter.isAccepted());
 
@@ -3826,7 +3826,7 @@ void TestICInline::testICDropZoneDropEventSignals()
         auto mime = std::make_unique<QMimeData>();
         mime->setData("application/x-wiredpanda-dragdrop", itemData);
 
-        QDragEnterEvent dragEnter(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
+        QDragEnterEvent dragEnter = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier);
         QCoreApplication::sendEvent(&embeddedZone, &dragEnter);
         QVERIFY(!dragEnter.isAccepted());
 
@@ -3847,21 +3847,21 @@ void TestICInline::testTrashButtonDragAcceptance()
     auto currentMime = std::make_unique<QMimeData>();
     currentMime->setData("application/x-wiredpanda-dragdrop", itemData);
 
-    QDragEnterEvent enterCurrent(QPoint(10, 10), Qt::CopyAction, currentMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterCurrent = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, currentMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&button, &enterCurrent);
     QVERIFY2(enterCurrent.isAccepted(), "TrashButton should accept current MIME type");
 
     auto legacyMime = std::make_unique<QMimeData>();
     legacyMime->setData("wpanda/x-dnditemdata", itemData);
 
-    QDragEnterEvent enterLegacy(QPoint(10, 10), Qt::CopyAction, legacyMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterLegacy = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, legacyMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&button, &enterLegacy);
     QVERIFY2(enterLegacy.isAccepted(), "TrashButton should accept legacy MIME type");
 
     auto textMime = std::make_unique<QMimeData>();
     textMime->setText("hello");
 
-    QDragEnterEvent enterText(QPoint(10, 10), Qt::CopyAction, textMime.get(), Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterText = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, textMime.get(), Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(&button, &enterText);
     QVERIFY2(!enterText.isAccepted(), "TrashButton should reject unrelated MIME types");
 }

--- a/Tests/Integration/TestMainWindowGui.cpp
+++ b/Tests/Integration/TestMainWindowGui.cpp
@@ -3310,7 +3310,7 @@ static void simulateDrop(QWidget *dropZone, const QByteArray &mimePayload)
     QMimeData mime;
     mime.setData("application/x-wiredpanda-dragdrop", mimePayload);
 
-    QDragEnterEvent enterEv(QPoint(10, 10), Qt::CopyAction, &mime, Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEv = makeDragEnterEvent(QPoint(10, 10), Qt::CopyAction, &mime, Qt::LeftButton, Qt::NoModifier);
     QCoreApplication::sendEvent(dropZone, &enterEv);
 
     QDropEvent dropEv(QPointF(10, 10), Qt::CopyAction, &mime, Qt::LeftButton, Qt::NoModifier);

--- a/Tests/Unit/Ui/TestICDropZone.cpp
+++ b/Tests/Unit/Ui/TestICDropZone.cpp
@@ -147,7 +147,7 @@ void TestICDropZone::testHintShownOnCompatibleDragEnter()
     QVERIFY2(hint->text().contains(QStringLiteral("embed")), qPrintable(hint->text()));
 
     // Dragging a compatible IC over the zone reveals the hint...
-    QDragEnterEvent enterEvent(QPoint(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent enterEvent = makeDragEnterEvent(QPoint(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
     QApplication::sendEvent(&dropZone, &enterEvent);
     QVERIFY(!hint->isHidden());
 

--- a/Tests/Unit/Ui/TestTrashButton.cpp
+++ b/Tests/Unit/Ui/TestTrashButton.cpp
@@ -59,7 +59,7 @@ void TestTrashButton::testDragEnterEvent()
     QMimeData mimeData;
     mimeData.setData(MimeType::DragDrop, makeIcDragPayload());
 
-    QDragEnterEvent event(QPoint(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    QDragEnterEvent event = makeDragEnterEvent(QPoint(5, 5), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
     button.dragEnterEvent(&event);
 
     QVERIFY(event.isAccepted());


### PR DESCRIPTION
## Summary
- `QDragEnterEvent`'s `QPoint`-taking constructor is deprecated on newer Qt (confirmed against the installed 6.12.0 headers) in favour of a `QPointF`-taking overload that doesn't exist on older Qt (confirmed absent in 6.9.3, this project's CI-pinned version) — so neither type works unmodified across both.
- Adds `makeDragEnterEvent()` to `Tests/Common/TestUtils.h`, version-gated the same way the existing `QVERIFY_THROWS` shim is, and switches all 15 direct `QDragEnterEvent` construction sites (`TestICDropZone.cpp`, `TestTrashButton.cpp`, `TestMainWindowGui.cpp`, `TestICInline.cpp`) to use it instead of the raw constructor.

## Test plan
- [x] `test_wiredpanda` builds clean against Qt 6.12.0 (no more `-Werror=deprecated-declarations`)
- [x] `test_wiredpanda` builds clean against Qt 6.9.3 (CI's pinned version)
- [x] `TestICDropZone`, `TestTrashButton`, `TestICInline`, `TestMainWindowGui` all pass under Qt 6.12.0
- [x] Full `ctest` suite: 192/192 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)