### PR TITLE
Fix Doxygen doc-comment warnings and gate against regressions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,77 @@
+# Copyright 2015 - 2026, GIBIS-Unifesp and the wiRedPanda contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: API docs
+
+# Doxyfile.in sets WARN_AS_ERROR, so a doc-comment regression fails the pull
+# request that introduces it. The site branch builds these same docs from
+# master's HEAD, so without this gate the failure would instead land on a site
+# deploy that has no changes of its own and blame the wrong commit.
+#
+# This lives in its own workflow because lint.yml's path filters cover only
+# MCP/Client, Scripts, Tests and config files -- never App/** -- and build.yml
+# is the Qt matrix.
+#
+# Triggers follow build.yml/lint.yml/sanitizers.yml: run on branch pushes for
+# early feedback and gate pull requests into master. Master itself is excluded
+# because the pull request already gated it, and a failure there is too late to
+# act on. Paths are duplicated rather than shared with a YAML anchor -- GitHub
+# Actions' parser does not support anchors, even though actionlint accepts them.
+on:
+  push:
+    branches-ignore:
+      - master
+      - wasm
+    paths:
+      - 'App/**'
+      - 'MCP/Server/**'
+      - Doxyfile.in
+      - .github/workflows/docs.yml
+
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'App/**'
+      - 'MCP/Server/**'
+      - Doxyfile.in
+      - .github/workflows/docs.yml
+
+jobs:
+  doxygen:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    # Same-repo branches already ran this on their push, so skip the duplicate
+    # pull_request run; forks get no push run and still need it. Matches
+    # build.yml, lint.yml and sanitizers.yml.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Pinned to the same release and checksum as the site branch's site.yml.
+      # WARN_AS_ERROR makes this version-sensitive: an unpinned newer Doxygen
+      # could emit new warnings and fail master while the site build passes.
+      - name: Install Doxygen
+        run: |
+          curl -fsSL https://github.com/doxygen/doxygen/releases/download/Release_1_16_1/doxygen-1.16.1.linux.bin.tar.gz -o "$RUNNER_TEMP/doxygen.tar.gz"
+          echo "a56f885d37e3aae08a99f638d17bbb381224c03a878d9e2dda4f9fa4baf1d8bd  $RUNNER_TEMP/doxygen.tar.gz" | sha256sum -c -
+          tar xzf "$RUNNER_TEMP/doxygen.tar.gz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/doxygen-1.16.1/bin" >> "$GITHUB_PATH"
+
+      # Doxyfile.in is a CMake template, but it needs only five substitutions --
+      # far cheaper than configuring the project just to lint doc comments.
+      # HAVE_DOT=NO because graphs are irrelevant here and would cost a graphviz
+      # install; the site build still renders them.
+      - name: Check API docs for warnings
+        run: |
+          mkdir -p "$RUNNER_TEMP/docs-build/docs"
+          sed -e "s|@CMAKE_SOURCE_DIR@|$PWD|g" \
+              -e "s|@CMAKE_BINARY_DIR@|$RUNNER_TEMP/docs-build|g" \
+              -e "s|@PROJECT_VERSION@|ci|g" \
+              -e "s|@DOXYGEN_HAVE_DOT@|NO|g" \
+              -e "s|@DOXYGEN_DOT_PATH@||g" \
+              Doxyfile.in > "$RUNNER_TEMP/Doxyfile.ci"
+          doxygen "$RUNNER_TEMP/Doxyfile.ci"

--- a/App/BeWavedDolphin/SignalModel.h
+++ b/App/BeWavedDolphin/SignalModel.h
@@ -24,7 +24,6 @@ class SignalModel : public QStandardItemModel
 public:
     /**
      * \brief Constructs the model.
-     * \param inputs  Number of input signal rows (stored for reference).
      * \param rows    Total number of signal rows.
      * \param columns Number of time-step columns.
      * \param parent  Optional parent object.

--- a/App/Core/ExerciseTourResources.h
+++ b/App/Core/ExerciseTourResources.h
@@ -42,7 +42,7 @@ struct ExerciseTourResourceEntry {
  *
  * Step text inside the JSON never passes through tr() (lupdate can't see JSON), so
  * translations instead live in a separate, Weblate-managed catalog at
- * :/i18n/ExerciseTour/<lang>.json; translate() looks strings up there, falling back to the
+ * :/i18n/ExerciseTour/\<lang\>.json; translate() looks strings up there, falling back to the
  * JSON's own English text when no translation is installed or found — which is also the
  * correct, automatic behavior for user-added content that will never have a catalog entry.
  */

