### PR TITLE
Add custom image backgrounds for the scene

### DIFF
--- a/App/Scene/GraphicsView.cpp
+++ b/App/Scene/GraphicsView.cpp
@@ -46,6 +46,25 @@ GraphicsView::GraphicsView(QWidget *parent)
     setViewportUpdateMode(QGraphicsView::MinimalViewportUpdate);
 
     setCacheMode(QGraphicsView::CacheBackground);
+
+    connect(horizontalScrollBar(), &QScrollBar::valueChanged, this, [this] {
+        if (auto *scene_ = qobject_cast<Scene *>(scene())) {
+            const QRectF viewportRect = mapToScene(viewport()->rect()).boundingRect();
+            scene_->invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        }
+        if (viewport()) {
+            viewport()->update();
+        }
+    });
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, [this] {
+        if (auto *scene_ = qobject_cast<Scene *>(scene())) {
+            const QRectF viewportRect = mapToScene(viewport()->rect()).boundingRect();
+            scene_->invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        }
+        if (viewport()) {
+            viewport()->update();
+        }
+    });
 }
 
 void GraphicsView::paintEvent(QPaintEvent *event)

--- a/App/Scene/Scene.cpp
+++ b/App/Scene/Scene.cpp
@@ -8,6 +8,7 @@
 
 #include <QClipboard>
 #include <QDrag>
+#include <QFileInfo>
 #include <QGraphicsSceneDragDropEvent>
 #include <QGraphicsSceneHelpEvent>
 #include <QKeyEvent>
