### PR TITLE
fix(updater): poll the site's static release data instead of the GitHub API

### DIFF
--- a/App/Core/UpdateChecker.cpp
+++ b/App/Core/UpdateChecker.cpp
@@ -5,7 +5,6 @@
 
 #include <QDate>
 #include <QDebug>
-#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
@@ -17,10 +16,10 @@
 #include "App/Core/Settings.h"
 #include "App/Versions.h"
 
-static constexpr auto k_apiUrl = "https://api.github.com/repos/gibis-unifesp/wiredpanda/releases/latest";
+static constexpr auto k_releaseDataUrl = "https://gibis-unifesp.github.io/wiRedPanda/latest-release.json";
 
 /// Compile-time name of the platform this binary was built for, matching the
-/// platform token embedded in release asset filenames by deploy.yml.
+/// platform token releaseAssetKey() expects.
 static QString currentPlatform()
 {
 #if defined(Q_OS_WIN)
@@ -34,19 +33,31 @@ static QString currentPlatform()
 #endif
 }
 
-bool isMatchingReleaseAsset(const QString &name, const QString &platform, const QString &arch)
+QString releaseAssetKey(const QString &platform, const QString &arch)
 {
     if (platform == "Linux") {
-        return name.endsWith(".AppImage") && name.contains(arch, Qt::CaseInsensitive);
+        if (arch == "x86_64") {
+            return QStringLiteral("linuxX64");
+        }
+        if (arch == "arm64") {
+            return QStringLiteral("linuxArm64");
+        }
+        return {};
     }
     if (platform == "Windows") {
-        return name.contains("Windows") && name.endsWith(".zip") && name.contains(arch, Qt::CaseInsensitive);
+        if (arch == "x86_64") {
+            return QStringLiteral("windowsX64");
+        }
+        if (arch == "arm64") {
+            return QStringLiteral("windowsArm64");
+        }
+        return {};
     }
     if (platform == "macOS") {
-        // A single universal DMG serves both architectures, so it carries no arch token.
-        return name.contains("macOS") && name.endsWith(".dmg");
+        // A single universal DMG serves both architectures, so it carries no arch-specific key.
+        return QStringLiteral("macosUniversal");
     }
-    return false;
+    return {};
 }
 
 bool shouldOfferUpdate(const QString &tagName, const QVersionNumber &currentVersion, const QString &skippedVersion)
@@ -93,14 +104,14 @@ void UpdateChecker::checkForUpdates()
         return;
     }
 
-    QNetworkRequest request = QNetworkRequest{QUrl(k_apiUrl)};
+    QNetworkRequest request = QNetworkRequest{QUrl(k_releaseDataUrl)};
     request.setHeader(QNetworkRequest::UserAgentHeader, "wiRedPanda/" APP_VERSION);
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                          QNetworkRequest::NoLessSafeRedirectPolicy);
     request.setTransferTimeout(10000);
 
     QNetworkReply *reply = m_network.get(request);
-    // The GitHub API response is realistically tens of KB; cap well above that
+    // The release data response is realistically under 1KB; cap well above that
     // as defense-in-depth against a hostile/corrupted endpoint buffering unbounded
     // bytes into memory before onReplyFinished ever gets a chance to react.
     reply->setReadBufferSize(1024 * 1024 + 1);
@@ -129,30 +140,22 @@ void UpdateChecker::onReplyFinished(QNetworkReply *reply)
 
     // A successful, parseable reply IS the daily check — record it here, not
     // when a dialog is shown: with no newer release (the common case) the
-    // date was never written and the API was hit on every launch. Network
+    // date was never written and the endpoint was hit on every launch. Network
     // failures above intentionally don't record, so the check retries.
     Settings::setUpdateCheckLastDate(QDate::currentDate().toString(Qt::ISODate));
 