--- a/App/Core/InstallRelativePaths.h
+++ b/App/Core/InstallRelativePaths.h
@@ -27,7 +27,7 @@ public:
     /// Builds the ordered list of candidate directories for \a category, relative to
     /// QCoreApplication::applicationDirPath(): Windows/dev builds, macOS app bundle
     /// Resources, Linux AppImage (via $APPDIR), Linux native FHS install
-    /// (share/wiredpanda/<category> next to a bin/ install), WASM's virtual
+    /// (share/wiredpanda/\<category\> next to a bin/ install), WASM's virtual
     /// filesystem, and finally a bare-category CWD fallback for development.
     static QStringList candidates(const QString &category);
 

--- a/App/Element/ElementSimState.h
+++ b/App/Element/ElementSimState.h
@@ -48,6 +48,8 @@ public:
     /**
      * \brief Snapshots each predecessor's output into the input cache, reading \a inputPorts
      * for unconnected-input defaults and multi-driver conflict detection.
+     * \param inputPorts Input ports, read for unconnected-input defaults and multi-driver
+     * conflict detection.
      * \param allowUnknown When true, only a truly unconnected Unknown input fails (combinational
      * domination rules can still short-circuit); when false any Unknown/Error fails.
      * \return true if simulation can proceed; false (all outputs set Unknown) otherwise.

--- a/App/Element/GraphicElement.h
+++ b/App/Element/GraphicElement.h
@@ -97,6 +97,7 @@ public:
 
     /**
      * \brief Loads the graphic element through a binary data stream.
+     * \param stream Binary stream positioned at this element's serialized data.
      * \param context carries portMap, version, contextDir and optional copy-operation state.
      */
     virtual void load(QDataStream &stream, SerializationContext &context);

--- a/App/Element/GraphicElements/AudioOutputElement.h
+++ b/App/Element/GraphicElements/AudioOutputElement.h
@@ -34,6 +34,8 @@ public:
     /// passes its own lower kDefaultVolume instead.
     static constexpr float kDefaultVolume = 0.5f;
 
+    /// \param type Concrete audio element type, forwarded to the GraphicElement base.
+    /// \param parent Optional parent item.
     /// \param initialVolume lets a subclass set its own volume default in one write --
     /// a derived class cannot member-initialize a base's field, and a ctor-body
     /// assignment would write m_volume twice per construction.

--- a/App/UI/SceneUiBinder.h
+++ b/App/UI/SceneUiBinder.h
@@ -45,6 +45,7 @@ public:
     /// \param palette Element palette (embedded-IC list reflects the active scene).
     /// \param previewPopup Shared IC hover-preview popup, driven off the bound scene's IC signals.
     /// \param shortcutParent Widget that parents the scene-property shortcuts (the window).
+    /// \param parent Optional QObject parent.
     SceneUiBinder(MainWindowUi *ui, ElementPalette *palette, ICPreviewPopup *previewPopup, QWidget *shortcutParent, QObject *parent = nullptr);
 
     /// Connects \a tab's scene/view/simulation to the chrome and syncs action state.

--- a/App/UI/WorkspaceManager.h
+++ b/App/UI/WorkspaceManager.h
@@ -38,6 +38,7 @@ class WorkspaceManager : public QObject
 public:
     /// \param tab The tab widget whose contents this manager owns (non-owning).
     /// \param host Application context for status/palette/dialog-parent/IC-button feedback.