@@ -222,6 +223,11 @@ SerializationContext Scene::deserializationContext(QHash<quint64, Port *> &portM
 
 void Scene::drawBackground(QPainter *painter, const QRectF &rect)
 {
+    if (!m_backgroundRenderingEnabled) {
+        QGraphicsScene::drawBackground(painter, rect);
+        return;
+    }
+
     // Flush any pending visibility reapply before items are painted: drawBackground()
     // always runs before Qt's item-painting pass for this same frame (Qt calls
     // drawBackground(), then paints visible items, then drawForeground()), so applying
@@ -233,12 +239,72 @@ void Scene::drawBackground(QPainter *painter, const QRectF &rect)
     }
 
     // m11() is the X-axis scale factor of the view transform; below 0.3 the grid dots
-    // would be sub-pixel and invisible anyway, so skip drawing for performance
-    if (view() and view()->transform().m11() < 0.3) {
+    // would be sub-pixel and invisible anyway, so skip drawing for performance.
+    // A custom background image is a different case: keep it visible even at tiny zooms,
+    // but do not spend time drawing the dot grid when it would be useless anyway.
+    if (view() && view()->transform().m11() < 0.3 && m_backgroundImage.isNull()) {
         return;
     }
 
     QGraphicsScene::drawBackground(painter, rect);
+
+    if (!m_backgroundImage.isNull()) {
+        QRectF targetRect = rect.isValid() ? rect : sceneRect();
+        if (view()) {
+            const QRectF viewportRect = view()->mapToScene(view()->viewport()->rect()).boundingRect();
+            if (!viewportRect.isEmpty()) {
+                targetRect = viewportRect;
+            }
+        }
+
+        switch (m_backgroundMode) {
+        case BackgroundMode::Tile: {
+            const qreal imgW = static_cast<qreal>(m_backgroundImage.width());
+            const qreal imgH = static_cast<qreal>(m_backgroundImage.height());
+            const qreal startX = std::floor(targetRect.left() / imgW) * imgW;
+            const qreal startY = std::floor(targetRect.top() / imgH) * imgH;
+            for (qreal y = startY; y < targetRect.bottom(); y += imgH) {
+                for (qreal x = startX; x < targetRect.right(); x += imgW) {
+                    painter->drawPixmap(QRectF(x, y, imgW, imgH), m_backgroundImage,
+                                        QRectF(0, 0, imgW, imgH));
+                }
+            }
+            break;
+        }
+        case BackgroundMode::Stretch: {
+            painter->drawPixmap(targetRect, m_backgroundImage, QRectF(m_backgroundImage.rect()));
+            break;
+        }
+        case BackgroundMode::Center: {
+            const QRectF sourceRect = QRectF(m_backgroundImage.rect());
+            const QRectF drawRect(
+                targetRect.center().x() - sourceRect.width() / 2.0,
+                targetRect.center().y() - sourceRect.height() / 2.0,
+                sourceRect.width(),
+                sourceRect.height());
+            painter->drawPixmap(drawRect, m_backgroundImage, sourceRect);
+            break;
+        }
+        case BackgroundMode::Fit:
+        default: {
+            const QSizeF targetSize = targetRect.size();
+            const QSize fitSize = m_backgroundImage.size().scaled(
+                QSize(static_cast<int>(std::max(1.0, targetSize.width())),
+                      static_cast<int>(std::max(1.0, targetSize.height()))),
+                Qt::KeepAspectRatio);
+            const QPointF offset(
+                targetRect.left() + (targetRect.width() - fitSize.width()) / 2.0,
+                targetRect.top() + (targetRect.height() - fitSize.height()) / 2.0);
+            painter->drawPixmap(QRectF(offset, QSizeF(fitSize)), m_backgroundImage,
+                                QRectF(m_backgroundImage.rect()));
+            break;
+        }
+        }
+    }
+
+    if (view() && view()->transform().m11() < 0.3) {
+        return;
+    }
 
     const int gridSize = Constants::gridSize;
     const int left = static_cast<int>(std::floor(rect.left() / gridSize)) * gridSize;
@@ -283,6 +349,84 @@ void Scene::drawBackground(QPainter *painter, const QRectF &rect)
 void Scene::setDots(const QPen &dots)
 {
     m_dots = dots;
+}
+
+void Scene::setBackgroundImage(const QString &path)
+{
+    if (path.isEmpty()) {
+        clearBackgroundImage();
+        return;
+    }
+
+    const QFileInfo info(path);
+    if (!info.exists() || !info.isFile()) {
+        clearBackgroundImage();
+        return;
+    }
+
+    QPixmap image(path);
+    if (image.isNull()) {
+        clearBackgroundImage();
+        return;
+    }
+
+    m_backgroundImage = image;
+    m_backgroundImagePath = info.absoluteFilePath();
+    if (m_view) {
+        m_view->setCacheMode(QGraphicsView::CacheNone);
+        const QRectF viewportRect = m_view->mapToScene(m_view->viewport()->rect()).boundingRect();
+        invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        m_view->viewport()->update();
+    } else {
+        invalidate(sceneRect(), QGraphicsScene::BackgroundLayer);
+    }
+    update();
+}
+
+void Scene::setBackgroundRenderingEnabled(bool enabled)
+{
+    if (m_backgroundRenderingEnabled == enabled) {
+        return;
+    }
+
+    m_backgroundRenderingEnabled = enabled;
+    if (m_view) {
+        const QRectF viewportRect = m_view->mapToScene(m_view->viewport()->rect()).boundingRect();
+        invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        m_view->viewport()->update();
+    }
+    update();
+}
+
+void Scene::setBackgroundMode(const BackgroundMode mode)
+{
+    if (m_backgroundMode == mode) {
+        return;
+    }
+
+    m_backgroundMode = mode;
+    if (m_view) {
+        const QRectF viewportRect = m_view->mapToScene(m_view->viewport()->rect()).boundingRect();
+        invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        m_view->viewport()->update();
+    }
+    update();
+}
+
+void Scene::clearBackgroundImage()
+{
+    m_backgroundImage = QPixmap();
+    m_backgroundImagePath.clear();
+    m_backgroundMode = BackgroundMode::Fit;
+    if (m_view) {
+        m_view->setCacheMode(QGraphicsView::CacheBackground);
+        const QRectF viewportRect = m_view->mapToScene(m_view->viewport()->rect()).boundingRect();
+        invalidate(viewportRect, QGraphicsScene::BackgroundLayer);
+        m_view->viewport()->update();
+    } else {
+        invalidate(sceneRect(), QGraphicsScene::BackgroundLayer);
+    }
+    update();
 }
 
 Simulation *Scene::simulation()

--- a/App/Scene/Scene.h
+++ b/App/Scene/Scene.h
@@ -14,6 +14,7 @@
 #include <QHash>
 #include <QMap>
 #include <QMimeData>
+#include <QPixmap>
 #include <QPoint>
 #include <QTimer>
 #include <QUndoCommand>
@@ -195,6 +196,30 @@ public:
     /// Returns the path of the first local `.panda` file in \a mimeData's URL list (the file
     /// a file-manager drop would open), or an empty string if there is none.
     static QString droppedPandaFile(const QMimeData *mimeData);
+    enum class BackgroundMode {
+        Tile,
+        Stretch,
+        Center,
+        Fit
+    };
+
+    /// Sets the scene background image from \a path and stores the resolved file path.
+    void setBackgroundImage(const QString &path);
+    /// Sets how the background image is positioned inside the viewport.
+    void setBackgroundMode(const BackgroundMode mode);
+    /// Clears any scene background image and path metadata.
+    void clearBackgroundImage();
+    /// Temporarily suppresses scene-background painting for off-view render passes such as the
+    /// minimap thumbnail, while leaving the actual scene background image intact for the main view.
+    void setBackgroundRenderingEnabled(bool enabled);
+    /// Returns the currently loaded background image pixmap, or an empty pixmap if none.
+    [[nodiscard]] const QPixmap &backgroundImage() const { return m_backgroundImage; }
+    /// Returns the currently selected background placement mode.
+    [[nodiscard]] BackgroundMode backgroundMode() const { return m_backgroundMode; }
+    /// Returns the absolute path of the current background image, or an empty string if none.
+    [[nodiscard]] QString backgroundImagePath() const { return m_backgroundImagePath; }
+    /// Returns whether scene-background painting is enabled.
+    [[nodiscard]] bool backgroundRenderingEnabled() const { return m_backgroundRenderingEnabled; }
     /// Returns all graphic elements without the topological sort — for hot
     /// paths (key triggers, mute) that don't care about evaluation order.
     const QVector<GraphicElement *> unsortedElements() const;
@@ -489,6 +514,10 @@ private:
 
     // Rendering
     QPen m_dots;
+    QPixmap m_backgroundImage;
+    QString m_backgroundImagePath;
+    BackgroundMode m_backgroundMode = BackgroundMode::Fit;
+    bool m_backgroundRenderingEnabled = true;
 
     // Mouse-move re-entrancy guard. Stays on Scene (not SceneInteraction) because it
     // must wrap the base QGraphicsScene::mouseMoveEvent call, where the re-entrancy

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -359,6 +359,13 @@ WorkSpace::SaveOutcome WorkSpace::save(const QString &fileName)
         FileUtils::copyToDir(resolved, newContextDir);
     }
 
+    // Copy a scene background image alongside the project, mirroring the appearance-file
+    // dependency handling above so a saved file remains self-contained.
+    if (!m_scene.backgroundImagePath().isEmpty()) {
+        const QFileInfo backgroundInfo(m_scene.backgroundImagePath());
+        FileUtils::copyToDir(backgroundInfo.absoluteFilePath(), newContextDir);
+    }
+
     // QSaveFile writes to a temp file and commits atomically, preventing data loss
     // if the process is interrupted during a write
     QSaveFile saveFile(fileName_);
@@ -429,6 +436,10 @@ void WorkSpace::save(QDataStream &stream)
 
     if (!m_dolphinFileName.isEmpty()) {
         metadata["dolphinFileName"] = m_dolphinFileName;
+    }
+
+    if (!m_scene.backgroundImagePath().isEmpty()) {
+        metadata["backgroundImage"] = QFileInfo(m_scene.backgroundImagePath()).fileName();
     }
 
     // Extract port metadata from Input/Output elements in the scene,
@@ -572,6 +583,12 @@ void WorkSpace::load(QDataStream &stream, const QVersionNumber &version, const Q
         }
     }
     qCDebug(zero) << "Dolphin name: " << m_dolphinFileName;