-    const QString tagName = doc.object().value("tag_name").toString();
-    if (!shouldOfferUpdate(tagName, AppVersion::current, Settings::updateCheckSkippedVersion())) {
+    const QString version = doc.object().value("version").toString();
+    if (!shouldOfferUpdate(version, AppVersion::current, Settings::updateCheckSkippedVersion())) {
         return;
     }
-    const QVersionNumber latest = QVersionNumber::fromString(tagName).normalized();
+    const QVersionNumber latest = QVersionNumber::fromString(version).normalized();
 
-    QUrl downloadUrl;
     const QString platform = currentPlatform();
     const QString arch = QSysInfo::buildCpuArchitecture(); // "x86_64" / "arm64"
-    const QJsonArray assets = doc.object().value("assets").toArray();
-    for (const QJsonValue &assetVal : assets) {
-        const QJsonObject asset = assetVal.toObject();
-        const QString name = asset.value("name").toString();
-        if (isMatchingReleaseAsset(name, platform, arch)) {
-            downloadUrl = QUrl(asset.value("browser_download_url").toString());
-            break;
-        }
-    }
+    const QString key = releaseAssetKey(platform, arch);
+    QUrl downloadUrl = key.isEmpty() ? QUrl{} : QUrl(doc.object().value(key).toString());
 
-    const QUrl releaseUrl = QUrl(doc.object().value("html_url").toString());
+    const QUrl releaseUrl = QUrl(QStringLiteral("https://github.com/GIBIS-UNIFESP/wiRedPanda/releases/tag/%1").arg(latest.toString()));
     if (!isSafeGitHubUrl(releaseUrl)) {
         qWarning() << "UpdateChecker: release URL has unexpected scheme/host, ignoring update notification:" << releaseUrl;
         return;

--- a/App/Core/UpdateChecker.h
+++ b/App/Core/UpdateChecker.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /** \file
- * \brief Checks the GitHub Releases API for newer versions of wiRedPanda.
+ * \brief Checks the wiRedPanda site's published release data for newer versions.
  */
 
 #pragma once
@@ -15,11 +15,15 @@
 
 /**
  * \class UpdateChecker
- * \brief Asynchronously queries the GitHub Releases API and emits a signal when a newer version is available.
+ * \brief Asynchronously queries the site's release data and emits a signal when a newer version is available.
  *
  * \details Call checkForUpdates() once after the main window is shown. The check is skipped if one
  * was already performed today. If the fetched release version is newer than the running application
  * and has not been suppressed by the user, \c updateAvailable is emitted.
+ *
+ * \note Polls the wiRedPanda site's published \c latest-release.json rather than the GitHub Releases
+ * API directly, so the per-user daily check never counts against GitHub's per-IP API rate limit; that
+ * file is itself kept fresh by a CI job that queries the API once per release, not once per user.
  */
 class UpdateChecker : public QObject
 {
@@ -51,14 +55,14 @@ private:
     QNetworkAccessManager m_network;
 };
 
-/// \brief True when a GitHub release asset filename is the binary for the given
+/// \brief The key in latest-release.json holding the download URL for the given
 /// platform ("Windows"/"macOS"/"Linux") and CPU arch token (a QSysInfo arch name,
-/// e.g. "x86_64", "arm64").
+/// e.g. "x86_64", "arm64"), or an empty string if that combination isn't published.
 ///
-/// \details Exposed for testing. Linux (.AppImage) and Windows (.zip) releases
-/// ship a per-architecture asset, so the arch token must also match; macOS ships
-/// a single universal DMG and is matched on platform alone.
-bool isMatchingReleaseAsset(const QString &name, const QString &platform, const QString &arch);
+/// \details Exposed for testing. Linux and Windows ship a per-architecture asset, so
+/// the arch token selects between two keys; macOS ships a single universal DMG and is
+/// keyed on platform alone.
+QString releaseAssetKey(const QString &platform, const QString &arch);
 
 /// \brief True when the release tagged \p tagName should be offered to a user
 /// running \p currentVersion who may have suppressed \p skippedVersion.
@@ -71,9 +75,10 @@ bool shouldOfferUpdate(const QString &tagName, const QVersionNumber &currentVers
 /// \brief True when \a url is safe to download from or hand to the OS's URL handler.
 ///
 /// \details Exposed for testing. Requires scheme https and host github.com — the only shape
-/// GitHub's release JSON ever populates \c browser_download_url / \c html_url with (the CDN
-/// redirect for the actual asset happens only after fetching this URL, so the field itself
-/// never contains the CDN's host). Guards against a compromised/future-relaxed API response
-/// smuggling a \c file:// path (silently copies a local file into the Downloads folder) or an
-/// unexpected scheme/UNC-style URL into QDesktopServices::openUrl.
+/// the site's latest-release.json ever populates a download URL with (it's copied verbatim
+/// from GitHub's \c browser_download_url; the CDN redirect for the actual asset happens only
+/// after fetching this URL, so the field itself never contains the CDN's host). Guards against
+/// a compromised/corrupted release-data response smuggling a \c file:// path (silently copies
+/// a local file into the Downloads folder) or an unexpected scheme/UNC-style URL into
+/// QDesktopServices::openUrl.
 bool isSafeGitHubUrl(const QUrl &url);

--- a/Tests/Unit/Core/TestUpdateChecker.cpp
+++ b/Tests/Unit/Core/TestUpdateChecker.cpp
@@ -47,52 +47,33 @@ void TestUpdateChecker::testNoUpdate()
     QVERIFY(!shouldOfferUpdate("5.2.0", current, "5.2"));
 }
 
-void TestUpdateChecker::testAssetSelection()
+void TestUpdateChecker::testReleaseAssetKey()
 {
-    // Regression: a release ships per-architecture Linux AppImages and Windows
-    // ZIPs. The GitHub API returns assets sorted alphabetically, so "arm64"
-    // precedes "x86_64"; selecting by suffix alone wrongly picked the arm64
-    // binary for x86_64 users. Pin architecture-aware selection here. These are
-    // the real 5.1.2 asset names.
-    const QString linuxArm = "wiRedPanda-5.1.2-Linux-arm64-Qt6.9.3.AppImage";
-    const QString linuxX86 = "wiRedPanda-5.1.2-Linux-x86_64-Qt6.9.3.AppImage";
-    const QString macUniversal = "wiRedPanda-5.1.2-macOS-Qt6.9.3.dmg";
-    const QString winArm = "wiRedPanda-5.1.2-Windows-arm64-Qt6.9.3-Portable.zip";
-    const QString winX86 = "wiRedPanda-5.1.2-Windows-x86_64-Qt6.9.3-Portable.zip";
+    // Each platform/arch combination must select its own key in latest-release.json.
+    QCOMPARE(releaseAssetKey("Linux", "x86_64"), QStringLiteral("linuxX64"));
+    QCOMPARE(releaseAssetKey("Linux", "arm64"), QStringLiteral("linuxArm64"));
+    QCOMPARE(releaseAssetKey("Windows", "x86_64"), QStringLiteral("windowsX64"));
+    QCOMPARE(releaseAssetKey("Windows", "arm64"), QStringLiteral("windowsArm64"));
 
-    // Linux: each arch matches only its own AppImage (the exact reported bug).
-    QVERIFY(isMatchingReleaseAsset(linuxX86, "Linux", "x86_64"));
-    QVERIFY(!isMatchingReleaseAsset(linuxArm, "Linux", "x86_64"));
-    QVERIFY(isMatchingReleaseAsset(linuxArm, "Linux", "arm64"));
-    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Linux", "arm64"));
+    // macOS: single universal DMG, keyed on platform regardless of arch token.
+    QCOMPARE(releaseAssetKey("macOS", "x86_64"), QStringLiteral("macosUniversal"));
+    QCOMPARE(releaseAssetKey("macOS", "arm64"), QStringLiteral("macosUniversal"));
 
-    // Windows: same latent defect, same guard.
-    QVERIFY(isMatchingReleaseAsset(winX86, "Windows", "x86_64"));
-    QVERIFY(!isMatchingReleaseAsset(winArm, "Windows", "x86_64"));
-    QVERIFY(isMatchingReleaseAsset(winArm, "Windows", "arm64"));
-    QVERIFY(!isMatchingReleaseAsset(winX86, "Windows", "arm64"));
+    // Unknown architecture resolves to no key where one is required — the caller
+    // then falls back to the release page rather than a wrong binary.
+    QVERIFY(releaseAssetKey("Linux", "ppc64").isEmpty());
+    QVERIFY(releaseAssetKey("Windows", "ppc64").isEmpty());
 
-    // A Linux build must never select a Windows or macOS asset, and vice-versa.
-    QVERIFY(!isMatchingReleaseAsset(winX86, "Linux", "x86_64"));
-    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Windows", "x86_64"));
-
-    // macOS: single universal DMG, matched on platform regardless of arch token.
-    QVERIFY(isMatchingReleaseAsset(macUniversal, "macOS", "x86_64"));
-    QVERIFY(isMatchingReleaseAsset(macUniversal, "macOS", "arm64"));
-    QVERIFY(!isMatchingReleaseAsset(linuxX86, "macOS", "x86_64"));
-
-    // Unknown architecture matches nothing where an arch token is required —
-    // the caller then falls back to the release page rather than a wrong binary.
-    QVERIFY(!isMatchingReleaseAsset(linuxX86, "Linux", "ppc64"));
-    QVERIFY(!isMatchingReleaseAsset(winX86, "Windows", "ppc64"));
+    // Unknown platform resolves to no key at all.
+    QVERIFY(releaseAssetKey("BeOS", "x86_64").isEmpty());
 }
 
 void TestUpdateChecker::testSafeGitHubUrl()
 {
-    // Regression: browser_download_url/html_url from the GitHub API response were used for a
-    // network download + file write and QDesktopServices::openUrl with no scheme/host check.
-    // GitHub's release JSON only ever populates these fields as https://github.com/... — the
-    // CDN redirect happens only after fetching this URL, so its host never appears here.
+    // Regression: a download URL from the (response-controlled) release data was used for a
+    // network download + file write with no scheme/host check. The site's latest-release.json
+    // only ever populates that field as https://github.com/... — the CDN redirect happens only
+    // after fetching this URL, so its host never appears here.
     QVERIFY(isSafeGitHubUrl(QUrl("https://github.com/gibis-unifesp/wiredpanda/releases/download/5.1.2/wiRedPanda.AppImage")));
     QVERIFY(isSafeGitHubUrl(QUrl("https://github.com/gibis-unifesp/wiredpanda/releases/tag/5.1.2")));
 

--- a/Tests/Unit/Core/TestUpdateChecker.h
+++ b/Tests/Unit/Core/TestUpdateChecker.h
@@ -14,6 +14,6 @@ private slots:
 
     void testUpdateAvailable();
     void testNoUpdate();
-    void testAssetSelection();
+    void testReleaseAssetKey();
     void testSafeGitHubUrl();
 };


### PR DESCRIPTION
## Summary
- `UpdateChecker` hit `api.github.com` directly once a day per installation, tripping GitHub's per-IP unauthenticated rate limit for users behind a shared NAT/proxy/CI runner and silently hiding update notifications for them.
- The site already resolves and publishes this data once per release via CI (`update-release-data.yml`) at `gibis-unifesp.github.io/wiRedPanda/latest-release.json` ([site PR](https://github.com/GIBIS-UNIFESP/wiRedPanda/commit/e43873c1e) — already merged and deployed). `UpdateChecker` now polls that instead, so the GitHub API is hit once per release, not once per user.
- `isMatchingReleaseAsset()`'s asset-filename matching is replaced by `releaseAssetKey()`, a direct platform+arch → JSON key lookup, since the site's data is already resolved per platform/arch. The release-page fallback URL is now constructed from the version number instead of the API's `html_url`, since the new payload doesn't carry one.

## Test plan
- [x] `TestUpdateChecker` (`testUpdateAvailable`, `testNoUpdate`, `testReleaseAssetKey`, `testSafeGitHubUrl`) passes
- [x] Full `ctest` suite: 192/192 passing (combined with the already-merged `fix/qt6.12-dragenterevent-deprecation`)
- [x] Confirmed live: `curl https://gibis-unifesp.github.io/wiRedPanda/latest-release.json` returns the expected JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)