+    /// \param parent Optional QObject parent.
     WorkspaceManager(QTabWidget *tab, MainWindowHost &host, QObject *parent = nullptr);
 
     // --- Accessors (MainWindow's DolphinHost/MainWindowHost delegate here) ---

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -51,6 +51,10 @@ WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = NO
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
+# FAIL_ON_WARNINGS rather than YES: YES aborts at the first warning, so a
+# contributor fixes one and immediately hits the next. This reports them all,
+# then exits non-zero.
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
 


### PR DESCRIPTION
Doxygen has been emitting 9 warnings on every docs build. They were invisible because `WARN_AS_ERROR` is unset and the site's docs build runs `QUIET = YES`, so nothing ever surfaced them. This clears all 9 and turns the gate on.

Found while auditing why the site branch's deployed CSS bundle differed from a local build — unrelated cause, but the Doxygen run was noisy along the way.

## The warnings

`WARN_NO_PARAMDOC = NO` only suppresses functions with *no* `\param` at all. These blocks document some parameters and omit others, which is `WARN_IF_INCOMPLETE_DOC` (default YES, unset here) — so the fix is to finish the doc blocks, not flip a switch.

| File | Missing |
| --- | --- |
| `AudioOutputElement.h` | `type`, `parent` |
| `ElementSimState.h` | `inputPorts` |
| `GraphicElement.h` | `stream` — also clears the `Node::load` warning, which inherits this block |
| `SceneUiBinder.h` | `parent` |
| `WorkspaceManager.h` | `parent` |

Two others were different in kind:

- **`SignalModel.h`** documented a `\param inputs` its constructor does not take — `SignalModel(int rows, int columns, QObject *parent)`. Left over from a signature change, and the only one of the nine that was actually *wrong* rather than incomplete. Removed.
- **`ExerciseTourResources.h` / `InstallRelativePaths.h`** wrote the placeholders `<lang>` and `<category>` in prose, which Doxygen parsed as HTML tags. Now escaped. Doxygen was already recovering and emitting the right text, so the published pages are unchanged — verified both still render `&lt;lang&gt;` and `&lt;category&gt;`.

## The gate

`Doxyfile.in` gets `WARN_AS_ERROR = FAIL_ON_WARNINGS` rather than `YES`: `YES` aborts at the first warning, so a contributor fixes one and immediately hits the next. `FAIL_ON_WARNINGS` completes the run and reports all of them.

It goes here rather than in the site branch's `Doxyfile` because `site.yml` builds these same docs from master's HEAD — gating there would fail a site deploy that has no changes of its own and point at the wrong commit. The site `Doxyfile` deliberately keeps no `WARN_AS_ERROR`.

`docs.yml` is a new workflow because neither existing one can host it: `lint.yml`'s path filters cover `MCP/Client`, `Scripts`, `Tests` and config files but never `App/**`, so it would not run when a doc comment changes, and `build.yml` is the Qt matrix. Its triggers follow `build.yml`/`lint.yml`/`sanitizers.yml` — `branches-ignore [master, wasm]` plus `pull_request` into master — so contributors get feedback on their own branch and the PR is what blocks.

Three implementation notes:

- It substitutes `Doxyfile.in`'s five `@VAR@`s with `sed` instead of configuring CMake, which would pull in the whole Qt toolchain just to lint comments. Runs in ~2s.
- `HAVE_DOT = NO`, since graphs cannot produce these warnings and it avoids a `graphviz` install.
- Doxygen is pinned to the same release and checksum as `site.yml`. `WARN_AS_ERROR` makes behaviour version-sensitive, and an unpinned newer Doxygen could fail master while the pinned site build still passes.

## Verification

- Doxygen completes with **zero** warnings, down from 9.
- The gate exits non-zero once a bogus `\param` is introduced, and returns to zero when reverted.
- The generated `classExerciseTourResources.html` and `classInstallRelativePaths.html` still render the escaped placeholders.
- Build, Sanitizers, Lint and the new API docs workflow all pass on this branch.

## Note for reviewers

`EXTRACT_ALL = YES` plus `WARN_AS_ERROR` means any newly added partially-documented function will now fail CI. That is the intent, but it is a real change in contribution friction. The gate covers only `App/` and `MCP/Server/` (the `INPUT` in `Doxyfile.in`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtKUSuG6Lj9eBbv9SPY8AT