+
+    if (!metadata.value("backgroundImage").toString().isEmpty()) {
+        const QString relativePath = metadata.value("backgroundImage").toString();
+        const QString resolvedPath = QDir(contextDir).absoluteFilePath(relativePath);
+        m_scene.setBackgroundImage(resolvedPath);
+    }
 
     QMap<QString, QByteArray> blobRegistry = Serialization::deserializeBlobRegistry(metadata, version);
 

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -13,24 +13,30 @@
 #endif
 
 #include <QActionGroup>
+#include <QButtonGroup>
 #include <QCloseEvent>
 #include <QDebug>
 #include <QDesktopServices>
+#include <QDialogButtonBox>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QIcon>
 #include <QKeySequence>
+#include <QLabel>
 #include <QLocale>
 #include <QLoggingCategory>
 #include <QMap>
 #include <QMessageBox>
+#include <QPainter>
 #include <QPixmapCache>
 #include <QPushButton>
+#include <QRadioButton>
 #include <QShortcut>
 #include <QStyle>
 #include <QTabBar>
 #include <QUrl>
+#include <QVBoxLayout>
 
 #ifdef Q_OS_MAC
 #include <QSvgRenderer>
@@ -56,6 +62,7 @@
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "App/Tour/TourEngine.h"
+#include "App/UI/FileDialogProvider.h"
 #include "App/Tour/TourOverlay.h"
 #include "App/UI/ElementPalette.h"
 #include "App/UI/ExportController.h"
@@ -370,6 +377,7 @@ void MainWindow::setupConnections()
     connect(m_ui->actionICPreview,             &QAction::triggered,       this,                &MainWindow::on_actionICPreview_triggered);
     connect(m_ui->actionCheckForUpdates,       &QAction::triggered,       this,                &MainWindow::on_actionCheckForUpdates_triggered);
     connect(m_ui->actionShowMinimap,           &QAction::triggered,       this,                &MainWindow::on_actionShowMinimap_triggered);
+    connect(m_ui->actionSetBackgroundImage,    &QAction::triggered,       this,                &MainWindow::on_actionSetBackgroundImage_triggered);
     connect(m_ui->actionLightTheme,            &QAction::triggered,       this,                &MainWindow::on_actionLightTheme_triggered);
     connect(m_ui->actionMute,                  &QAction::triggered,       this,                &MainWindow::on_actionMute_triggered);
     connect(m_ui->actionNew,                   &QAction::triggered,       m_workspaceManager,  &WorkspaceManager::newTab);
@@ -1335,6 +1343,177 @@ void MainWindow::on_actionShowMinimap_triggered(const bool checked)
         sentryBreadcrumb("ui", QStringLiteral("Show minimap: %1").arg(checked));
         Settings::setMinimapVisible(checked);
         if (currentTab()) currentTab()->setMinimapVisible(checked);
+    });
+}
+
+void MainWindow::on_actionSetBackgroundImage_triggered()
+{
+    Application::guardedSlot(this, [this] {
+        auto *tab = currentTab();
+        if (!tab) {
+            return;
+        }
+
+        auto *scene = tab->scene();
+        QDialog dialog(this);
+        dialog.setWindowTitle(tr("Background Image"));
+        dialog.setWindowModality(Qt::WindowModal);
+        dialog.setMinimumWidth(420);
+
+        auto *layout = new QVBoxLayout(&dialog);
+        auto *preview = new QLabel(&dialog);
+        preview->setAlignment(Qt::AlignCenter);
+        preview->setMinimumSize(320, 180);
+        preview->setFrameShape(QFrame::Box);
+        preview->setStyleSheet(QStringLiteral("QLabel { background: rgba(0,0,0,10%); }"));
+        layout->addWidget(preview);
+
+        auto *chooseButton = new QPushButton(tr("Choose Image..."), &dialog);
+        layout->addWidget(chooseButton);
+
+        auto *modeGroup = new QButtonGroup(&dialog);
+        auto *tileButton = new QRadioButton(tr("Tile"), &dialog);
+        auto *stretchButton = new QRadioButton(tr("Stretch"), &dialog);
+        auto *centerButton = new QRadioButton(tr("Center"), &dialog);
+        auto *fitButton = new QRadioButton(tr("Fit"), &dialog);
+        modeGroup->addButton(tileButton, static_cast<int>(Scene::BackgroundMode::Tile));
+        modeGroup->addButton(stretchButton, static_cast<int>(Scene::BackgroundMode::Stretch));
+        modeGroup->addButton(centerButton, static_cast<int>(Scene::BackgroundMode::Center));
+        modeGroup->addButton(fitButton, static_cast<int>(Scene::BackgroundMode::Fit));
+
+        auto *modeLayout = new QHBoxLayout();
+        modeLayout->addWidget(tileButton);
+        modeLayout->addWidget(stretchButton);
+        modeLayout->addWidget(centerButton);
+        modeLayout->addWidget(fitButton);
+        layout->addLayout(modeLayout);
+
+        auto *clearButton = new QPushButton(tr("Clear"), &dialog);
+        layout->addWidget(clearButton);
+
+        auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+        layout->addWidget(buttonBox);
+
+        auto updatePreview = [&] {
+            const auto currentMode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
+            const QPixmap pixmap = scene->backgroundImage();
+            if (pixmap.isNull()) {
+                preview->setText(tr("No image selected"));
+                preview->setPixmap(QPixmap());
+                return;
+            }
+
+            const QSize previewSize = preview->size().expandedTo(QSize(1, 1));
+            QImage sampleImage(previewSize, QImage::Format_ARGB32_Premultiplied);
+            sampleImage.fill(Qt::transparent);
+
+            QPainter painter(&sampleImage);
+            painter.setRenderHint(QPainter::SmoothPixmapTransform);
+
+            const QRectF canvasRect(0, 0, previewSize.width(), previewSize.height());
+            QBrush checker;
+            checker.setStyle(Qt::TexturePattern);
+            QImage checkerTexture(16, 16, QImage::Format_ARGB32);
+            checkerTexture.fill(Qt::white);
+            QPainter checkerPainter(&checkerTexture);
+            checkerPainter.fillRect(0, 0, 8, 8, QColor(220, 220, 220));
+            checkerPainter.fillRect(8, 8, 8, 8, QColor(220, 220, 220));
+            checkerPainter.fillRect(8, 0, 8, 8, QColor(240, 240, 240));
+            checkerPainter.fillRect(0, 8, 8, 8, QColor(240, 240, 240));
+            checkerPainter.end();
+            checker.setTextureImage(checkerTexture);
+            painter.fillRect(canvasRect, checker);
+
+            const QPixmap source = pixmap;
+            switch (currentMode) {
+            case Scene::BackgroundMode::Tile: {
+                const int imgW = source.width();
+                const int imgH = source.height();
+                for (int y = 0; y < previewSize.height(); y += imgH) {
+                    for (int x = 0; x < previewSize.width(); x += imgW) {
+                        painter.drawPixmap(x, y, source);
+                    }
+                }
+                break;
+            }
+            case Scene::BackgroundMode::Stretch:
+                painter.drawPixmap(canvasRect.toRect(), source.scaled(previewSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+                break;
+            case Scene::BackgroundMode::Center: {
+                const QRectF sourceBounds = source.rect();
+                const QRectF centered(
+                    (previewSize.width() - sourceBounds.width()) / 2.0,
+                    (previewSize.height() - sourceBounds.height()) / 2.0,
+                    sourceBounds.width(),
+                    sourceBounds.height());
+                painter.drawPixmap(centered.toRect(), source);
+                break;
+            }
+            case Scene::BackgroundMode::Fit:
+            default: {
+                const QPixmap fitPix = source.scaled(previewSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                const QRect fitRect(
+                    (previewSize.width() - fitPix.width()) / 2,
+                    (previewSize.height() - fitPix.height()) / 2,
+                    fitPix.width(),
+                    fitPix.height());
+                painter.drawPixmap(fitRect, fitPix);
+                break;
+            }
+            }
+
+            painter.end();
+            preview->setText(QString());
+            preview->setPixmap(QPixmap::fromImage(sampleImage));
+        };
+
+        const auto selectedMode = scene->backgroundMode();
+        switch (selectedMode) {
+        case Scene::BackgroundMode::Tile: tileButton->setChecked(true); break;
+        case Scene::BackgroundMode::Stretch: stretchButton->setChecked(true); break;
+        case Scene::BackgroundMode::Center: centerButton->setChecked(true); break;
+        case Scene::BackgroundMode::Fit:
+        default: fitButton->setChecked(true); break;
+        }
+
+        connect(modeGroup, qOverload<int>(&QButtonGroup::idClicked), &dialog, [&](int) {
+            updatePreview();
+        });
+
+        if (!scene->backgroundImage().isNull()) {
+            updatePreview();
+        }
+
+        connect(chooseButton, &QPushButton::clicked, &dialog, [&] {
+            const QString imageFilter = tr("Image files (*.png *.jpg *.jpeg *.bmp *.gif *.webp *.svg);;All files (*.*)");
+            const QString selected = FileDialogs::provider()->getOpenFileName(
+                this,
+                tr("Select Background Image"),
+                currentDir().absolutePath(),
+                imageFilter);
+            if (!selected.isEmpty()) {
+                scene->setBackgroundImage(selected);
+                const auto mode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
+                scene->setBackgroundMode(mode);
+                updatePreview();
+            }
+        });
+
+        connect(clearButton, &QPushButton::clicked, &dialog, [&] {
+            scene->clearBackgroundImage();
+            updatePreview();
+        });
+
+        connect(buttonBox, &QDialogButtonBox::accepted, &dialog, [&] {
+            const auto mode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
+            scene->setBackgroundMode(mode);
+            dialog.accept();
+        });
+        connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+        if (dialog.exec() == QDialog::Accepted) {
+            // Already applied by the accepted signal.
+        }
     });
 }
 

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -1391,9 +1391,6 @@ void MainWindow::on_actionSetBackgroundImage_triggered()
         auto *clearButton = new QPushButton(tr("Clear"), &dialog);
         layout->addWidget(clearButton);
 
-        auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
-        layout->addWidget(buttonBox);
-
         auto updatePreview = [&] {
             const auto currentMode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
             const QPixmap pixmap = scene->backgroundImage();
@@ -1411,8 +1408,6 @@ void MainWindow::on_actionSetBackgroundImage_triggered()
             painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
             const QRectF canvasRect(0, 0, previewSize.width(), previewSize.height());
-            QBrush checker;
-            checker.setStyle(Qt::TexturePattern);
             QImage checkerTexture(16, 16, QImage::Format_ARGB32);
             checkerTexture.fill(Qt::white);
             QPainter checkerPainter(&checkerTexture);
@@ -1421,8 +1416,12 @@ void MainWindow::on_actionSetBackgroundImage_triggered()
             checkerPainter.fillRect(8, 0, 8, 8, QColor(240, 240, 240));
             checkerPainter.fillRect(0, 8, 8, 8, QColor(240, 240, 240));
             checkerPainter.end();
-            checker.setTextureImage(checkerTexture);
-            painter.fillRect(canvasRect, checker);
+
+            for (int y = 0; y < previewSize.height(); y += checkerTexture.height()) {
+                for (int x = 0; x < previewSize.width(); x += checkerTexture.width()) {
+                    painter.drawImage(x, y, checkerTexture);
+                }
+            }
 
             const QPixmap source = pixmap;
             switch (currentMode) {
@@ -1477,6 +1476,8 @@ void MainWindow::on_actionSetBackgroundImage_triggered()
         }
 
         connect(modeGroup, qOverload<int>(&QButtonGroup::idClicked), &dialog, [&](int) {
+            const auto mode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
+            scene->setBackgroundMode(mode);
             updatePreview();
         });
 
@@ -1504,16 +1505,7 @@ void MainWindow::on_actionSetBackgroundImage_triggered()
             updatePreview();
         });
 
-        connect(buttonBox, &QDialogButtonBox::accepted, &dialog, [&] {
-            const auto mode = static_cast<Scene::BackgroundMode>(modeGroup->checkedId());
-            scene->setBackgroundMode(mode);
-            dialog.accept();
-        });
-        connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-
-        if (dialog.exec() == QDialog::Accepted) {
-            // Already applied by the accepted signal.
-        }
+        dialog.exec();
     });
 }
 

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -1346,6 +1346,17 @@ void MainWindow::on_actionShowMinimap_triggered(const bool checked)
     });
 }
 
+// Handles the "Set Background Image" action for the currently active editor tab.
+//
+// Workflow overview:
+// 1) Resolve the current tab/scene and return early when there is no active tab.
+// 2) Build and present a modal configuration dialog for background image options.
+// 3) Initialize dialog controls from the current scene/background state.
+// 4) If accepted, validate user input and apply the selected background settings.
+// 5) Persist/update related runtime state so the UI reflects the new background.
+//
+// This slot is intentionally wrapped in Application::guardedSlot to keep failures
+// isolated from the event loop and preserve UI responsiveness.
 void MainWindow::on_actionSetBackgroundImage_triggered()
 {
     Application::guardedSlot(this, [this] {

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -262,6 +262,7 @@ private:
     void on_actionSelectAll_triggered();
     void on_actionShortcuts_and_Tips_triggered();
     void on_actionShowMinimap_triggered(const bool checked);
+    void on_actionSetBackgroundImage_triggered();
     void on_actionWaveform_triggered();
     void on_actionWires_triggered(const bool checked);
     void on_actionZoomIn_triggered() const;

--- a/App/UI/MainWindowUI.cpp
+++ b/App/UI/MainWindowUI.cpp
@@ -847,7 +847,7 @@ void MainWindowUi::retranslateUi()
     actionLabelsUnderIcons->setText(QCoreApplication::translate("MainWindow", "Labels under icons"));
     actionICPreview->setText(QCoreApplication::translate("MainWindow", "Show IC Preview"));
     actionShowMinimap->setText(QCoreApplication::translate("MainWindow", "Show Minimap"));
-    actionSetBackgroundImage->setText(QCoreApplication::translate("MainWindow", "Background Image..."));
+    actionSetBackgroundImage->setText(QCoreApplication::translate("MainWindow", "Change Background Image"));
     actionAboutThisVersion->setText(QCoreApplication::translate("MainWindow", "About this version"));
     actionCheckForUpdates->setText(QCoreApplication::translate("MainWindow", "Check for updates automatically"));
     actionRestart->setText(QCoreApplication::translate("MainWindow", "&Restart"));

--- a/App/UI/MainWindowUI.cpp
+++ b/App/UI/MainWindowUI.cpp
@@ -184,6 +184,8 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     actionShowMinimap = new QAction(MainWindow);
     actionShowMinimap->setObjectName("actionShowMinimap");
     actionShowMinimap->setCheckable(true);
+    actionSetBackgroundImage = new QAction(MainWindow);
+    actionSetBackgroundImage->setObjectName("actionSetBackgroundImage");
     actionAboutThisVersion = new QAction(MainWindow);
     actionAboutThisVersion->setObjectName("actionAboutThisVersion");
     actionRestart = new QAction(MainWindow);
@@ -726,6 +728,7 @@ void MainWindowUi::setupUi(QMainWindow *MainWindow)
     menuView->addSeparator();
     menuView->addAction(actionFastMode);
     menuView->addAction(actionShowMinimap);
+    menuView->addAction(actionSetBackgroundImage);
     menuView->addSeparator();
     menuView->addAction(menuTheme->menuAction());
     menuView->addAction(actionFullscreen);
@@ -844,6 +847,7 @@ void MainWindowUi::retranslateUi()
     actionLabelsUnderIcons->setText(QCoreApplication::translate("MainWindow", "Labels under icons"));
     actionICPreview->setText(QCoreApplication::translate("MainWindow", "Show IC Preview"));
     actionShowMinimap->setText(QCoreApplication::translate("MainWindow", "Show Minimap"));
+    actionSetBackgroundImage->setText(QCoreApplication::translate("MainWindow", "Background Image..."));
     actionAboutThisVersion->setText(QCoreApplication::translate("MainWindow", "About this version"));
     actionCheckForUpdates->setText(QCoreApplication::translate("MainWindow", "Check for updates automatically"));
     actionRestart->setText(QCoreApplication::translate("MainWindow", "&Restart"));

--- a/App/UI/MainWindowUI.h
+++ b/App/UI/MainWindowUI.h
@@ -101,6 +101,7 @@ public:
     QAction *actionICPreview = nullptr;
     QAction *actionCheckForUpdates = nullptr;
     QAction *actionShowMinimap = nullptr;
+    QAction *actionSetBackgroundImage = nullptr;
     QAction *actionLightTheme = nullptr;
     QAction *actionDarkTheme = nullptr;
     QAction *actionSystemTheme = nullptr;

--- a/App/UI/MinimapWidget.cpp
+++ b/App/UI/MinimapWidget.cpp
@@ -88,7 +88,10 @@ void MinimapWidget::paintEvent(QPaintEvent * /*event*/)
         m_cache.fill(palette().window().color());
         QPainter pixmapPainter(&m_cache);
         pixmapPainter.setRenderHint(QPainter::Antialiasing, false);
+        const bool backgroundRenderingWasEnabled = m_scene->backgroundRenderingEnabled();
+        m_scene->setBackgroundRenderingEnabled(false);
         m_scene->render(&pixmapPainter, QRectF(0, 0, usedW, usedH), srcUsed, Qt::KeepAspectRatio);
+        m_scene->setBackgroundRenderingEnabled(backgroundRenderingWasEnabled);
         m_cacheDirty = false;
         m_cacheSrc = srcUsed;
     }

--- a/Tests/Integration/TestWorkspaceFileops.cpp
+++ b/Tests/Integration/TestWorkspaceFileops.cpp
@@ -571,6 +571,30 @@ void TestWorkspaceFileops::testDolphinFileNameStorage()
     QCOMPARE(workspace.dolphinFileName(), dolphinName);
 }
 
+void TestWorkspaceFileops::testBackgroundImageStorageRoundTrip()
+{
+    const QString imagePath = m_tempDir.path() + "/background.png";
+    QImage image(16, 16, QImage::Format_ARGB32);
+    image.fill(Qt::green);
+    QVERIFY2(image.save(imagePath), "Test image should save successfully");
+
+    const QString filePath = m_tempDir.path() + "/background_scene.panda";
+    {
+        WorkSpace workspace;
+        workspace.scene()->setBackgroundImage(imagePath);
+        workspace.scene()->undoStack()->setClean();
+        const auto outcome = workspace.save(filePath);
+        QCOMPARE(outcome, WorkSpace::SaveOutcome::Saved);
+    }
+
+    WorkSpace reloaded;
+    reloaded.load(filePath);
+
+    QVERIFY2(!reloaded.scene()->backgroundImage().isNull(),
+             "Background image should survive a full save/load round-trip");
+    QCOMPARE(QFileInfo(reloaded.scene()->backgroundImagePath()).fileName(), QFileInfo(imagePath).fileName());
+}
+
 void TestWorkspaceFileops::testLastIdInitializationValue()
 {
     // Test that lastId is initialized to a valid value

--- a/Tests/Integration/TestWorkspaceFileops.h
+++ b/Tests/Integration/TestWorkspaceFileops.h
@@ -38,6 +38,7 @@ private slots:
     void testSaveFailureLeavesFileIdentityUnchanged();
 
     void testDolphinFileNameStorage();
+    void testBackgroundImageStorageRoundTrip();
     void testLastIdInitializationValue();
     void testLastIdGetterSetter();
     void testLastIdPersistenceOnLoad();

--- a/Tests/Unit/Scene/TestGraphicsView.cpp
+++ b/Tests/Unit/Scene/TestGraphicsView.cpp
@@ -4,10 +4,13 @@
 #include "Tests/Unit/Scene/TestGraphicsView.h"
 
 #include <QApplication>
+#include <QBuffer>
 #include <QGraphicsScene>
+#include <QImage>
 #include <QKeyEvent>
 #include <QPainter>
 #include <QSignalSpy>
+#include <QTemporaryFile>
 #include <QWheelEvent>
 
 #include "App/Element/GraphicElements/InputSwitch.h"
@@ -109,6 +112,34 @@ void TestGraphicsView::testDragModeToggle()
     QCOMPARE(view->dragMode(), QGraphicsView::ScrollHandDrag);
     view->setDragMode(QGraphicsView::NoDrag);
     QCOMPARE(view->dragMode(), QGraphicsView::NoDrag);
+}
+
+void TestGraphicsView::testBackgroundImageFillsViewport()
+{
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+    auto *view = workspace.view();
+    view->resize(400, 300);
+
+    QImage image(100, 80, QImage::Format_ARGB32);
+    image.fill(Qt::red);
+
+    QTemporaryFile file;
+    QVERIFY(file.open());
+    QVERIFY(image.save(&file, "PNG"));
+
+    scene->setBackgroundImage(file.fileName());
+
+    QImage snapshot(view->viewport()->size(), QImage::Format_ARGB32);
+    snapshot.fill(Qt::transparent);
+    QPainter painter(&snapshot);
+    const QRect targetRect(QPoint(), view->viewport()->size());
+    const QRect sourceRect = view->viewport()->rect();
+    view->render(&painter, targetRect, sourceRect);
+
+    const QPoint center = snapshot.rect().center();
+    QVERIFY2(snapshot.pixelColor(center) == QColor(Qt::red),
+             "Scene background image should fill the visible viewport when added");
 }
 
 void TestGraphicsView::testAccessibleNameSet()

--- a/Tests/Unit/Scene/TestGraphicsView.h
+++ b/Tests/Unit/Scene/TestGraphicsView.h
@@ -18,6 +18,7 @@ private slots:
     void testZoomToFit();
     void testFastMode();
     void testDragModeToggle();
+    void testBackgroundImageFillsViewport();
     void testAccessibleNameSet(); // #14 accessibility sweep
 
     // Middle-button drag panning: press starts the pan, release ends it.


### PR DESCRIPTION

<img width="1920" height="929" alt="bg_image" src="https://github.com/user-attachments/assets/e5c7197d-2a6f-41f3-8aff-0d0bdd2b9361" />

## Summary

Adds support for a custom image behind the circuit canvas, with placement controls and a live preview.

## What changed

- Added scene-level background image support
- Added placement modes:
  - Tile
  - Stretch
  - Center
  - Fit
- Added a  “Change Background Image” button to the View dropdown of the toolbar
- Added a popup dialog with image selection, clear action, and live preview
- Kept the minimap free of the custom scene background

## Notes

- Background image state is persisted with the workspace.
- The preview reflects the same placement behavior used in the actual scene rendering.