### PR TITLE
fix: fourteen shipped-code defects found while auditing the simulation engine

### DIFF
--- a/App/BeWavedDolphin/BeWavedDolphin.cpp
+++ b/App/BeWavedDolphin/BeWavedDolphin.cpp
@@ -179,6 +179,7 @@ void BewavedDolphin::prepare(const QString &fileName)
     m_inputs     = tableSignals.inputs;
     m_outputs    = tableSignals.outputs;
     m_inputPorts = tableSignals.inputPorts;
+    m_rows       = tableSignals.rows;
 
     qCDebug(zero) << "Loading initial data into the table.";
     loadNewTable(tableSignals.inputLabels, tableSignals.outputLabels);
@@ -299,7 +300,7 @@ void BewavedDolphin::run()
     {
         SignalModel::BulkEditGuard guard(*m_model);
         m_simDriver->sweep(
-            m_inputs, m_outputs, m_inputPorts, m_model->columnCount(),
+            m_rows, m_model->columnCount(),
             [this](int row, int col) { return m_model->value(row, col) != 0; },
             [this](int row, int col, int value) { m_model->setValue(row, col, value); });
     }
@@ -414,8 +415,12 @@ void BewavedDolphin::setCellValue(const int row, const int col, const int value)
 
 int BewavedDolphin::inputRow(const QString &label) const
 {
-    for (int row = 0; row < m_inputs.size(); ++row) {
-        if (m_inputs.at(row)->label() == label) {
+    // Indexes m_rows, not m_inputs: a multi-port input occupies one row PER PORT, so an
+    // element index is not a row index. Matches the per-port row label ("Bus[0]"), which is
+    // also what the table header and snapshot() report, so all three agree on one name.
+    for (int row = 0; row < m_rows.size(); ++row) {
+        const auto &descriptor = m_rows.at(row);
+        if (descriptor.kind == DolphinModelBuilder::RowKind::Input && descriptor.label == label) {
             return row;
         }
     }
@@ -426,27 +431,27 @@ int BewavedDolphin::inputRow(const QString &label) const
 BewavedDolphin::WaveformSnapshot BewavedDolphin::snapshot(const int duration) const
 {
     // Read the computed waveform into a plain DTO so automation consumers (the MCP server)
-    // need neither the live model nor the element vectors. Input rows come first; output
-    // rows follow at the m_inputs.size() offset (mirroring the table's row layout).
+    // need neither the live model nor the element vectors.
+    //
+    // Walks m_rows, which IS the table's row layout, rather than re-deriving it from the
+    // element vectors: a row is one PORT, so an element index is not a row index, and the
+    // first output row is at the input PORT count rather than at m_inputs.size().
     WaveformSnapshot result;
 
-    for (int row = 0; row < m_inputs.size(); ++row) {
+    for (int row = 0; row < m_rows.size(); ++row) {
+        const auto &descriptor = m_rows.at(row);
+
         Signal signal;
-        signal.label = m_inputs.at(row)->label();
+        signal.label = descriptor.label;
         for (int col = 0; col < duration; ++col) {
             signal.values.append(m_model->value(row, col));
         }
-        result.inputs.append(signal);
-    }
 
-    for (int row = 0; row < m_outputs.size(); ++row) {
-        Signal signal;
-        signal.label = m_outputs.at(row)->label();
-        const int outputRowIndex = static_cast<int>(m_inputs.size()) + row;
-        for (int col = 0; col < duration; ++col) {
-            signal.values.append(m_model->value(outputRowIndex, col));
+        if (descriptor.kind == DolphinModelBuilder::RowKind::Input) {
+            result.inputs.append(signal);
+        } else {
+            result.outputs.append(signal);
         }
-        result.outputs.append(signal);
     }
 
     return result;
@@ -507,7 +512,7 @@ void BewavedDolphin::saveToTxt(QTextStream &stream)
     {
         SignalModel::BulkEditGuard guard(truthTable);
         m_simDriver->sweep(
-            m_inputs, m_outputs, m_inputPorts, columns,
+            m_rows, columns,
             [&truthTable](int row, int col) { return truthTable.value(row, col) != 0; },
             [&truthTable](int row, int col, int value) { truthTable.setValue(row, col, value); });
     }

--- a/App/BeWavedDolphin/BeWavedDolphin.h
+++ b/App/BeWavedDolphin/BeWavedDolphin.h
@@ -17,6 +17,7 @@
 #include <QUndoStack>
 
 #include "App/BeWavedDolphin/BeWavedDolphinUI.h"
+#include "App/BeWavedDolphin/DolphinModelBuilder.h"
 #include "App/BeWavedDolphin/SignalDelegate.h"
 #include "App/BeWavedDolphin/SignalModel.h"
 #include "App/Scene/Scene.h"
@@ -260,6 +261,10 @@ private:
     const bool m_askConnection;                       ///< If true, closing consults checkSave()'s save-changes prompt.
     int m_clockPeriod              = 0;               ///< Period used by "Set Clock Wave" (0 = auto).
     int m_inputPorts               = 0;               ///< Number of input ports in the circuit.
+    /// The table's row layout, one entry per row: element, port, side and per-port label.
+    /// Single source of truth shared with the sweep and the snapshot API; see
+    /// DolphinModelBuilder::Row.
+    QVector<DolphinModelBuilder::Row> m_rows;
     int m_length                   = 32;              ///< Number of simulation time-step columns.
     ExerciseOverlay *m_exerciseOverlay = nullptr;     ///< Non-owning; repositioned on resize.
 };

--- a/App/BeWavedDolphin/DolphinExporter.cpp
+++ b/App/BeWavedDolphin/DolphinExporter.cpp
@@ -14,6 +14,7 @@
 #include "App/BeWavedDolphin/SignalDelegate.h"
 #include "App/BeWavedDolphin/SignalModel.h"
 #include "App/Core/Common.h"
+#include "App/Core/Enums.h"
 
 namespace {
 constexpr int kExportCellWidth  = 50;  ///< Per-column pixel width for PNG/PDF export.
@@ -76,12 +77,23 @@ void exportToPdf(const SignalModel *model, const PlotType plotType, const QStrin
     painter.end();
 }
 
+/// One character per cell. The format writes cells with no separator, so every value must be
+/// exactly one character wide -- a raw Status::Unknown (-1) would print as two and silently shift
+/// the column count, making the row unparseable. 'x' and 'E' follow the usual HDL convention for
+/// undefined and conflicting.
+static QChar cellChar(const int value)
+{
+    if (value == static_cast<int>(Status::Unknown)) { return QLatin1Char('x'); }
+    if (value == static_cast<int>(Status::Error))   { return QLatin1Char('E'); }
+    return (value == 0) ? QLatin1Char('0') : QLatin1Char('1');
+}
+
 void writeTruthTableText(QTextStream &out, const SignalModel *model, const int inputRowCount)
 {
     // Write input rows first, then output rows, each followed by its signal label.
     for (int row = 0; row < inputRowCount; ++row) {
         for (int col = 0; col < model->columnCount(); ++col) {
-            out << model->value(row, col);
+            out << cellChar(model->value(row, col));
         }
 
         const auto *header = model->verticalHeaderItem(row);
@@ -92,7 +104,7 @@ void writeTruthTableText(QTextStream &out, const SignalModel *model, const int i
 
     for (int row = inputRowCount; row < model->rowCount(); ++row) {
         for (int col = 0; col < model->columnCount(); ++col) {
-            out << model->value(row, col);
+            out << cellChar(model->value(row, col));
         }
 
         const auto *header = model->verticalHeaderItem(row);

--- a/App/BeWavedDolphin/DolphinModelBuilder.cpp
+++ b/App/BeWavedDolphin/DolphinModelBuilder.cpp
@@ -17,13 +17,13 @@ namespace DolphinModelBuilder {
 
 namespace {
 
-/// Builds per-port row labels for \a elements: the element's label (or its translated type
-/// name when blank), suffixed with "[port]" when the element exposes more than one port.
+/// Appends one Row per PORT of each element in \a elements to \a rows, labelling each with
+/// the element's label (or its translated type name when blank), suffixed with "[port]" when
+/// the element exposes more than one port. This is the only place the table's row layout is
+/// decided; the sweep, the snapshot API and the header labels all read the result.
 template <typename Elements, typename PortCount>
-QStringList buildLabels(const Elements &elements, const PortCount &portCount)
+void appendRows(QVector<Row> &rows, const Elements &elements, const RowKind kind, const PortCount &portCount)
 {
-    QStringList labels;
-
     for (auto *elm : elements) {
         QString label = elm->label();
 
@@ -35,16 +35,23 @@ QStringList buildLabels(const Elements &elements, const PortCount &portCount)
         const int ports = portCount(elm);
         for (int port = 0; port < ports; ++port) {
             // Multi-port elements (e.g. bus inputs, multi-bit displays) get indexed labels
-            if (ports > 1) {
-                labels.append(label + "[" + QString::number(port) + "]");
-            } else {
-                labels.append(label);
-            }
+            const QString rowLabel = (ports > 1) ? label + "[" + QString::number(port) + "]" : label;
+            rows.append(Row{elm, port, kind, rowLabel});
         }
     }
+} // LCOV_EXCL_LINE -- compiler-generated cleanup for an exception path appendRows() never takes (both template instantiations)
 
+/// Projects the labels of every \a kind row out of \a rows, preserving order.
+QStringList labelsOf(const QVector<Row> &rows, const RowKind kind)
+{
+    QStringList labels;
+    for (const auto &row : rows) {
+        if (row.kind == kind) {
+            labels.append(row.label);
+        }
+    }
     return labels;
-} // LCOV_EXCL_LINE -- compiler-generated QStringList cleanup for an exception path buildLabels() never takes (both template instantiations)
+} // LCOV_EXCL_LINE -- compiler-generated QStringList cleanup for an exception path labelsOf() never takes
 
 } // namespace
 
@@ -69,8 +76,6 @@ Signals collect(Scene *scene)
 
         if (elm->elementGroup() == ElementGroup::Input) {
             result.inputs.append(qobject_cast<GraphicElementInput *>(elm));
-            // Multi-bit inputs (e.g. rotary encoder) contribute multiple port rows
-            result.inputPorts += elm->outputSize();
         }
 
         if (elm->elementGroup() == ElementGroup::Output) {
@@ -100,8 +105,16 @@ Signals collect(Scene *scene)
         throw PANDACEPTION_WITH_CONTEXT("BewavedDolphin", "The circuit has no output elements. Add at least one output (e.g. LED or Display) to generate a waveform.");
     }
 
-    result.inputLabels  = buildLabels(result.inputs,  [](const GraphicElementInput *e) { return e->outputSize(); });
-    result.outputLabels = buildLabels(result.outputs, [](const GraphicElement *e) { return e->inputSize(); });
+    // Rows first -- they are the source of truth; the label lists are projections of them.
+    appendRows(result.rows, result.inputs,  RowKind::Input,  [](const GraphicElementInput *e) { return e->outputSize(); });
+    appendRows(result.rows, result.outputs, RowKind::Output, [](const GraphicElement *e) { return e->inputSize(); });
+
+    result.inputLabels  = labelsOf(result.rows, RowKind::Input);
+    result.outputLabels = labelsOf(result.rows, RowKind::Output);
+    // Derived, not accumulated separately: the input rows ARE inputLabels, so counting ports in
+    // the collection loop would be a second computation of the same quantity by different code --
+    // the duplication this row layout exists to remove.
+    result.inputPorts   = static_cast<int>(result.inputLabels.size());
 
     return result;
 }

--- a/App/BeWavedDolphin/DolphinModelBuilder.h
+++ b/App/BeWavedDolphin/DolphinModelBuilder.h
@@ -24,13 +24,38 @@ class Scene;
  */
 namespace DolphinModelBuilder {
 
-/// The input/output elements (label-sorted) and the row labels for a waveform table.
+/// Which side of the table a row belongs to.
+enum class RowKind { Input, Output };
+
+/**
+ * \brief One waveform table row: exactly one PORT of one element.
+ *
+ * \details The table is laid out per port -- a 2-bit rotary input occupies two rows, a
+ * Display7 occupies eight -- so an element index is never a row index. This descriptor is the
+ * single source of truth for that layout: the label builder, the sweep and the snapshot API
+ * all consume it rather than deriving it independently, which is what keeps them from
+ * disagreeing about which row belongs to which port.
+ */
+struct Row {
+    GraphicElement *element = nullptr;  ///< The element this row reads or drives.
+    int port = 0;                       ///< Port index on \a element (output port for an
+                                        ///< input row, input port for an output row).
+    RowKind kind = RowKind::Input;
+    QString label;                      ///< Per-PORT label ("Bus[0]"), never the bare element
+                                        ///< label -- eight Display7 rows must not share one.
+};
+
+/// The input/output elements (label-sorted) and the row layout for a waveform table.
 struct Signals {
     QVector<GraphicElementInput *> inputs;  ///< Input elements, sorted by label.
     QVector<GraphicElement *> outputs;      ///< Output elements, sorted by label.
-    int inputPorts = 0;                     ///< Total input rows (sum of input output-port counts).
+    int inputPorts = 0;                     ///< Total input rows; derived from \a rows.
     QStringList inputLabels;                ///< Row label per input port (indexed for multi-port).
     QStringList outputLabels;               ///< Row label per output port (indexed for multi-port).
+    /// Every table row in display order: all input rows, then all output rows. Derived once,
+    /// here; inputPorts/inputLabels/outputLabels are projections of it, kept for the callers
+    /// that only need the counts or the header strings.
+    QVector<Row> rows;
 };
 
 /// Gathers \a scene's input/output elements, stable-sorts them by label, validates the

--- a/App/BeWavedDolphin/SignalDelegate.cpp
+++ b/App/BeWavedDolphin/SignalDelegate.cpp
@@ -7,12 +7,17 @@
 #include <QStyleOptionViewItem>
 
 #include "App/BeWavedDolphin/SignalModel.h"
+#include "App/Core/Enums.h"
 
 namespace
 {
 // Waveform colors: green for output rows, blue for input rows.
 const QColor kOutputColor(0, 128, 0);        ///< #008000
 const QColor kInputColor(0x75, 0x8e, 0xff);  ///< #758eff
+/// Four-state colours, matching the canvas's wire vocabulary (ThemeManager::m_connectionUnknown
+/// / m_connectionError) so the same signal reads the same way in both views.
+const QColor kUnknownColor(0x9e, 0x9e, 0x9e); ///< grey -- undefined
+const QColor kErrorColor(0xd3, 0x2f, 0x2f);   ///< red  -- conflicting drivers
 
 // Geometry, as fractions of the cell, decoded from the original 100x30 SVGs.
 constexpr double kLineThickness = 4.0 / 30.0;   ///< Horizontal plateau line thickness.
@@ -35,6 +40,18 @@ void SignalDelegate::setPlotType(const PlotType plotType)
 
 WaveSegment SignalDelegate::segmentFor(const int value, const bool hasPrev, const int prevValue)
 {
+    // Cells carry a four-state Status, not a bit: Unknown is -1 and Error is 2. Treating the
+    // cell as "0 is low, everything else is high" would draw an undefined signal as a confident
+    // logic HIGH, while the canvas renders that same signal as a distinct grey wire
+    // (Connection.cpp / theme.m_connectionUnknown). Give them their own segments so the two views
+    // agree -- routinely reachable, since the engine canonicalises oscillating regions to Unknown
+    // and propagates it to every reader.
+    if (value == static_cast<int>(Status::Unknown)) {
+        return WaveSegment::Unknown;
+    }
+    if (value == static_cast<int>(Status::Error)) {
+        return WaveSegment::Error;
+    }
     if (value == 0) {
         return (hasPrev && (prevValue == 1)) ? WaveSegment::Falling : WaveSegment::Low;
     }
@@ -44,14 +61,29 @@ WaveSegment SignalDelegate::segmentFor(const int value, const bool hasPrev, cons
 
 void SignalDelegate::drawWaveform(QPainter *painter, const QRectF &cell, const WaveSegment seg, const bool isInput) const
 {
-    const QColor color = isInput ? kInputColor : kOutputColor;
-    QColor bandColor = color;
-    bandColor.setAlpha(128); // 50% opacity translucent fill
-
     const double x = cell.x();
     const double y = cell.y();
     const double w = cell.width();
     const double h = cell.height();
+
+    // Undefined and conflicting signals get their own rendering rather than being folded into a
+    // plateau: a mid-level bar in the same vocabulary the canvas uses for wires -- grey for
+    // Unknown, red for Error (see Connection.cpp / ThemeManager's m_connectionUnknown and
+    // m_connectionError). Deliberately NOT a high or low plateau: the whole point is that the
+    // value is neither.
+    if ((seg == WaveSegment::Unknown) || (seg == WaveSegment::Error)) {
+        const QColor stateColor = (seg == WaveSegment::Unknown) ? kUnknownColor : kErrorColor;
+        QColor stateBand = stateColor;
+        stateBand.setAlpha(64);
+        painter->fillRect(QRectF(x, y, w, h), stateBand);
+        const double midTop = ((kHighTop + kLowTop) / 2.0) * h;
+        painter->fillRect(QRectF(x, y + midTop, w, kLineThickness * h), stateColor);
+        return;
+    }
+
+    const QColor color = isInput ? kInputColor : kOutputColor;
+    QColor bandColor = color;
+    bandColor.setAlpha(128); // 50% opacity translucent fill
 
     // High plateau for High/Rising, low plateau for Low/Falling.
     const bool high = (seg == WaveSegment::High) || (seg == WaveSegment::Rising);

--- a/App/BeWavedDolphin/SignalDelegate.h
+++ b/App/BeWavedDolphin/SignalDelegate.h
@@ -19,10 +19,12 @@ enum class PlotType {
 
 /// Identifies which waveform segment a Line-mode cell draws.
 enum class WaveSegment {
-    Low,     ///< Logic-low plateau (signal stays at 0).
-    High,    ///< Logic-high plateau (signal stays at 1).
-    Rising,  ///< Low → high transition (high plateau + leading edge).
-    Falling  ///< High → low transition (low plateau + leading edge).
+    Low,      ///< Logic-low plateau (signal stays at 0).
+    High,     ///< Logic-high plateau (signal stays at 1).
+    Rising,   ///< Low → high transition (high plateau + leading edge).
+    Falling,  ///< High → low transition (low plateau + leading edge).
+    Unknown,  ///< Undefined (Status::Unknown): drawn mid-level in the canvas's "unknown" grey.
+    Error     ///< Conflicting drivers (Status::Error): drawn mid-level in the canvas's red.
 };
 
 /**

--- a/App/BeWavedDolphin/WaveformSimulator.cpp
+++ b/App/BeWavedDolphin/WaveformSimulator.cpp
@@ -12,6 +12,7 @@
 #include "App/Simulation/Simulation.h"
 #include "App/Simulation/SimulationBlocker.h"
 #include "App/Simulation/SimulationThrottleDisabler.h"
+#include "App/Wiring/Port.h"
 
 WaveformSimulator::WaveformSimulator(Scene *externalScene, Simulation *simulation)
     : m_externalScene(externalScene)
@@ -45,7 +46,22 @@ void WaveformSimulator::restoreInputs(const QVector<GraphicElementInput *> &inpu
     int portIndex = 0;
     for (auto *input : std::as_const(inputs)) {
         for (int port = 0; port < input->outputSize(); ++port) {
-            const bool oldValue = static_cast<bool>(saved.at(portIndex++));
+            const Status savedStatus = saved.at(portIndex++);
+
+            // A captured Status is four-state, and setOn() only speaks two: Status::Unknown is
+            // -1 and Status::Error is 2, so `static_cast<bool>` would make BOTH true and restore
+            // an undefined port ON -- a sweep turning an undriven input into a driven-high one in
+            // the live circuit. Put a non-definite capture back on the port directly, which is
+            // exactly what captureInputs() read, and leave the element's own on/off state alone:
+            // it was never meaningfully on or off.
+            if (savedStatus != Status::Active && savedStatus != Status::Inactive) {
+                if (auto *outPort = input->outputPort(port)) {
+                    outPort->setStatus(savedStatus);
+                }
+                continue;
+            }
+
+            const bool oldValue = (savedStatus == Status::Active);
             if (input->outputSize() > 1) {
                 // Multi-port inputs (e.g. InputRotary) are one-hot: selecting any port
                 // deselects the others, so calling setOn() for every port in sequence would

--- a/App/BeWavedDolphin/WaveformSimulator.cpp
+++ b/App/BeWavedDolphin/WaveformSimulator.cpp
@@ -5,6 +5,8 @@
 
 #include <utility>
 
+#include <QScopeGuard>
+
 #include "App/Core/Common.h"
 #include "App/Element/GraphicElement.h"
 #include "App/Element/GraphicElementInput.h"
@@ -88,6 +90,27 @@ void WaveformSimulator::sweep(const QVector<DolphinModelBuilder::Row> &rows, con
     // update() call. Without this, output port statuses are stale for most columns and the
     // waveform shows incorrect values.
     SimulationThrottleDisabler throttleDisabler(m_simulation);
+
+    // Snapshot the live circuit before the reset below, and put it back on the way out. The
+    // sweep resets everything so its own results are reproducible, but it is a read-only
+    // QUESTION about the circuit -- without this the canvas would be left holding whatever the
+    // last column produced, so a read-only-looking create_waveform would mutate the user's
+    // flip-flops. Symmetrical with the reset, and it covers the state resetSimState() clears:
+    // outputs plus each sequential element's edge-detection history, recursing through ICs.
+    QVector<Status> liveState;
+    for (auto *elm : m_externalScene->elements()) {
+        if (elm && elm->type() == GraphicElement::Type) {
+            elm->saveSimState(liveState);
+        }
+    }
+    auto restoreLiveState = qScopeGuard([this, &liveState] {
+        int cursor = 0;
+        for (auto *elm : m_externalScene->elements()) {
+            if (elm && elm->type() == GraphicElement::Type) {
+                elm->restoreSimState(liveState, cursor);
+            }
+        }
+    });
 
     // Reset every element's sequential state (Q/~Q outputs, edge-detection variables) to
     // power-on defaults before the sweep so results are reproducible regardless of any

--- a/App/BeWavedDolphin/WaveformSimulator.cpp
+++ b/App/BeWavedDolphin/WaveformSimulator.cpp
@@ -61,9 +61,7 @@ void WaveformSimulator::restoreInputs(const QVector<GraphicElementInput *> &inpu
     }
 }
 
-void WaveformSimulator::sweep(const QVector<GraphicElementInput *> &inputs,
-                              const QVector<GraphicElement *> &outputs,
-                              const int inputPorts, const int columns,
+void WaveformSimulator::sweep(const QVector<DolphinModelBuilder::Row> &rows, const int columns,
                               const std::function<bool(int row, int col)> &readInput,
                               const std::function<void(int row, int col, int value)> &writeOutput) const
 {
@@ -86,14 +84,21 @@ void WaveformSimulator::sweep(const QVector<GraphicElementInput *> &inputs,
     }
 
     // --- Step through each time column and compute circuit outputs ---
+    // A row's index IS its position in `rows`, so the input rows and the output rows are
+    // walked by the same index the model and snapshot() use; there is no separately-computed
+    // offset that could disagree with them.
     for (int column = 0; column < columns; ++column) {
-        qCDebug(four) << "Itr: " << column << ", inputs: " << inputs.size();
-        int row = 0;
+        qCDebug(four) << "Itr: " << column << ", rows: " << rows.size();
 
-        for (auto *input : std::as_const(inputs)) {
-            for (int port = 0; port < input->outputSize(); ++port) {
-                // Each input applies the cell value its own way (e.g. a rotary ignores lows).
-                input->setWaveformValue(readInput(row++, column), port);
+        for (int row = 0; row < rows.size(); ++row) {
+            const auto &descriptor = rows.at(row);
+            if (descriptor.kind != DolphinModelBuilder::RowKind::Input) {
+                continue;
+            }
+            // Each input applies the cell value its own way (e.g. a rotary ignores lows).
+            auto *input = qobject_cast<GraphicElementInput *>(descriptor.element);
+            if (input) {
+                input->setWaveformValue(readInput(row, column), descriptor.port);
             }
         }
 
@@ -102,14 +107,13 @@ void WaveformSimulator::sweep(const QVector<GraphicElementInput *> &inputs,
 
         // Write computed output port states back into the model's output rows
         qCDebug(four) << "Setting the computed output values to the waveform results.";
-        row = inputPorts;
-
-        for (auto *output : std::as_const(outputs)) {
-            for (int port = 0; port < output->inputSize(); ++port) {
-                const int value = static_cast<int>(output->inputPort(port)->status());
-                writeOutput(row, column, value);
-                ++row;
+        for (int row = 0; row < rows.size(); ++row) {
+            const auto &descriptor = rows.at(row);
+            if (descriptor.kind != DolphinModelBuilder::RowKind::Output || !descriptor.element) {
+                continue;
             }
+            const int value = static_cast<int>(descriptor.element->inputPort(descriptor.port)->status());
+            writeOutput(row, column, value);
         }
     }
 }

--- a/App/BeWavedDolphin/WaveformSimulator.h
+++ b/App/BeWavedDolphin/WaveformSimulator.h
@@ -11,6 +11,7 @@
 
 #include <QVector>
 
+#include "App/BeWavedDolphin/DolphinModelBuilder.h"
 #include "App/Core/Enums.h"
 
 class GraphicElement;
@@ -46,19 +47,18 @@ public:
 
     /**
      * \brief Runs the simulation across \a columns time steps.
-     * \param inputs      Input elements, in row order.
-     * \param outputs     Output elements, in row order.
-     * \param inputPorts  Number of input rows (offset of the first output row).
+     * \param rows        The table's row layout, in display order (DolphinModelBuilder::Row).
      * \param columns     Number of time-step columns to sweep.
      * \param readInput   Returns the input bit at (row, col) from the waveform model.
      * \param writeOutput Stores the computed output bit at (row, col) into the model.
      *
-     * \details Resets every element's sequential state before sweeping. Does not restore
-     * inputs — the caller pairs this with restoreInputs().
+     * \details Takes the row descriptors rather than the element vectors plus a row offset:
+     * a row's index, its element and its port all come from one place, so the sweep cannot
+     * drift out of step with the snapshot API (see DolphinModelBuilder::Row).
+     * Resets every element's sequential state before sweeping. Does not restore inputs — the
+     * caller pairs this with restoreInputs().
      */
-    void sweep(const QVector<GraphicElementInput *> &inputs,
-               const QVector<GraphicElement *> &outputs,
-               int inputPorts, int columns,
+    void sweep(const QVector<DolphinModelBuilder::Row> &rows, int columns,
                const std::function<bool(int row, int col)> &readInput,
                const std::function<void(int row, int col, int value)> &writeOutput) const;
 

--- a/App/CodeGen/SystemVerilogCodeGen.cpp
+++ b/App/CodeGen/SystemVerilogCodeGen.cpp
@@ -564,6 +564,17 @@ void SystemVerilogCodeGen::generate()
 
     generateICModules();
 
+    // Feedback detection for the TOP-LEVEL netlist. generateSingleICModule() sets
+    // m_feedbackElements for the IC it is emitting and clears it again on the way out, so
+    // without this the set would be empty by the time declareAuxVariables() runs and no
+    // top-level element could be recognised as a loop member. A feedback circuit drawn directly
+    // on the canvas -- a cross-coupled NAND latch, say -- would then be emitted as plain `wire`
+    // + `assign`, and otherPortNameImpl()'s cycle guard would substitute 1'b0 for the feedback
+    // edge, since top-level gates are inlined and have no m_varMap entry. That is worse than an
+    // x-locking comb loop: a silently constant-folded expression with the memory removed, which
+    // simulates cleanly and computes the wrong function.
+    m_feedbackElements = findFeedbackElements(m_elements);
+
     // Top-level module
     m_stream << "module " << m_fileName << " (" << Qt::endl;
     // Declare input and output pins
@@ -718,7 +729,15 @@ void SystemVerilogCodeGen::declareAuxVariablesRec(const QVector<GraphicElement *
             // Skip wire declarations for top-level logic gates (their expressions
             // are inlined). Inside IC modules (m_generatingICModule), declare wires so that
             // feedback loops produce proper circular assign references instead of 1'b0.
-            if (!m_generatingICModule &&
+            //
+            // A top-level FEEDBACK member is the exception, for exactly the reason that comment
+            // gives. Inlining walks otherPortNameImpl(), whose cycle guard returns 1'b0 when the
+            // revisited port has no m_varMap entry -- and skipping the declaration is what would
+            // leave it without one, yielding not an x-locking comb loop but a silently
+            // constant-folded expression: a canvas-drawn cross-coupled NAND latch with its memory
+            // removed. Declaring it lets the seeded `reg` + `always @(*)` path below treat it the
+            // same way an IC-internal loop is already treated.
+            if (!m_generatingICModule && !m_feedbackElements.contains(elm) &&
                 (type == ElementType::And ||
                  type == ElementType::Or ||
                  type == ElementType::Nand ||
@@ -995,10 +1014,16 @@ void SystemVerilogCodeGen::assignVariablesRec(const QVector<GraphicElement *> &e
             elm->elementType() == ElementType::Node) {
 
             QString expr = generateLogicExpression(elm);
+            const bool isFeedback = m_feedbackElements.contains(elm);
             for (auto *port : elm->outputs()) {
                 QString existingVar = m_varMap.value(port);
-                if (!existingVar.isEmpty() && m_generatingICModule) {
-                    const bool isFeedback = m_feedbackElements.contains(elm);
+                // Emit an assignment whenever this port actually HAS a declared variable --
+                // inside an IC module, or at top level when the element is a feedback member and
+                // declareAuxVariablesRec() therefore gave it a seeded reg. Gating on
+                // m_generatingICModule alone would send top-level feedback gates down the inline
+                // branch below, overwriting the declared name with an expression and leaving the
+                // reg at its seed forever.
+                if (!existingVar.isEmpty() && (m_generatingICModule || isFeedback)) {
                     if (isFeedback) {
                         // Cross-coupled feedback node: drive the seeded `reg`
                         // combinationally so the loop settles (vs. a comb-loop

--- a/App/CodeGen/SystemVerilogCodeGen.cpp
+++ b/App/CodeGen/SystemVerilogCodeGen.cpp
@@ -64,7 +64,26 @@ SystemVerilogCodeGen::SystemVerilogCodeGen(const QString &fileName, const QVecto
 
 QString SystemVerilogCodeGen::highLow(const Status val)
 {
+    // POWER-ON-SAFE, deliberately two-state: a non-definite status becomes 1'b0. This mirrors
+    // ElementSimState::reset(), which coerces an Unknown power-on default to Inactive, so the
+    // generated module starts where the engine starts -- which is what the iverilog differential
+    // compares. It is also what keeps a seeded feedback `reg` from x-locking instead of settling.
+    // For a value that must stay undefined, use fourState() below.
     return (val == Status::Active) ? "1'b1" : "1'b0";
+}
+
+QString SystemVerilogCodeGen::fourState(const Status val)
+{
+    // SystemVerilog is four-state, so unlike every other place a Status meets something narrower,
+    // nothing here forces a collapse. Used where Unknown genuinely means "nothing drives this" --
+    // an unconnected input's default, whose Unknown the engine propagates as Unknown (only
+    // reset() coerces, and only at power-on). Emitting 1'b0 there would export a disconnected
+    // input as a confident logic 0.
+    switch (val) {
+    case Status::Active:   return "1'b1";
+    case Status::Inactive: return "1'b0";
+    default:               return "1'bx"; // Unknown and Error alike are "not a known level"
+    }
 }
 
 // [QUALITY-14] Ensures result is a valid SystemVerilog identifier (starts with letter/underscore, non-empty)
@@ -121,11 +140,11 @@ QString SystemVerilogCodeGen::otherPortNameImpl(Port *port, QSet<Port *> &visite
                 return otherPortNameImpl(txInputPort, visited);
             }
         }
-        return highLow(port->defaultValue());
+        return fourState(port->defaultValue());
     }
 
     auto *otherPort = port->connections().constFirst()->otherPort(port);
-    if (!otherPort) return highLow(port->defaultValue());
+    if (!otherPort) return fourState(port->defaultValue());
 
     // Cycle detection: if we've already visited the connected port, don't inline.
     // Unreachable given this app's wiring model: every Connection joins one
@@ -149,7 +168,7 @@ QString SystemVerilogCodeGen::otherPortNameImpl(Port *port, QSet<Port *> &visite
     // into a Connection — a connected port's graphicElement() is never null.
     if (!elm) {
         QString mapped = m_varMap.value(otherPort); // LCOV_EXCL_LINE
-        return mapped.isEmpty() ? highLow(port->defaultValue()) : mapped; // LCOV_EXCL_LINE
+        return mapped.isEmpty() ? fourState(port->defaultValue()) : mapped; // LCOV_EXCL_LINE
     } // LCOV_EXCL_LINE
 
     // Check m_varMap first — if a wire/variable was declared for this port, use it
@@ -1467,7 +1486,7 @@ void SystemVerilogCodeGen::loop()
         // Unreachable: otherPortName() never returns an empty string (see its own
         // documented exclusions above).
         if (expr.isEmpty()) {
-            expr = highLow(pin.m_port->defaultValue()); // LCOV_EXCL_LINE
+            expr = fourState(pin.m_port->defaultValue()); // LCOV_EXCL_LINE
         }
         m_stream << QString("assign %1 = %2;").arg(pin.m_varName, expr) << Qt::endl;
     }

--- a/App/CodeGen/SystemVerilogCodeGen.h
+++ b/App/CodeGen/SystemVerilogCodeGen.h
@@ -100,6 +100,10 @@ private:
 
     /// Returns "1'b1" or "1'b0" for Active/Inactive status values.
     static QString highLow(Status val);
+
+    /// Four-state literal for a value that must stay undefined (1'bx for Unknown/Error).
+    /// Contrast highLow(), which is deliberately power-on-safe.
+    static QString fourState(Status val);
     /// Strips characters that are illegal in SystemVerilog identifiers.
     static QString removeForbiddenChars(const QString &input);
     /// Returns \c true if \a expr is already a simple identifier (no operators).

--- a/App/Core/InstallRelativePaths.cpp
+++ b/App/Core/InstallRelativePaths.cpp
@@ -28,6 +28,28 @@ QStringList InstallRelativePaths::candidates(const QString &category)
     return result;
 }
 
+bool InstallRelativePaths::isCandidate(const QString &category, const QString &directory)
+{
+    // canonicalPath() resolves "..", symlinks and CWD-relative entries to one comparable
+    // form, and returns "" for a path that doesn't exist -- which is also the right answer
+    // here, since a directory that isn't there can't be the bundled content directory.
+    const QString target = QDir(directory).canonicalPath();
+    if (target.isEmpty()) {
+        return false;
+    }
+
+    const auto candidateDirs = candidates(category);
+    for (const QString &candidate : candidateDirs) {
+        if (candidate.isEmpty()) {
+            continue;
+        }
+        if (QDir(candidate).canonicalPath() == target) {
+            return true;
+        }
+    }
+    return false;
+}
+
 QString InstallRelativePaths::resolve(const QString &category)
 {
     for (const QString &candidate : candidates(category)) {

--- a/App/Core/InstallRelativePaths.h
+++ b/App/Core/InstallRelativePaths.h
@@ -31,6 +31,14 @@ public:
     /// filesystem, and finally a bare-category CWD fallback for development.
     static QStringList candidates(const QString &category);
 
+    /// True if \a directory is one of the candidates() entries for \a category, compared by
+    /// canonical path so ".."-relative and CWD-relative candidates match correctly. Used to
+    /// recognise bundled/installed content directories that must not be written into even when
+    /// the filesystem would permit it (a dev checkout's Examples/ is writable, an installed
+    /// one usually isn't). Read-only — creates nothing; a directory that doesn't exist is
+    /// never a candidate.
+    static bool isCandidate(const QString &category, const QString &directory);
+
     /// Returns the first candidate() entry that already exists on disk, or "" if none do.
     /// Read-only — creates nothing.
     static QString resolve(const QString &category);

--- a/App/Core/Priorities.h
+++ b/App/Core/Priorities.h
@@ -187,7 +187,7 @@ void legacyCalculatePriorities(
             // intentional: it gives feedback-loop nodes a *lower* priority
             // (based only on already-computed successors) so the simulation
             // processes them *after* their non-cyclic inputs.  Because
-            // LogicElement::updateLogic() reads live predecessor outputs,
+            // GraphicElement::updateLogic() reads live predecessor outputs,
             // processing feedback nodes late ensures they see fresh values
             // from the current iteration rather than stale ones.
             if (allProcessed || hasFeedbackLoop) {

--- a/App/Element/GraphicElement.cpp
+++ b/App/Element/GraphicElement.cpp
@@ -737,6 +737,23 @@ void GraphicElement::resetSimState()
     m_sim.reset(m_ports.outputs());
 }
 
+void GraphicElement::saveSimState(QVector<Status> &out) const
+{
+    for (int i = 0; i < static_cast<int>(m_sim.outputSize()); ++i) {
+        out.append(m_sim.outputValue(i));
+    }
+}
+
+void GraphicElement::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    for (int i = 0; i < static_cast<int>(m_sim.outputSize()); ++i) {
+        if (cursor >= in.size()) {
+            return; // LCOV_EXCL_LINE -- save/restore are always paired over the same element set
+        }
+        m_sim.setOutputValue(i, in.at(cursor++));
+    }
+}
+
 void GraphicElement::connectPredecessor(const int inputIndex, GraphicElement *source, const int outputPort)
 {
     m_sim.connectPredecessor(inputIndex, source, outputPort);

--- a/App/Element/GraphicElement.h
+++ b/App/Element/GraphicElement.h
@@ -398,6 +398,21 @@ public:
      */
     virtual void resettleCombinational() { updateLogic(); }
 
+    /**
+     * \brief Appends this element's full simulation state to \a out.
+     * \details The exact counterpart of resetSimState(): whatever a subclass clears there, it
+     * must save here and put back in restoreSimState(). The base handles the output values;
+     * sequential elements add their edge-detection history, and IC recurses into its internals.
+     * Used to make a BeWavedDolphin sweep state-neutral for the live circuit -- the sweep resets
+     * everything so its own results are reproducible, and must hand the user's circuit back
+     * exactly as it found it.
+     */
+    virtual void saveSimState(QVector<Status> &out) const;
+
+    /// Restores what saveSimState() wrote, reading from \a in at \a cursor and advancing it.
+    /// The read order must mirror the write order exactly.
+    virtual void restoreSimState(const QVector<Status> &in, int &cursor);
+
     /// Returns the four-state signal value on simulation output port \a index.
     inline Status outputValue(const int index = 0) const { return m_sim.outputValue(index); }
 

--- a/App/Element/GraphicElements/Clock.cpp
+++ b/App/Element/GraphicElements/Clock.cpp
@@ -231,6 +231,16 @@ void Clock::resetClock(std::chrono::steady_clock::time_point globalTime)
     m_startTime -= std::chrono::microseconds(delayMicroseconds);
 }
 
+void Clock::shiftClock(std::chrono::steady_clock::duration pause)
+{
+    // Resume-after-pause: the wall clock advanced by `pause` while the simulation was
+    // stopped, so move the phase reference forward by the same amount. updateClock() then
+    // sees the same elapsed-within-interval it saw at the moment of the pause — the output
+    // level is untouched (no forced HIGH, no injected edge) and no missed toggles fire in
+    // a burst.
+    m_startTime += pause;
+}
+
 QString Clock::genericProperties()
 {
     return QString::number(frequency()) + " Hz";

--- a/App/Element/GraphicElements/Clock.h
+++ b/App/Element/GraphicElements/Clock.h
@@ -77,6 +77,11 @@ public:
 
     /// Resets the clock phase reference to \a globalTime.
     void resetClock(std::chrono::steady_clock::time_point globalTime);
+    /// Shifts the clock phase reference forward by \a pause, preserving the current output
+    /// level and the position within the period. Used to resume after a pause: unlike
+    /// resetClock(), which forces the output HIGH and restarts the phase, this keeps the
+    /// waveform exactly where it stopped while still preventing a burst of missed toggles.
+    void shiftClock(std::chrono::steady_clock::duration pause);
     /// Advances the clock state based on elapsed time since \a globalTime.
     void updateClock(std::chrono::steady_clock::time_point globalTime);
 

--- a/App/Element/GraphicElements/DFlipFlop.cpp
+++ b/App/Element/GraphicElements/DFlipFlop.cpp
@@ -117,3 +117,19 @@ void DFlipFlop::resetSimState()
     m_simLastClk   = Status::Inactive;
     m_simLastValue = Status::Active;
 }
+
+void DFlipFlop::saveSimState(QVector<Status> &out) const
+{
+    // Mirrors resetSimState(): the outputs via the base, then the edge-detection history, in a
+    // fixed order that restoreSimState() reads back identically.
+    GraphicElement::saveSimState(out);
+    out.append(m_simLastClk);
+    out.append(m_simLastValue);
+}
+
+void DFlipFlop::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+    if (cursor < in.size()) { m_simLastClk = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastValue = in.at(cursor++); }
+}

--- a/App/Element/GraphicElements/DFlipFlop.h
+++ b/App/Element/GraphicElements/DFlipFlop.h
@@ -44,6 +44,10 @@ public:
 
     /// Resets Q/~Q outputs and edge-detection state to power-on defaults.
     void resetSimState() override;
+    /// \reimp Adds the edge-detection history to the base class's output values.
+    void saveSimState(QVector<Status> &out) const override;
+    /// \reimp
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
 private:
     Status m_simLastClk = Status::Inactive;
     Status m_simLastValue = Status::Active;

--- a/App/Element/GraphicElements/InputRotary.cpp
+++ b/App/Element/GraphicElements/InputRotary.cpp
@@ -268,6 +268,29 @@ void InputRotary::setOn(const bool value, const int port)
     }
 }
 
+void InputRotary::resetSimState()
+{
+    GraphicElement::resetSimState();
+    m_currentPort = 0;
+}
+
+void InputRotary::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+
+    // The base restores the one-hot output values, but isOn() answers from m_currentPort and
+    // GraphicElementInput::updateOutputs() pushes that onto the outputs on the very next tick --
+    // so without this the restore is undone before anything reads it. Derive the selection back
+    // out of the outputs rather than smuggling an int through a QVector<Status>, whose enum has
+    // no fixed underlying type and no room for a port index.
+    for (int i = 0; i < outputSize(); ++i) {
+        if (GraphicElement::outputValue(i) == Status::Active) {
+            m_currentPort = i;
+            break;
+        }
+    }
+}
+
 void InputRotary::setWaveformValue(const bool value, const int port)
 {
     // Only a high cell selects this port; a low cell is implicit (writing it would wrongly

--- a/App/Element/GraphicElements/InputRotary.h
+++ b/App/Element/GraphicElements/InputRotary.h
@@ -52,6 +52,17 @@ public:
      */
     void setOn(const bool value, const int port = 0) override;
 
+    /// \reimp Also returns the selection to port 0. m_currentPort is the rotary's own
+    /// simulation state -- isOn() reads it and updateOutputs() republishes it every tick -- so
+    /// without this a BeWavedDolphin sweep inherits whatever position the user last left on the
+    /// canvas, and its "reset for reproducibility" pass has no effect on this element.
+    void resetSimState() override;
+
+    /// \reimp Recovers the selection from the restored one-hot outputs. The base class already
+    /// saves and restores those; what it cannot know is that they are republished from
+    /// m_currentPort on the next tick, which would overwrite them.
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
+
     /// \reimp A rotary selects exactly one active port, so a low cell is implicit: only a
     /// high \a value writes (selecting \a port); a low one is a no-op.
     void setWaveformValue(const bool value, const int port = 0) override;

--- a/App/Element/GraphicElements/JKFlipFlop.cpp
+++ b/App/Element/GraphicElements/JKFlipFlop.cpp
@@ -128,3 +128,21 @@ void JKFlipFlop::resetSimState()
     m_simLastJ   = Status::Active;
     m_simLastK   = Status::Active;
 }
+
+void JKFlipFlop::saveSimState(QVector<Status> &out) const
+{
+    // Mirrors resetSimState(): the outputs via the base, then the edge-detection history, in a
+    // fixed order that restoreSimState() reads back identically.
+    GraphicElement::saveSimState(out);
+    out.append(m_simLastClk);
+    out.append(m_simLastJ);
+    out.append(m_simLastK);
+}
+
+void JKFlipFlop::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+    if (cursor < in.size()) { m_simLastClk = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastJ = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastK = in.at(cursor++); }
+}

--- a/App/Element/GraphicElements/JKFlipFlop.h
+++ b/App/Element/GraphicElements/JKFlipFlop.h
@@ -43,6 +43,10 @@ public:
     void updateLogic() override;
     /// Resets Q/~Q outputs and edge-detection state to power-on defaults.
     void resetSimState() override;
+    /// \reimp Adds the edge-detection history to the base class's output values.
+    void saveSimState(QVector<Status> &out) const override;
+    /// \reimp
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
 private:
     Status m_simLastClk = Status::Inactive;
     Status m_simLastJ = Status::Active;

--- a/App/Element/GraphicElements/SRFlipFlop.cpp
+++ b/App/Element/GraphicElements/SRFlipFlop.cpp
@@ -125,3 +125,21 @@ void SRFlipFlop::resetSimState()
     m_simLastS   = Status::Inactive;
     m_simLastR   = Status::Inactive;
 }
+
+void SRFlipFlop::saveSimState(QVector<Status> &out) const
+{
+    // Mirrors resetSimState(): the outputs via the base, then the edge-detection history, in a
+    // fixed order that restoreSimState() reads back identically.
+    GraphicElement::saveSimState(out);
+    out.append(m_simLastClk);
+    out.append(m_simLastS);
+    out.append(m_simLastR);
+}
+
+void SRFlipFlop::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+    if (cursor < in.size()) { m_simLastClk = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastS = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastR = in.at(cursor++); }
+}

--- a/App/Element/GraphicElements/SRFlipFlop.h
+++ b/App/Element/GraphicElements/SRFlipFlop.h
@@ -43,6 +43,10 @@ public:
     void updateLogic() override;
     /// Resets Q/~Q outputs and edge-detection state to power-on defaults.
     void resetSimState() override;
+    /// \reimp Adds the edge-detection history to the base class's output values.
+    void saveSimState(QVector<Status> &out) const override;
+    /// \reimp
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
 private:
     Status m_simLastClk = Status::Inactive;
     Status m_simLastS = Status::Inactive;

--- a/App/Element/GraphicElements/TFlipFlop.cpp
+++ b/App/Element/GraphicElements/TFlipFlop.cpp
@@ -114,3 +114,19 @@ void TFlipFlop::resetSimState()
     m_simLastClk   = Status::Inactive;
     m_simLastValue = Status::Active;
 }
+
+void TFlipFlop::saveSimState(QVector<Status> &out) const
+{
+    // Mirrors resetSimState(): the outputs via the base, then the edge-detection history, in a
+    // fixed order that restoreSimState() reads back identically.
+    GraphicElement::saveSimState(out);
+    out.append(m_simLastClk);
+    out.append(m_simLastValue);
+}
+
+void TFlipFlop::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+    if (cursor < in.size()) { m_simLastClk = in.at(cursor++); }
+    if (cursor < in.size()) { m_simLastValue = in.at(cursor++); }
+}

--- a/App/Element/GraphicElements/TFlipFlop.h
+++ b/App/Element/GraphicElements/TFlipFlop.h
@@ -43,6 +43,10 @@ public:
     void updateLogic() override;
     /// Resets Q/~Q outputs and edge-detection state to power-on defaults.
     void resetSimState() override;
+    /// \reimp Adds the edge-detection history to the base class's output values.
+    void saveSimState(QVector<Status> &out) const override;
+    /// \reimp
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
 private:
     Status m_simLastClk = Status::Inactive;
     Status m_simLastValue = Status::Active;

--- a/App/Element/GraphicElements/TruthTable.cpp
+++ b/App/Element/GraphicElements/TruthTable.cpp
@@ -49,13 +49,31 @@ struct ElementInfo<TruthTable> {
     }();
 };
 
+namespace {
+
+/// Rows in a full table: the row index is the inputs read MSB-first, so an element wired to the
+/// maximum number of inputs addresses 2^maxInputSize of them.
+constexpr qsizetype kTruthTableRows = qsizetype{1} << ElementInfo<TruthTable>::constraints.maxInputSize;
+
+/// Bits in m_key: one per (output column, row). updateLogic() indexes kTruthTableRows * output
+/// + row, so the largest index it can form is exactly this minus one -- the array has ZERO
+/// slack, and derived constants are what keep that true if the port limits ever move.
+constexpr qsizetype kTruthTableKeyBits = kTruthTableRows * ElementInfo<TruthTable>::constraints.maxOutputSize;
+
+static_assert(kTruthTableKeyBits == 2048,
+              "The .panda format stores this QBitArray verbatim and setkey() resizes every loaded "
+              "key to it, so the size is part of the file format. Raising maxInputSize or "
+              "maxOutputSize silently changes what is written and what older files decode to -- "
+              "handle it as a format change, not a constant edit.");
+
+} // namespace
+
 TruthTable::TruthTable(QGraphicsItem *parent)
     : GraphicElement(ElementType::TruthTable, parent)
 {
-    // 2048 bits = 256 rows × 8 output columns (max: 8 inputs × 8 outputs).
-    // Laid out as [row0_out0, row0_out1, ..., row0_out7, row1_out0, ...].
+    // Laid out as [out0_row0..out0_rowN, out1_row0..out1_rowN, ...].
     // All outputs default to 0 (all-false table).
-    m_key.resize(2048);
+    m_key.resize(kTruthTableKeyBits);
     m_key.fill(0);
     TruthTable::updatePortsProperties();
 }
@@ -221,11 +239,11 @@ QBitArray &TruthTable::key()
 void TruthTable::setkey(const QBitArray &key)
 {
     m_key = key;
-    // updateLogic() indexes the key at 256*output + row (up to bit 2047) and
-    // ToggleTruthTableOutputCommand toggles bits in place, so the key must
-    // hold exactly 2048 bits regardless of what a (possibly corrupt or
-    // crafted) .panda file supplied — resize pads with zeros or truncates.
-    m_key.resize(2048);
+    // updateLogic() indexes the key at kTruthTableRows*output + row (up to the last bit) and
+    // ToggleTruthTableOutputCommand toggles bits in place, so the key must hold exactly
+    // kTruthTableKeyBits bits regardless of what a (possibly corrupt or crafted) .panda file
+    // supplied — resize pads with zeros or truncates.
+    m_key.resize(kTruthTableKeyBits);
 }
 
 void TruthTable::save(QDataStream &stream, SerializationOptions options) const
@@ -275,7 +293,7 @@ void TruthTable::updateLogic()
     }
 
     for (int i = 0; i < outputSize(); ++i) {
-        const bool result = m_key.at(static_cast<qsizetype>(256 * i) + static_cast<qsizetype>(pos));
+        const bool result = m_key.at(kTruthTableRows * i + static_cast<qsizetype>(pos));
         setOutputValue(i, result);
     }
 }

--- a/App/Element/IC.cpp
+++ b/App/Element/IC.cpp
@@ -356,6 +356,28 @@ void IC::resettleCombinational()
     ICSimulation::resettle(*this);
 }
 
+void IC::saveSimState(QVector<Status> &out) const
+{
+    // Same reason resetSimState() recurses: the IC is only structure, but its internal
+    // primitives are simulated directly by the flat netlist and hold the sequential state.
+    GraphicElement::saveSimState(out);
+    for (auto *internal : std::as_const(m_internalElements)) {
+        if (internal) {
+            internal->saveSimState(out);
+        }
+    }
+}
+
+void IC::restoreSimState(const QVector<Status> &in, int &cursor)
+{
+    GraphicElement::restoreSimState(in, cursor);
+    for (auto *internal : std::as_const(m_internalElements)) {
+        if (internal) {
+            internal->restoreSimState(in, cursor);
+        }
+    }
+}
+
 void IC::refresh()
 {
 }

--- a/App/Element/IC.h
+++ b/App/Element/IC.h
@@ -117,6 +117,11 @@ public:
     /// Builds the internal simulation graph (connection graph + sort) for direct simulation.
     void initializeSimulation();
 
+    /// \reimp Saves/restores every internal primitive's state too (recursively through nested
+    /// ICs), so a BeWavedDolphin sweep hands the live circuit back exactly as it found it.
+    void saveSimState(QVector<Status> &out) const override;
+    void restoreSimState(const QVector<Status> &in, int &cursor) override;
+
     /// \reimp
     QRectF boundingRect() const override;
     /// \reimp

--- a/App/Scene/Commands.cpp
+++ b/App/Scene/Commands.cpp
@@ -1069,8 +1069,8 @@ void ToggleTruthTableOutputCommand::redo()
 
     if (!truthtable) throw PANDACEPTION("Could not find truthtable element!");
 
-    // The key holds exactly 2048 bits (256 rows × 8 outputs); toggleBit on
-    // any other position is an out-of-bounds write. This command is the model
+    // The key holds a fixed number of bits, derived from the element's port limits in
+    // TruthTable.cpp; toggleBit outside it is an out-of-bounds write. This command is the model
     // boundary shared by the UI and the MCP server, and undo() == redo(), so
     // the bound is enforced here regardless of caller.
     if (m_pos < 0 || m_pos >= truthtable->key().size()) {

--- a/App/Scene/Workspace.cpp
+++ b/App/Scene/Workspace.cpp
@@ -14,6 +14,7 @@
 
 #include "App/Core/Application.h"
 #include "App/Core/Common.h"
+#include "App/Core/InstallRelativePaths.h"
 #include "App/Core/SentryHelpers.h"
 #include "App/Core/Settings.h"
 #include "App/Element/GraphicElement.h"
@@ -669,18 +670,28 @@ void WorkSpace::autosave()
 
     qCDebug(three) << "Undo is !clean. Must set autosave file.";
 
-    // Choose the directory to write into, mirroring the pre-existing policy:
-    // unsaved projects go to the global autosaves dir, saved projects go next
-    // to their .panda file unless that directory is read-only.
+    // Choose the directory to write into: unsaved projects go to the global
+    // autosaves dir, saved projects go next
+    // to their .panda file unless that directory is read-only OR is the bundled
+    // Examples directory. Writing beside the file is deliberate (an autosave stays
+    // with the project it protects), but the bundled examples are shipped content,
+    // not the user's project: an installed copy is usually read-only and already
+    // took the fallback, while a dev checkout's Examples/ is writable and would
+    // otherwise accumulate hidden .<name>.<uuid>.panda files that .gitignore
+    // explicitly un-ignores. Recovery reads absolute paths out of
+    // Settings::autosaveFiles(), so relocating the file changes nothing for it.
     QDir path;
+    const QString globalAutosaves =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/autosaves";
     if (m_fileInfo.fileName().isEmpty()) {
-        path.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/autosaves");
+        path.setPath(globalAutosaves);
     } else {
-        const QFileInfo dirInfo(m_fileInfo.absolutePath());
-        if (dirInfo.isWritable()) {
-            path.setPath(m_fileInfo.absolutePath());
+        const QString projectDir = m_fileInfo.absolutePath();
+        const QFileInfo dirInfo(projectDir);
+        if (dirInfo.isWritable() && !InstallRelativePaths::isCandidate(QStringLiteral("Examples"), projectDir)) {
+            path.setPath(projectDir);
         } else {
-            path.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/autosaves");
+            path.setPath(globalAutosaves);
         }
     }
     if (!path.exists()) {

--- a/App/Simulation/Simulation.cpp
+++ b/App/Simulation/Simulation.cpp
@@ -320,6 +320,12 @@ bool Simulation::isInFeedbackLoop(const GraphicElement *element) const
 
 void Simulation::stop()
 {
+    // Record when the pause began (only when actually running) so start() can shift the
+    // clocks' phase reference by the pause duration instead of resetting them.
+    if (m_timer.isActive()) {
+        m_pausedAt = std::chrono::steady_clock::now();
+        m_hasPausedAt = true;
+    }
     m_timer.stop();
     if (m_host) {
         m_host->setMuted(true);
@@ -332,9 +338,26 @@ void Simulation::start()
 
     if (!m_initialized) {
         initialize();
+    } else if (m_hasPausedAt) {
+        // Resuming after a stop(): the wall clock advanced while paused, so shift each
+        // clock's phase reference by the pause duration. This prevents the burst of missed
+        // toggles a stale reference would cause, WITHOUT resetting the clocks — resetClock()
+        // forces the output HIGH and restarts the phase, which would feed a spurious rising
+        // edge into every clock-driven circuit on each SimulationBlocker cycle (every
+        // UpdateCommand redo/undo, including a plain InputSwitch click). Level and phase
+        // survive any pause/resume; only initialize() (Restart, rebuilds) gives clocks a
+        // fresh HIGH start via resetClock().
+        const auto pause = std::chrono::steady_clock::now() - m_pausedAt;
+        for (auto *clock : std::as_const(m_clocks)) {
+            if (clock) {
+                clock->shiftClock(pause);
+            }
+        }
+        m_hasPausedAt = false; // consumed; a repeated start() must not double-shift
     } else {
-        // After a pause the wall clock has advanced, so clocks must be reset
-        // to "now" — otherwise they would fire many missed ticks immediately.
+        // Initialized but with no recorded pause (e.g. initialize() ran directly via a
+        // structural edit while stopped): the clocks' references are stale by an unknown
+        // amount, so reset them to now.
         const auto globalTime = std::chrono::steady_clock::now();
         for (auto *clock : std::as_const(m_clocks)) {
             if (clock) {
@@ -451,6 +474,10 @@ bool Simulation::initialize()
     }
 
     qCDebug(zero) << "Elements read: " << elements.size();
+
+    // Every clock was just reset to "now" above, so any pause recorded by stop() is stale —
+    // a later start() must not additionally shift the fresh references by the old pause.
+    m_hasPausedAt = false;
 
     if (elements.empty()) {
         return false;

--- a/App/Simulation/Simulation.cpp
+++ b/App/Simulation/Simulation.cpp
@@ -28,7 +28,16 @@ Simulation::Simulation(SimulationHost *host, QObject *parent)
     // 1ms tick drives the simulation at ~1000 steps/second — fast enough for
     // human perception while keeping CPU load predictable.
     m_timer.setInterval(1ms);
-    connect(&m_timer, &QTimer::timeout, this, &Simulation::update);
+    // Guarded at the CONNECTION, not inside update(): update() is also public API called
+    // directly (BeWavedDolphin's sweep, MCP, tests), and those callers must keep seeing an
+    // exception rather than a silently swallowed tick. Only the timer-driven invocation
+    // crosses Qt's signal-slot dispatch, which is where throwing is undefined behaviour --
+    // on macOS the unwinder reaches std::terminate mid-stack and Application::notify's
+    // backstop never runs (see Application::guardedSlot). update() runs arbitrary
+    // updateLogic() code 1000x/s, so it is exactly the kind of body that doc means.
+    connect(&m_timer, &QTimer::timeout, this, [this] {
+        Application::guardedSlot(this, [this] { update(); });
+    });
 
     // Derive the visual refresh interval from the monitor's refresh rate so
     // we match the display without wasting repaints.  Falls back to 60 Hz.

--- a/App/Simulation/Simulation.h
+++ b/App/Simulation/Simulation.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include <QGraphicsItem>
@@ -161,6 +162,12 @@ private:
     // --- Members: Timer & element lists ---
 
     QTimer m_timer;
+    /// When stop() paused a running simulation. start() shifts each clock's phase
+    /// reference by the elapsed pause instead of resetting it, so a pause/resume cycle
+    /// (SimulationBlocker around every UpdateCommand, or the user's Play toggle) neither
+    /// injects a spurious clock edge nor loses the phase. Invalidated by initialize().
+    std::chrono::steady_clock::time_point m_pausedAt;
+    bool m_hasPausedAt = false;
     QVector<Clock *> m_clocks;
     QVector<GraphicElement *> m_outputs;
     QVector<GraphicElementInput *> m_inputs;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,14 +491,31 @@ if(EMSCRIPTEN)
     )
 endif()
 
-# Copy JSON schema to executable directory after build
-add_custom_command(TARGET wiredpanda POST_BUILD
+# Copy the JSON schema next to the executables, keyed on the schema itself.
+#
+# DEPENDS on the source rather than POST_BUILD on each target: a POST_BUILD command runs only
+# when that target relinks, so editing ONLY the schema would leave a stale copy beside the
+# executable and the MCP server validating against the old contract -- which presents as a
+# baffling "additional property is invalid" error naming a property the checked-in schema
+# plainly allows. Keyed this way, the copy reruns whenever the schema changes and never
+# otherwise.
+# The destination must be $<TARGET_FILE_DIR:wiredpanda>, not the binary directory: with
+# MACOSX_BUNDLE the executable lives in wiredpanda.app/Contents/MacOS/, and MCPProcessor
+# resolves the schema from QCoreApplication::applicationDirPath(). A target generator
+# expression cannot appear in OUTPUT (the path must resolve without a target), so the
+# destination is formed in COMMAND and a stamp file carries the up-to-date check. Naming the
+# target in COMMAND also orders this after the link, so the bundle directory exists.
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp.stamp
     COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/MCP/schema-mcp.json
         $<TARGET_FILE_DIR:wiredpanda>/schema-mcp.json
-    COMMENT "Copying JSON schema to executable directory"
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp.stamp
+    DEPENDS ${CMAKE_SOURCE_DIR}/MCP/schema-mcp.json
+    COMMENT "Copying JSON schema next to the wiredpanda executable"
     VERBATIM
 )
+add_custom_target(copy_mcp_schema ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp.stamp)
 
 # Copy WASM support files and patch the HTML shell
 if(EMSCRIPTEN)
@@ -678,14 +695,18 @@ target_compile_definitions(test_wiredpanda PRIVATE
 # Copy JSON schema to the test executable's own directory too -- MCPProcessor locates it via
 # QCoreApplication::applicationDirPath(), and the copy above (attached to the `wiredpanda`
 # target) lands inside wiredpanda.app/Contents/MacOS/ on macOS (MACOSX_BUNDLE ON), nowhere near
-# test_wiredpanda's own (non-bundle) output directory.
-add_custom_command(TARGET test_wiredpanda POST_BUILD
+# test_wiredpanda's own (non-bundle) output directory. Keyed on the schema for the same reason.
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp-tests.stamp
     COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/MCP/schema-mcp.json
         $<TARGET_FILE_DIR:test_wiredpanda>/schema-mcp.json
-    COMMENT "Copying JSON schema to test executable directory"
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp-tests.stamp
+    DEPENDS ${CMAKE_SOURCE_DIR}/MCP/schema-mcp.json
+    COMMENT "Copying JSON schema next to the test executable"
     VERBATIM
 )
+add_custom_target(copy_mcp_schema_tests ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/schema-mcp-tests.stamp)
 
 if(ENABLE_PCH)
     target_precompile_headers(test_wiredpanda REUSE_FROM wiredpanda_lib)

--- a/MCP/Client/protocol/commands.py
+++ b/MCP/Client/protocol/commands.py
@@ -152,7 +152,13 @@ class SetInputValueCommand(MCPCommand):
 
 
 class GetOutputValueCommand(MCPCommand):
-    """Model for get_output_value command"""
+    """Model for get_output_value command.
+
+    The response carries both ``value`` (bool, true only for logic high) and ``status``
+    (``low``/``high``/``unknown``/``error``). ``value`` is a lossy convenience -- it cannot tell
+    unknown or error apart from logic low -- and the engine produces unknown routinely, since an
+    oscillating region is canonicalised to it and propagated to every reader. Prefer ``status``.
+    """
 
     class Parameters(BaseModel):
         element_id: Annotated[int, Field(gt=0)]

--- a/MCP/Client/protocol/commands.py
+++ b/MCP/Client/protocol/commands.py
@@ -236,7 +236,12 @@ class CreateWaveformCommand(MCPCommand):
             default=64, description="Number of simulation steps"
         )
         input_patterns: dict[str, list[Annotated[int, Field(ge=0, le=1)]]] | None = Field(
-            default=None, description="Input patterns for specific input elements"
+            default=None,
+            description=(
+                "Input patterns keyed by per-PORT signal label. A single-port element uses its "
+                'plain label; a multi-port element (e.g. a rotary input) uses "Name[port]", '
+                'such as "Bus[0]" -- the same labels the response reports.'
+            ),
         )
 
         model_config = ConfigDict(extra="forbid")

--- a/MCP/Server/Handlers/ElementHandler.cpp
+++ b/MCP/Server/Handlers/ElementHandler.cpp
@@ -296,6 +296,24 @@ QJsonObject ElementHandler::handleMoveElement(const QJsonObject &params, const Q
     return createSuccessResponse(result, requestId);
 }
 
+namespace {
+
+/// Four-state name for a port status. `value` stays a bool for compatibility, but it cannot
+/// distinguish Unknown or Error from logic 0 -- and the engine produces Unknown routinely, since
+/// an oscillating region is canonicalised to it and propagated to every reader. Matches the
+/// vocabulary the canvas already uses for wires (grey unknown, red error).
+QString statusName(const Status status)
+{
+    switch (status) {
+    case Status::Active:   return QStringLiteral("high");
+    case Status::Inactive: return QStringLiteral("low");
+    case Status::Error:    return QStringLiteral("error");
+    default:               return QStringLiteral("unknown");
+    }
+}
+
+} // namespace
+
 QJsonObject ElementHandler::handleSetElementProperties(const QJsonObject &params, const QJsonValue &requestId)
 {
     if (!validateParameters(params, {"element_id"})) {
@@ -573,12 +591,14 @@ QJsonObject ElementHandler::handleGetOutputValue(const QJsonObject &params, cons
             }
             InputPort *inPort = element->inputPort(portIndex);
             result["value"] = inPort ? (inPort->status() == Status::Active) : false;
+            result["status"] = statusName(inPort ? inPort->status() : Status::Unknown);
         } else {
             if (!validatePortRange(element, portIndex, true, "port", errorMsg)) {
                 return createErrorResponse(errorMsg, requestId, JsonRpcError::ValidationError);
             }
             OutputPort *outPort = element->outputPort(portIndex);
             result["value"] = outPort ? (outPort->status() == Status::Active) : false;
+            result["status"] = statusName(outPort ? outPort->status() : Status::Unknown);
         }
     }
 

--- a/MCP/schema-mcp.json
+++ b/MCP/schema-mcp.json
@@ -2450,8 +2450,10 @@
                               },
                               "values": {
                                 "type": "array",
+                                "description": "Per-column logic values for this input row. Input rows are two-state: SignalModel::setValue() clamps anything else to 0/1 and warns.",
                                 "items": {
-                                  "type": "integer"
+                                  "type": "integer",
+                                  "enum": [0, 1]
                                 }
                               }
                             },
@@ -2476,8 +2478,10 @@
                               },
                               "values": {
                                 "type": "array",
+                                "description": "Per-column four-state logic values for this output row: -1 unknown, 0 low, 1 high, 2 error -- the same states get_output_value names in its `status` field.",
                                 "items": {
-                                  "type": "integer"
+                                  "type": "integer",
+                                  "enum": [-1, 0, 1, 2]
                                 }
                               }
                             },

--- a/MCP/schema-mcp.json
+++ b/MCP/schema-mcp.json
@@ -2359,11 +2359,18 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Lossy convenience: true only for logic high, so unknown and error are indistinguishable from low. Prefer `status`."
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["low", "high", "unknown", "error"],
+                      "description": "Four-state port status. The engine produces `unknown` routinely: an oscillating region is canonicalised to it and propagated to every reader."
                     }
                   },
                   "required": [
-                    "value"
+                    "value",
+                    "status"
                   ],
                   "additionalProperties": false
                 }

--- a/MCP/schema-mcp.json
+++ b/MCP/schema-mcp.json
@@ -1261,7 +1261,7 @@
         },
         "create_waveform": {
           "type": "object",
-          "description": "Create waveform analysis for the current circuit",
+          "description": "Create waveform analysis for the current circuit. Signals are reported one per PORT, not one per element: a multi-port element (a rotary input, a 7-segment display) contributes one signal per port, labelled \"Name[port]\". input_patterns keys and the labels in the response both use that per-port form, so a multi-port element is addressed by \"Name[0]\" rather than by its bare label.",
           "properties": {
             "jsonrpc": {
               "type": "string",
@@ -1282,7 +1282,7 @@
                 },
                 "input_patterns": {
                   "type": "object",
-                  "description": "Input patterns for specific input elements",
+                  "description": "Input patterns keyed by per-port signal label. Single-port elements use their plain label; a multi-port element uses \"Name[port]\" (e.g. \"Bus[0]\").",
                   "additionalProperties": {
                     "type": "array",
                     "items": {

--- a/Tests/Integration/TestArduino.cpp
+++ b/Tests/Integration/TestArduino.cpp
@@ -25,6 +25,7 @@ QString TestArduino::s_cliCachePath;
 #include "App/Core/Enums.h"
 #include "App/Element/ElementFactory.h"
 #include "App/Element/GraphicElement.h"
+#include "App/Element/GraphicElementInput.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Element/GraphicElements/Led.h"
 #include "App/Element/GraphicElements/Node.h"
@@ -2913,4 +2914,155 @@ void TestArduino::testSimavrFunctionalSimulation()
     c1.reset();
     c2.reset();
     qDeleteAll(elements);
+}
+
+namespace {
+
+/// Arduino API shims sufficient to compile a generated sketch on the host. The sketch is plain
+/// C++ over `bool` globals; only the pin calls and the elapsedMillis type come from the board.
+constexpr auto kArduinoStubs = R"CPP(
+#include <cstdio>
+#define HIGH true
+#define LOW  false
+#define INPUT 0
+#define OUTPUT 1
+using pin_t = int;
+static const pin_t A0 = 14, A1 = 15, A2 = 16, A3 = 17, A4 = 18, A5 = 19;
+static bool g_clockPin = false;
+inline void pinMode(pin_t, int) {}
+inline bool digitalRead(pin_t) { return g_clockPin; }
+inline void digitalWrite(pin_t, bool) {}
+)CPP";
+
+constexpr auto kElapsedMillisStub = R"CPP(
+#pragma once
+struct elapsedMillis {
+    unsigned long v = 0;
+    operator unsigned long() const { return v; }
+    elapsedMillis &operator=(unsigned long x) { v = x; return *this; }
+};
+)CPP";
+
+} // namespace
+
+void TestArduino::testGeneratedSketchMatchesEngineOnRippleCounter()
+{
+#ifndef Q_OS_LINUX
+    QSKIP("the sketch differential needs a host C++ compiler (Linux only)");
+#endif
+    if (QStandardPaths::findExecutable("g++").isEmpty()) {
+        QSKIP("g++ not available");
+    }
+
+    // A ripple counter: the external clock drives FF1, and FF1.Q clocks FF2. This is the shape
+    // where a single sample/commit per tick diverges from the engine, which advances the whole
+    // chain within one update().
+    std::unique_ptr<WorkSpace> workspace = TestUtils::createWorkspace();
+    auto *scene = workspace->scene();
+    auto *clk = ElementFactory::buildElement(ElementType::InputSwitch);
+    auto *ff1 = ElementFactory::buildElement(ElementType::DFlipFlop);
+    auto *ff2 = ElementFactory::buildElement(ElementType::DFlipFlop);
+    auto *led1 = ElementFactory::buildElement(ElementType::Led);
+    auto *led2 = ElementFactory::buildElement(ElementType::Led);
+    for (auto *e : QVector<GraphicElement *>{clk, ff1, ff2, led1, led2}) { scene->addItem(e); }
+    clk->setPos(0, 0); ff1->setPos(120, 0); ff2->setPos(260, 0);
+    led1->setPos(400, 0); led2->setPos(400, 80);
+    clk->setLabel("CLK");
+
+    const auto wire = [scene](GraphicElement *a, int ap, GraphicElement *b, int bp) {
+        auto *c = new Connection();
+        scene->addItem(c);
+        c->setStartPort(a->outputPort(ap));
+        c->setEndPort(b->inputPort(bp));
+    };
+    wire(clk, 0, ff1, 1);    // external clock -> FF1.CLK
+    wire(ff1, 1, ff1, 0);    // FF1.~Q -> FF1.D (toggle)
+    wire(ff1, 0, ff2, 1);    // FF1.Q  -> FF2.CLK (the ripple)
+    wire(ff2, 1, ff2, 0);    // FF2.~Q -> FF2.D (toggle)
+    wire(ff1, 0, led1, 0);
+    wire(ff2, 0, led2, 0);
+
+    // --- Engine reference ---
+    auto *sim = scene->simulation();
+    QVERIFY(sim->initialize());
+    auto *clkIn = qobject_cast<GraphicElementInput *>(clk);
+    clkIn->setOn(false, 0);
+    sim->update();
+    QStringList engineTrace;
+    for (int edge = 0; edge < 4; ++edge) {
+        clkIn->setOn(true, 0);
+        sim->update();
+        engineTrace << QString("%1%2").arg(static_cast<int>(ff1->outputValue(0)))
+                                      .arg(static_cast<int>(ff2->outputValue(0)));
+        clkIn->setOn(false, 0);
+        sim->update();
+        engineTrace << QString("%1%2").arg(static_cast<int>(ff1->outputValue(0)))
+                                      .arg(static_cast<int>(ff2->outputValue(0)));
+    }
+
+    // --- Export, compile, drive ---
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString inoPath = dir.filePath("sketch.ino");
+    QVector<GraphicElement *> elements = scene->elements();
+    ArduinoCodeGen generator(inoPath, elements);
+    generator.generate();
+    QVERIFY(QFile::exists(inoPath));
+
+    const auto writeFile = [](const QString &path, const QString &text) {
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Text)) { return false; }
+        QTextStream(&f) << text;
+        return true;
+    };
+    QVERIFY(writeFile(dir.filePath("elapsedMillis.h"), QString::fromUtf8(kElapsedMillisStub)));
+
+    QString harness = QString::fromUtf8(kArduinoStubs);
+    harness += "#include \"sketch.ino\"\n";
+    harness += R"CPP(
+int main()
+{
+    setup();
+    g_clockPin = false;
+    loop();
+    for (int edge = 0; edge < 4; ++edge) {
+        g_clockPin = true;  loop(); printf("%d%d ", FF1 ? 1 : 0, FF2 ? 1 : 0);
+        g_clockPin = false; loop(); printf("%d%d ", FF1 ? 1 : 0, FF2 ? 1 : 0);
+    }
+    return 0;
+}
+)CPP";
+    // Generated variable names are derived from element ids. Rather than widen the codegen's
+    // public surface for a test, read them back out of the emitted output writes -- led1 is
+    // wired to FF1.Q and led2 to FF2.Q, and loop() writes them in that order.
+    QFile inoFile(inoPath);
+    QVERIFY(inoFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString ino = QString::fromUtf8(inoFile.readAll());
+    inoFile.close();
+    const QRegularExpression writeRe(QStringLiteral(R"(digitalWrite\(\s*\w+\s*,\s*(\w+)\s*\))"));
+    QStringList outputVars;
+    auto it = writeRe.globalMatch(ino);
+    while (it.hasNext()) { outputVars << it.next().captured(1); }
+    QVERIFY2(outputVars.size() == 2,
+             qPrintable(QString("expected two output writes in the sketch, found %1").arg(outputVars.size())));
+    const QString q1 = outputVars.at(0);
+    const QString q2 = outputVars.at(1);
+    harness.replace("FF1", q1).replace("FF2", q2);
+    QVERIFY(writeFile(dir.filePath("harness.cpp"), harness));
+
+    QProcess compile;
+    compile.setWorkingDirectory(dir.path());
+    compile.start("g++", {"-std=c++17", "-I.", "-o", "harness", "harness.cpp"});
+    QVERIFY2(compile.waitForFinished(60000), "g++ timed out");
+    QVERIFY2(compile.exitCode() == 0,
+             qPrintable("generated sketch did not compile:\n"
+                        + QString::fromUtf8(compile.readAllStandardError())));
+
+    QProcess run;
+    run.setWorkingDirectory(dir.path());
+    run.start(dir.filePath("harness"), {});
+    QVERIFY2(run.waitForFinished(30000), "harness timed out");
+    const QString sketchTrace = QString::fromUtf8(run.readAllStandardOutput()).trimmed();
+
+    QCOMPARE(sketchTrace, engineTrace.join(' '));
 }

--- a/Tests/Integration/TestArduino.h
+++ b/Tests/Integration/TestArduino.h
@@ -57,6 +57,13 @@ private:
     bool validateArduinoSyntax(const QString &content);
 
 private slots:
+    /// Compiles the GENERATED SKETCH and drives it, comparing against the engine on the same
+    /// circuit. A ripple counter is the shape that exposes a tick-model divergence: the sketch
+    /// can advance one stage per tick where the engine advances the whole chain. Only running
+    /// the sketch catches that -- emitted text that implements the wrong tick model still reads
+    /// as correct.
+    void testGeneratedSketchMatchesEngineOnRippleCounter();
+
     void initTestCase();
     void cleanupTestCase();
 

--- a/Tests/Integration/TestSystemVerilogExport.cpp
+++ b/Tests/Integration/TestSystemVerilogExport.cpp
@@ -9,6 +9,7 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QRandomGenerator>
+#include <QStandardPaths>
 #include <QTemporaryFile>
 #include <QTextStream>
 
@@ -1192,4 +1193,117 @@ void TestSystemVerilogExport::testSystemVerilogExportRegisterFile32x16()
 void TestSystemVerilogExport::testSystemVerilogExportSingleCycleCpu8Bit()
 {
     testSystemVerilogExportHelper("level9_single_cycle_cpu_8bit.panda");
+}
+
+void TestSystemVerilogExport::testTopLevelFeedbackLatchHoldsStateInExport()
+{
+#ifndef Q_OS_LINUX
+    QSKIP("SystemVerilog export tests require iverilog (Linux only)");
+#endif
+    if (QStandardPaths::findExecutable("iverilog").isEmpty()
+        || QStandardPaths::findExecutable("vvp").isEmpty()) {
+        QSKIP("iverilog/vvp not available");
+    }
+
+    // A cross-coupled NAND SR latch drawn at TOP LEVEL -- no IC anywhere in the scene.
+    // Active-low: nS=0 sets, nR=0 resets, both high holds.
+    std::unique_ptr<WorkSpace> workspace = TestUtils::createWorkspace();
+    auto *scene = workspace->scene();
+    CircuitBuilder builder(scene);
+
+    auto *swS = new InputSwitch();
+    auto *swR = new InputSwitch();
+    auto *nandQ = ElementFactory::buildElement(ElementType::Nand);
+    auto *nandQBar = ElementFactory::buildElement(ElementType::Nand);
+    auto *led = new Led();
+    builder.add(swS, swR, nandQ, nandQBar, led);
+    swS->setLabel("NS");
+    swR->setLabel("NR");
+
+    builder.connect(swS, 0, nandQ, 0);        // nS -> NAND_Q
+    builder.connect(nandQBar, 0, nandQ, 1);   // ~Q -> NAND_Q   (feedback)
+    builder.connect(swR, 0, nandQBar, 1);     // nR -> NAND_QBAR
+    builder.connect(nandQ, 0, nandQBar, 0);   //  Q -> NAND_QBAR (feedback)
+    builder.connect(nandQ, 0, led, 0);
+
+    Simulation *sim = builder.initSimulation();
+    QVERIFY(sim != nullptr);
+    QVERIFY2(sim->isInFeedbackLoop(nandQ), "precondition: the engine must see this as a loop");
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString svPath = dir.filePath("toplevel_latch.sv");
+    QVector<GraphicElement *> elements = scene->elements();
+    SystemVerilogCodeGen generator(svPath, elements);
+    generator.generate();
+    QVERIFY(QFile::exists(svPath));
+
+    QFile svFile(svPath);
+    QVERIFY(svFile.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString sv = QString::fromUtf8(svFile.readAll());
+    svFile.close();
+
+    // Resolve the generated port names from the module header rather than guessing.
+    const QRegularExpression inRe(QStringLiteral(R"(input\s+(\w+))"));
+    const QRegularExpression outRe(QStringLiteral(R"(output\s+(\w+))"));
+    QStringList inputs;
+    auto it = inRe.globalMatch(sv);
+    while (it.hasNext()) { inputs << it.next().captured(1); }
+    const auto outMatch = outRe.match(sv);
+    QVERIFY2(inputs.size() == 2 && outMatch.hasMatch(),
+             qPrintable(QString("unexpected module interface:\n%1").arg(sv)));
+    const QString nS = inputs.at(0);
+    const QString nR = inputs.at(1);
+    const QString q = outMatch.captured(1);
+
+    // Drive the latch: set, hold, reset, hold. The hold steps are the whole point -- a module
+    // whose feedback was folded to a constant has no memory and cannot pass them.
+    QString tb;
+    QTextStream ts(&tb);
+    ts << "`timescale 1ns/1ps\n"
+       << "module tb;\n"
+       << "    reg " << nS << ", " << nR << ";\n"
+       << "    wire " << q << ";\n"
+       << "    integer errors = 0;\n"
+       << "    toplevel_latch dut(." << nS << "(" << nS << "), ." << nR << "(" << nR << "), ."
+       << q << "(" << q << "));\n"
+       << "    task chk(input exp, input [63:0] tag);\n"
+       << "        begin if (" << q << " !== exp) begin errors = errors + 1;"
+       << " $display(\"FAIL %0s: got %b want %b\", tag, " << q << ", exp); end end\n"
+       << "    endtask\n"
+       << "    initial begin\n"
+       << "        " << nS << " = 1; " << nR << " = 1; #5;\n"
+       << "        " << nS << " = 0; " << nR << " = 1; #5; chk(1'b1, \"set\");\n"
+       << "        " << nS << " = 1; " << nR << " = 1; #5; chk(1'b1, \"hold1\");\n"
+       << "        " << nS << " = 1; " << nR << " = 0; #5; chk(1'b0, \"reset\");\n"
+       << "        " << nS << " = 1; " << nR << " = 1; #5; chk(1'b0, \"hold0\");\n"
+       << "        if (errors == 0) $display(\"PASS\"); else $display(\"FAILED %0d\", errors);\n"
+       << "        $finish;\n"
+       << "    end\n"
+       << "endmodule\n";
+    ts.flush();
+
+    const QString tbPath = dir.filePath("tb.sv");
+    QFile tbFile(tbPath);
+    QVERIFY(tbFile.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream(&tbFile) << tb;
+    tbFile.close();
+
+    const QString simOut = dir.filePath("sim.out");
+    QProcess compile;
+    compile.setProcessChannelMode(QProcess::MergedChannels);
+    compile.start("iverilog", {"-g2012", "-o", simOut, tbPath, svPath});
+    QVERIFY2(compile.waitForFinished(30000), "iverilog timed out");
+    QVERIFY2(compile.exitCode() == 0,
+             qPrintable(QString("generated top-level module did not compile:\n%1\n--- sv ---\n%2")
+                            .arg(QString::fromUtf8(compile.readAll()), sv)));
+
+    QProcess run;
+    run.start(simOut, {});
+    QVERIFY2(run.waitForFinished(30000), "vvp timed out");
+    const QString out = QString::fromUtf8(run.readAllStandardOutput());
+
+    QVERIFY2(out.contains("PASS") && !out.contains("FAIL"),
+             qPrintable(QString("the exported top-level latch does not hold state:\n%1\n--- sv ---\n%2")
+                            .arg(out, sv)));
 }

--- a/Tests/Integration/TestSystemVerilogExport.h
+++ b/Tests/Integration/TestSystemVerilogExport.h
@@ -10,6 +10,14 @@ class TestSystemVerilogExport : public QObject
     Q_OBJECT
 
 private slots:
+    /// The only top-level (non-IC) circuit in the differential; every .panda fixture exercises
+    /// generateSingleICModule(), which is where findFeedbackElements() runs and where the set is
+    /// cleared again before top-level declaration. Without top-level detection a canvas-drawn
+    /// feedback circuit is not recognised as a loop, and otherPortNameImpl()'s cycle guard folds
+    /// the feedback edge to 1'b0 -- exporting a latch as combinational logic with the memory
+    /// removed. Behavioural, not textual: the exported module must HOLD STATE.
+    void testTopLevelFeedbackLatchHoldsStateInExport();
+
     void initTestCase();
     void cleanupTestCase();
 

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -215,6 +215,48 @@ void TestBewavedDolphinGui::testRunSimulationFillsOutputs()
     QCOMPARE(outputAt0, 0);
 }
 
+void TestBewavedDolphinGui::testRunLeavesLiveSequentialStateUnchanged()
+{
+    // The sweep is a read-only question about the circuit. It resets every element to power-on
+    // defaults on entry so its own results are reproducible, so it must put ALL of that state
+    // back on exit -- restoring only the INPUT port levels would leave everything else,
+    // flip-flop state above all, wherever the last swept column happened to leave it.
+    WorkSpace ws;
+    auto *scene = ws.scene();
+    auto *data = new InputSwitch();
+    auto *clk = new InputSwitch();
+    auto *dff = new DFlipFlop();
+    auto *led = new Led();
+    scene->addItem(data);
+    scene->addItem(clk);
+    scene->addItem(dff);
+    scene->addItem(led);
+    CircuitBuilder builder(scene);
+    builder.connect(data, 0, dff, 0); // Data
+    builder.connect(clk, 0, dff, 1);  // Clock
+    builder.connect(dff, 0, led, 0);  // Q
+
+    auto *sim = scene->simulation();
+    QVERIFY(sim->initialize());
+
+    // Clock a 1 into the flip-flop, live.
+    data->setOn(true);
+    clk->setOn(false);
+    sim->update();
+    clk->setOn(true); // rising edge
+    sim->update();
+    sim->update();
+    QCOMPARE(dff->outputValue(0), Status::Active); // precondition: Q is live-high
+
+    std::unique_ptr<BewavedDolphin> dolphin(createDolphin(&ws));
+    dolphin->setLength(8, false);
+    dolphin->run();
+
+    QVERIFY2(dff->outputValue(0) == Status::Active,
+             "a sweep must not leave its own last column in the live circuit: the flip-flop was "
+             "driven high before the sweep and must still be high after it");
+}
+
 void TestBewavedDolphinGui::testSetLengthChangesColumns()
 {
     auto ws = createAndCircuit();

--- a/Tests/System/TestBewavedDolphinGui.cpp
+++ b/Tests/System/TestBewavedDolphinGui.cpp
@@ -34,6 +34,9 @@
 #include "App/BeWavedDolphin/DolphinZoom.h"
 #include "App/Core/Application.h"
 #include "App/Element/GraphicElements/And.h"
+#include "App/Element/GraphicElements/DFlipFlop.h"
+#include "App/Element/GraphicElements/Display7.h"
+#include "App/Element/GraphicElements/InputRotary.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Element/GraphicElements/Led.h"
 #include "App/Exercise/ExerciseEngine.h"
@@ -1696,15 +1699,96 @@ void TestBewavedDolphinGui::testTriggerCombinationalFillsAllInputPatterns()
 void TestBewavedDolphinGui::testInputRowLooksUpByLabel()
 {
     auto ws = createAndCircuit();
-    std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
 
     // createAndCircuit()'s InputSwitches don't get distinct default labels, so give them one
-    // each here to make inputRow()'s label lookup unambiguous.
-    dolphin->inputElements().first()->setLabel("swA");
-    dolphin->inputElements().last()->setLabel("swB");
+    // each to make inputRow()'s label lookup unambiguous. Labelled BEFORE the waveform is
+    // built: inputRow() matches the row's own label, which -- like the table's header text
+    // and snapshot()'s signal labels -- is captured when the table is prepared. Matching the
+    // element's live label instead would let inputRow() resolve a name the header and the
+    // snapshot don't show -- the class of disagreement this row layout exists to stop.
+    auto inputs = ws->scene()->elements();
+    std::stable_sort(inputs.begin(), inputs.end(), [](auto *a, auto *b) { return a->pos().x() < b->pos().x(); });
+    int labelled = 0;
+    for (auto *elm : inputs) {
+        if (elm->elementGroup() == ElementGroup::Input) {
+            elm->setLabel(labelled == 0 ? "swA" : "swB");
+            if (++labelled == 2) {
+                break;
+            }
+        }
+    }
+    QCOMPARE(labelled, 2);
+
+    std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
+
     QCOMPARE(dolphin->inputRow("swA"), 0);
     QCOMPARE(dolphin->inputRow("swB"), 1);
     QCOMPARE(dolphin->inputRow("no such signal"), -1);
+}
+
+void TestBewavedDolphinGui::testSnapshotMatchesModelRowsForMultiPortElements()
+{
+    // A circuit with BOTH a multi-port input (InputRotary) and a multi-port output
+    // (Display7): an element index and a row index differ on each side of the table.
+    auto ws = std::make_unique<WorkSpace>();
+    auto *scene = ws->scene();
+
+    auto *rotary = new InputRotary();
+    auto *sw = new InputSwitch();
+    auto *display = new Display7();
+    scene->addItem(rotary);
+    scene->addItem(sw);
+    scene->addItem(display);
+    rotary->setLabel("ROT");
+    sw->setLabel("EN");
+    display->setLabel("DISP");
+
+    CircuitBuilder builder(scene);
+    builder.connect(rotary, 0, display, 0);
+    builder.connect(sw, 0, display, 1);
+
+    std::unique_ptr<BewavedDolphin> dolphin(createDolphin(ws.get()));
+    dolphin->setLength(4, false);
+    dolphin->run();
+
+    const auto *model = dolphin->model();
+    QVERIFY(model);
+
+    const auto snap = dolphin->snapshot(4);
+    const int totalSignals = static_cast<int>(snap.inputs.size() + snap.outputs.size());
+
+    // One signal per table ROW -- not one per element.
+    QCOMPARE(totalSignals, model->rowCount());
+    QVERIFY2(snap.inputs.size() > rotary->outputSize() - 1,
+             "a multi-port input must contribute one signal per port, not one per element");
+    QCOMPARE(static_cast<int>(snap.inputs.size()), model->inputRows());
+
+    // Row-for-row agreement with the model: same order, same per-port labels, same values.
+    QList<BewavedDolphin::Signal> allSignals = snap.inputs;
+    allSignals.append(snap.outputs);
+    for (int row = 0; row < model->rowCount(); ++row) {
+        const QString headerLabel = model->headerData(row, Qt::Vertical).toString();
+        QCOMPARE(allSignals.at(row).label, headerLabel);
+        for (int col = 0; col < 4; ++col) {
+            QCOMPARE(allSignals.at(row).values.at(col), model->value(row, col));
+        }
+    }
+
+    // Per-port labels must actually disambiguate: no two rows share a name.
+    QSet<QString> seenLabels;
+    for (const auto &signal : allSignals) {
+        QVERIFY2(!seenLabels.contains(signal.label),
+                 qPrintable(QStringLiteral("duplicate row label: %1").arg(signal.label)));
+        seenLabels.insert(signal.label);
+    }
+
+    // inputRow() indexes the same rows, and can now address a port beyond the first.
+    // Inputs are label-sorted, so "EN" precedes the rotary's ports.
+    QCOMPARE(dolphin->inputRow(QStringLiteral("EN")), 0);
+    QCOMPARE(dolphin->inputRow(QStringLiteral("ROT[0]")), 1);
+    QCOMPARE(dolphin->inputRow(QStringLiteral("ROT[1]")), 2);
+    // The bare element label addresses nothing: every row of a multi-port element is indexed.
+    QCOMPARE(dolphin->inputRow(QStringLiteral("ROT")), -1);
 }
 
 void TestBewavedDolphinGui::testSnapshotReturnsRunValues()

--- a/Tests/System/TestBewavedDolphinGui.h
+++ b/Tests/System/TestBewavedDolphinGui.h
@@ -140,6 +140,10 @@ private slots:
     void testTriggerCombinationalFillsAllInputPatterns();
     void testInputRowLooksUpByLabel();
     void testSnapshotReturnsRunValues();
+    /// snapshot() must agree with the model row-for-row, in order, including per-port labels.
+    /// The table is laid out one row per PORT, so indexing per ELEMENT anywhere makes a
+    /// multi-port element report confidently wrong values under correct-looking labels.
+    void testSnapshotMatchesModelRowsForMultiPortElements();
     void testCheckSaveDiscardAndSaveButtons();
     void testActionSetClockWaveNoSelectionThrowsUserFacingError();
     void testActionSetClockWaveDialogRejectedLeavesGridUnchanged();

--- a/Tests/System/TestBewavedDolphinGui.h
+++ b/Tests/System/TestBewavedDolphinGui.h
@@ -30,6 +30,12 @@ private slots:
     void testSetLengthChangesColumns();
     void testCombinationalMode();
 
+    /// A sweep must be state-neutral for the LIVE circuit. sweep() resets every element on entry,
+    /// so restoring only the input port levels on exit would leave the canvas holding whatever the
+    /// last column produced -- a read-only-looking create_waveform mutating the user's circuit.
+    /// Sequential state is where that shows: a flip-flop driven high live comes back low.
+    void testRunLeavesLiveSequentialStateUnchanged();
+
     // --- File I/O ---
 
     void testExportToPng();

--- a/Tests/Unit/Core/TestInstallRelativePaths.cpp
+++ b/Tests/Unit/Core/TestInstallRelativePaths.cpp
@@ -69,3 +69,68 @@ void TestInstallRelativePaths::testResolveFindsCwdFallbackCandidate()
 
     QCOMPARE(resolved, category);
 }
+
+void TestInstallRelativePaths::testIsCandidateMatchesCwdFallbackByCanonicalPath()
+{
+    QTemporaryDir cwdDir;
+    QVERIFY(cwdDir.isValid());
+
+    const QString category = QStringLiteral("InstallRelativePathsTestIsCandidate");
+    QVERIFY(QDir(cwdDir.path()).mkpath(category));
+
+    const QString previousCwd = QDir::currentPath();
+    QVERIFY(QDir::setCurrent(cwdDir.path()));
+
+    // The bare-category CWD fallback is a *relative* candidate; isCandidate() is given the
+    // absolute path a caller would actually hold, so this only passes via canonicalisation.
+    const bool matched = InstallRelativePaths::isCandidate(category, QDir(cwdDir.path()).absoluteFilePath(category));
+
+    QVERIFY(QDir::setCurrent(previousCwd));
+
+    QVERIFY(matched);
+}
+
+void TestInstallRelativePaths::testIsCandidateMatchesEquivalentPathSpellings()
+{
+    QTemporaryDir cwdDir;
+    QVERIFY(cwdDir.isValid());
+
+    const QString category = QStringLiteral("InstallRelativePathsTestSpellings");
+    QVERIFY(QDir(cwdDir.path()).mkpath(category));
+
+    const QString previousCwd = QDir::currentPath();
+    QVERIFY(QDir::setCurrent(cwdDir.path()));
+
+    const QString base = QDir(cwdDir.path()).absoluteFilePath(category);
+    const bool trailingDot = InstallRelativePaths::isCandidate(category, base + QStringLiteral("/."));
+    const bool parentRoundTrip = InstallRelativePaths::isCandidate(category, base + QStringLiteral("/../") + category);
+
+    QVERIFY(QDir::setCurrent(previousCwd));
+
+    QVERIFY(trailingDot);
+    QVERIFY(parentRoundTrip);
+}
+
+void TestInstallRelativePaths::testIsCandidateRejectsUnrelatedMissingAndEmptyDirs()
+{
+    QTemporaryDir cwdDir;
+    QVERIFY(cwdDir.isValid());
+
+    const QString category = QStringLiteral("InstallRelativePathsTestReject");
+    QVERIFY(QDir(cwdDir.path()).mkpath(category));
+    const QString unrelated = QStringLiteral("SomewhereElse");
+    QVERIFY(QDir(cwdDir.path()).mkpath(unrelated));
+
+    const QString previousCwd = QDir::currentPath();
+    QVERIFY(QDir::setCurrent(cwdDir.path()));
+
+    const bool unrelatedDir = InstallRelativePaths::isCandidate(category, QDir(cwdDir.path()).absoluteFilePath(unrelated));
+    const bool missingDir = InstallRelativePaths::isCandidate(category, QDir(cwdDir.path()).absoluteFilePath(QStringLiteral("NoSuchDir")));
+    const bool emptyPath = InstallRelativePaths::isCandidate(category, QString());
+
+    QVERIFY(QDir::setCurrent(previousCwd));
+
+    QVERIFY(!unrelatedDir);
+    QVERIFY(!missingDir);
+    QVERIFY(!emptyPath);
+}

--- a/Tests/Unit/Core/TestInstallRelativePaths.h
+++ b/Tests/Unit/Core/TestInstallRelativePaths.h
@@ -17,4 +17,13 @@ private slots:
 
     void testResolveReturnsEmptyWhenNoCandidateExists();
     void testResolveFindsCwdFallbackCandidate();
+
+    /// isCandidate() recognises the bundled content directory so callers can refuse to write
+    /// into it even where the filesystem allows it (a dev checkout's Examples/ is writable).
+    void testIsCandidateMatchesCwdFallbackByCanonicalPath();
+    /// Matching is by canonical path, so an equivalent spelling of the same directory
+    /// (trailing "/.", a ".." round trip) still matches -- a plain string compare would not.
+    void testIsCandidateMatchesEquivalentPathSpellings();
+    /// A directory that isn't a candidate, doesn't exist, or is empty is never a match.
+    void testIsCandidateRejectsUnrelatedMissingAndEmptyDirs();
 };

--- a/Tests/Unit/Elements/TestInputElements.cpp
+++ b/Tests/Unit/Elements/TestInputElements.cpp
@@ -12,7 +12,9 @@
 #include <QTemporaryDir>
 #include <QTest>
 
+#include "App/Element/ElementFactory.h"
 #include "App/Element/GraphicElements/InputButton.h"
+#include "App/Element/GraphicElements/InputRotary.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/IO/SerializationContext.h"
 #include "App/Scene/Scene.h"
@@ -715,4 +717,39 @@ void TestInputElements::testAppearanceReloadsAfterFileModified()
     QVERIFY2(firstSize != secondSize,
              "A fresh element loading the same path after the file changed on disk must not "
              "reuse another element's stale cached pixmap");
+}
+
+void TestInputElements::testRotarySelectionIsResetAndRestoredWithSimState()
+{
+    auto *rotary = qobject_cast<InputRotary *>(ElementFactory::buildElement(ElementType::InputRotary));
+    QVERIFY(rotary != nullptr);
+    rotary->setOutputSize(4);
+    rotary->initSimulationVectors(rotary->inputSize(), rotary->outputSize());
+
+    rotary->setOn(true, 2);                 // as a user click would
+    // A live tick is what puts the selection into the SIMULATION outputs; setOn() only writes
+    // m_currentPort and the port statuses. sweep() snapshots after the simulation has been
+    // running, so this mirrors the real ordering rather than saving an empty state.
+    rotary->updateOutputs();
+    QVERIFY(rotary->isOn(2));
+    QVERIFY(!rotary->isOn(0));
+
+    // Snapshot / reset / restore, exactly the order WaveformSimulator::sweep() uses.
+    QVector<Status> saved;
+    rotary->saveSimState(saved);
+
+    rotary->resetSimState();
+    QVERIFY2(rotary->isOn(0),
+             "the sweep's reset must return the rotary to its power-on position, or every run "
+             "inherits the live one");
+    QVERIFY(!rotary->isOn(2));
+
+    int cursor = 0;
+    rotary->restoreSimState(saved, cursor);
+    QVERIFY2(rotary->isOn(2),
+             "and the restore must put the live selection back, or a sweep leaves the canvas "
+             "rotated to wherever its last column landed");
+    QVERIFY(!rotary->isOn(0));
+
+    delete rotary;
 }

--- a/Tests/Unit/Elements/TestInputElements.h
+++ b/Tests/Unit/Elements/TestInputElements.h
@@ -10,6 +10,14 @@ class TestInputElements : public QObject
     Q_OBJECT
 
 private slots:
+    /// A sweep resets every element for reproducibility, and InputRotary must take part.
+    /// m_currentPort is not an output value, and updateOutputs() republishes it onto the outputs
+    /// every tick, so a reset that misses it is overwritten before anything reads it. A default
+    /// all-zero waveform table cannot correct that either -- setWaveformValue() is deliberately a
+    /// no-op for a low cell -- which would leave every column running at whatever position the
+    /// user last left on the canvas.
+    void testRotarySelectionIsResetAndRestoredWithSimState();
+
     // InputSwitch Tests
     void testInputSwitchConstructor();
     void testInputSwitchInitialState();

--- a/Tests/Unit/MCP/TestElementHandler.cpp
+++ b/Tests/Unit/MCP/TestElementHandler.cpp
@@ -379,6 +379,38 @@ void TestElementHandler::testHandleSetElementPropertiesRejectsPortSizeParams()
     QCOMPARE(response["error"].toObject()["code"].toInt(), JsonRpcError::ValidationError);
 }
 
+void TestElementHandler::testGetOutputValueReportsFourStateStatus()
+{
+    MainWindow window;
+    ElementHandler handler(&window, nullptr);
+    const int id = createElement(handler, "And");
+    auto *element = elementById(window, id);
+    QVERIFY(element);
+
+    const auto statusFor = [&handler, id](int) {
+        const QJsonObject response =
+            handler.handleCommand("get_output_value", {{"element_id", id}, {"port", 0}}, 1);
+        return response["result"].toObject();
+    };
+
+    element->outputPort(0)->setStatus(Status::Active);
+    QCOMPARE(statusFor(0)["status"].toString(), QStringLiteral("high"));
+    QCOMPARE(statusFor(0)["value"].toBool(), true);
+
+    element->outputPort(0)->setStatus(Status::Inactive);
+    QCOMPARE(statusFor(0)["status"].toString(), QStringLiteral("low"));
+
+    // The cases `value` alone cannot express: both report false, indistinguishable from a
+    // genuine logic low.
+    element->outputPort(0)->setStatus(Status::Unknown);
+    QCOMPARE(statusFor(0)["status"].toString(), QStringLiteral("unknown"));
+    QCOMPARE(statusFor(0)["value"].toBool(), false);
+
+    element->outputPort(0)->setStatus(Status::Error);
+    QCOMPARE(statusFor(0)["status"].toString(), QStringLiteral("error"));
+    QCOMPARE(statusFor(0)["value"].toBool(), false);
+}
+
 void TestElementHandler::testHandleSetElementPropertiesChangesLabel()
 {
     MainWindow window;

--- a/Tests/Unit/MCP/TestElementHandler.h
+++ b/Tests/Unit/MCP/TestElementHandler.h
@@ -42,6 +42,10 @@ private slots:
     void testHandleSetElementPropertiesRejectsMissingElementId();
     void testHandleSetElementPropertiesRejectsUnknownElement();
     void testHandleSetElementPropertiesRejectsPortSizeParams();
+    /// get_output_value's `value` is a bool, so unknown and error are indistinguishable from
+    /// logic low -- while create_waveform reports the same state as a raw -1, leaving one server
+    /// describing the same signal two different ways. An explicit `status` field resolves it.
+    void testGetOutputValueReportsFourStateStatus();
     void testHandleSetElementPropertiesChangesLabel();
     void testHandleSetElementPropertiesChangesColorWhenSupported();
     void testHandleSetElementPropertiesChangesFrequencyWhenSupported();

--- a/Tests/Unit/MCP/TestMCPValidator.cpp
+++ b/Tests/Unit/MCP/TestMCPValidator.cpp
@@ -6,6 +6,7 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTemporaryFile>
@@ -288,6 +289,55 @@ void TestMCPValidator::testValidateResponseRejectsMissingCommandResponseDefiniti
 
     QVERIFY(!result.isValid);
     QCOMPARE(result.errorMessage, QStringLiteral("CommandResponse schema not found in definitions"));
+}
+
+namespace {
+
+// A create_waveform response carrying one input row and one output row, each with the given
+// per-column values. Every other field the schema requires is present, so the only thing a
+// rejection can be about is the values themselves.
+QJsonObject waveformResponse(const QJsonArray &inputValues, const QJsonArray &outputValues)
+{
+    const QJsonObject waveformData{
+        {"duration", inputValues.size()},
+        {"inputs", QJsonArray{QJsonObject{{"label", "sw1"}, {"type", "input"}, {"values", inputValues}}}},
+        {"outputs", QJsonArray{QJsonObject{{"label", "led1"}, {"type", "output"}, {"values", outputValues}}}},
+    };
+    const QJsonObject result{
+        {"actual_duration", inputValues.size()},
+        {"requested_duration", inputValues.size()},
+        {"message", "Waveform created and analyzed successfully"},
+        {"status", "ready"},
+        {"waveform_data", waveformData},
+    };
+    return QJsonObject{{"jsonrpc", "2.0"}, {"result", result}, {"id", 1}};
+}
+
+} // namespace
+
+void TestMCPValidator::testCreateWaveformResponseConstrainsSignalValuesToTheFourStateVocabulary()
+{
+    // create_waveform's per-column values are `static_cast<int>(Status)` for output rows
+    // (WaveformSimulator::sweep()) and the 0/1 SignalModel::setValue() clamps input rows to.
+    // A bare {"type": "integer"} would leave the encoding a client must decode -- notably that
+    // -1 means unknown and 2 means error, the same states get_output_value names -- undocumented
+    // and unenforced. MCPProcessor validates its own responses before sending, so constraining
+    // the vocabulary turns an out-of-band value into a loud internal error rather than an
+    // undocumented integer on the wire.
+    MCPValidator validator(realSchemaPath());
+
+    const ValidationResult fourState = validator.validateResponse(
+        waveformResponse({0, 1, 0, 1}, {-1, 0, 1, 2}), "create_waveform");
+    QVERIFY2(fourState.isValid, qPrintable(fourState.errorMessage));
+    QCOMPARE(fourState.schemaUsed, QStringLiteral("create_waveform_response"));
+
+    const ValidationResult outOfVocabulary = validator.validateResponse(
+        waveformResponse({0, 1}, {0, 7}), "create_waveform");
+    QVERIFY2(!outOfVocabulary.isValid, "an output value outside the four-state vocabulary must be rejected");
+
+    const ValidationResult nonBinaryInput = validator.validateResponse(
+        waveformResponse({0, -1}, {0, 1}), "create_waveform");
+    QVERIFY2(!nonBinaryInput.isValid, "input rows are clamped to 0/1, so a non-binary input value must be rejected");
 }
 
 void TestMCPValidator::testFindCommandSchemaReturnsNullForUnknownCommand()

--- a/Tests/Unit/MCP/TestMCPValidator.h
+++ b/Tests/Unit/MCP/TestMCPValidator.h
@@ -30,6 +30,7 @@ private slots:
     void testValidateResponseUsesSpecificSchemaWhenAvailable();
     void testValidateResponseQJsonOverloadCatchesMalformedInput();
     void testValidateResponseRejectsMissingCommandResponseDefinition();
+    void testCreateWaveformResponseConstrainsSignalValuesToTheFourStateVocabulary();
 
     void testFindCommandSchemaReturnsNullForUnknownCommand();
     void testFindResponseSchemaReturnsNullForUnknownCommand();

--- a/Tests/Unit/MCP/TestSimulationHandler.cpp
+++ b/Tests/Unit/MCP/TestSimulationHandler.cpp
@@ -3,6 +3,8 @@
 
 #include "Tests/Unit/MCP/TestSimulationHandler.h"
 
+#include <QCoreApplication>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
@@ -15,12 +17,15 @@
 #include "App/BeWavedDolphin/SignalModel.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Element/GraphicElements/Led.h"
+#include "App/Element/GraphicElements/Not.h"
 #include "App/Scene/Commands.h"
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
 #include "App/UI/MainWindow.h"
+#include "App/Wiring/Connection.h"
 #include "MCP/Server/Core/JsonRpcError.h"
+#include "MCP/Server/Core/MCPValidator.h"
 #include "MCP/Server/Handlers/SimulationHandler.h"
 
 namespace {
@@ -228,6 +233,59 @@ void TestSimulationHandler::testCreateWaveformReplacesExistingDolphin()
 
     QVERIFY(handler.handleCommand("create_waveform", {{"duration", 4}}, 1).contains("result"));
     QVERIFY2(handler.m_persistentDolphin != firstDolphin, "a second create_waveform call must replace the previous instance, not reuse or leak it");
+}
+
+void TestSimulationHandler::testCreateWaveformResponseValidatesAgainstTheSchema()
+{
+    // The schema constrains a waveform row's per-column values to the four-state vocabulary
+    // (output rows) and to 0/1 (input rows). MCPProcessor validates its own responses before
+    // sending, so if a real sweep could produce anything outside that vocabulary, the
+    // constraint would turn a working call into an internal error.
+    //
+    // The circuit is a self-feeding NOT: the engine canonicalises an oscillating region to
+    // Unknown, so the LED reading it reports -1. An UNDRIVEN LED would not do -- its input
+    // port falls back to a defaultValue() of Inactive and reports a plain 0, which would leave
+    // this guard unable to distinguish a correct vocabulary from a two-state one.
+    MainWindow window;
+    SimulationHandler handler(&window, nullptr);
+    Scene *scene = window.currentTab()->scene();
+
+    auto *sw = new InputSwitch();
+    sw->setLabel("sw1");
+    auto *notGate = new Not();
+    auto *led = new Led();
+    scene->receiveCommand(new AddItemsCommand({sw, notGate, led}, scene));
+
+    auto *loop = new Connection();
+    scene->addItem(loop);
+    loop->setStartPort(notGate->outputPort(0));
+    loop->setEndPort(notGate->inputPort(0));
+
+    auto *tap = new Connection();
+    scene->addItem(tap);
+    tap->setStartPort(notGate->outputPort(0));
+    tap->setEndPort(led->inputPort(0));
+
+    const QJsonObject response = handler.handleCommand("create_waveform", {{"duration", 4}}, 1);
+    QVERIFY2(response.contains("result"), qPrintable(QJsonDocument(response).toJson()));
+
+    QStringList seen;
+    const QJsonObject waveformData = response["result"].toObject()["waveform_data"].toObject();
+    for (const QJsonValue &row : waveformData["outputs"].toArray()) {
+        for (const QJsonValue &value : row.toObject()["values"].toArray()) {
+            seen.append(QString::number(value.toInt()));
+        }
+    }
+    // Precondition: without a non-binary value in the sweep this guard proves only that 0
+    // validates, which every two-state schema would also allow.
+    QVERIFY2(seen.contains(QStringLiteral("-1")),
+             qPrintable("precondition: the sweep must produce an unknown output; seen: " + seen.join(", ")));
+
+    MCPValidator validator(QDir(QCoreApplication::applicationDirPath()).absoluteFilePath("schema-mcp.json"));
+    QVERIFY(validator.isSchemaLoaded());
+    const ValidationResult outcome = validator.validateResponse(response, "create_waveform");
+    QVERIFY2(outcome.isValid, qPrintable(outcome.errorMessage + " -- output values seen: " + seen.join(", ")));
+    QCOMPARE(outcome.schemaUsed, QStringLiteral("create_waveform_response"));
 }
 
 void TestSimulationHandler::testExportWaveformRejectsMissingParams()

--- a/Tests/Unit/MCP/TestSimulationHandler.h
+++ b/Tests/Unit/MCP/TestSimulationHandler.h
@@ -25,6 +25,7 @@ private slots:
     void testCreateWaveformRejectsPatternLengthMismatch();
     void testCreateWaveformRejectsInvalidPatternValue();
     void testCreateWaveformReplacesExistingDolphin();
+    void testCreateWaveformResponseValidatesAgainstTheSchema();
 
     void testExportWaveformRejectsMissingParams();
     void testExportWaveformRejectsInvalidFormat();

--- a/Tests/Unit/Scene/TestWorkspace.cpp
+++ b/Tests/Unit/Scene/TestWorkspace.cpp
@@ -4,6 +4,7 @@
 #include "Tests/Unit/Scene/TestWorkspace.h"
 
 #include <QDataStream>
+#include <QDir>
 #include <QFile>
 #include <QFileDevice>
 #include <QLayout>
@@ -566,6 +567,41 @@ void TestWorkspaceUnit::testAutosaveFallsBackToAppDataWhenProjectDirIsReadOnly()
     QFile::setPermissions(dir.path(), QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
     QFile::remove(workspace.m_autosaveFileName);
 #endif
+}
+
+void TestWorkspaceUnit::testAutosaveFallsBackToAppDataForBundledExamplesDir()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    QVERIFY(QDir(dir.path()).mkpath(QStringLiteral("Examples")));
+    const QString examplesDir = QDir(dir.path()).absoluteFilePath(QStringLiteral("Examples"));
+
+    // Deliberately left WRITABLE: this is the dev-checkout shape, where the read-only
+    // check passes, so writability is not what keeps the autosave out.
+    QVERIFY(QFileInfo(examplesDir).isWritable());
+
+    WorkSpace workspace;
+    workspace.m_fileInfo = QFileInfo(examplesDir + QStringLiteral("/counter.panda"));
+    auto *gate = new And();
+    workspace.scene()->receiveCommand(new AddItemsCommand(QList<QGraphicsItem *>{gate}, workspace.scene()));
+    QVERIFY(!workspace.scene()->undoStack()->isClean());
+
+    // Make that directory the bare-category CWD candidate, which is how a dev checkout's
+    // Examples/ is actually reached.
+    const QString previousCwd = QDir::currentPath();
+    QVERIFY(QDir::setCurrent(dir.path()));
+    workspace.autosave();
+    QVERIFY(QDir::setCurrent(previousCwd));
+
+    QVERIFY2(!workspace.m_autosaveFileName.isEmpty(),
+             "autosave() must still protect the work -- the file is relocated, not skipped");
+    QVERIFY2(!workspace.m_autosaveFileName.startsWith(examplesDir),
+             "must not write an autosave into the bundled Examples directory");
+    QVERIFY(QFile::exists(workspace.m_autosaveFileName));
+    QVERIFY2(QDir(examplesDir).entryList(QDir::Files | QDir::Hidden).isEmpty(),
+             "the bundled Examples directory must be left completely untouched");
+
+    QFile::remove(workspace.m_autosaveFileName);
 }
 
 void TestWorkspaceUnit::testAutosaveRemovesPreviousFileWhenProjectDirChanges()

--- a/Tests/Unit/Scene/TestWorkspace.h
+++ b/Tests/Unit/Scene/TestWorkspace.h
@@ -39,6 +39,11 @@ private slots:
     void testAutosaveSkipsNewerVersionFile();
     void testAutosaveRemovesFileWhenUndoStackIsClean();
     void testAutosaveFallsBackToAppDataWhenProjectDirIsReadOnly();
+    /// An autosave must never be written into the bundled Examples directory: .gitignore
+    /// explicitly un-ignores it, so a hidden .<name>.<uuid>.panda beside an opened example
+    /// becomes a tracked file. An installed Examples/ is usually read-only and takes the
+    /// fallback above; a dev checkout's is writable, so read-only-ness is not the test.
+    void testAutosaveFallsBackToAppDataForBundledExamplesDir();
     void testAutosaveRemovesPreviousFileWhenProjectDirChanges();
     void testAutosaveThrowsWhenFileCannotBeOpened();
     void testAutosaveThrowsWhenCommitFails();

--- a/Tests/Unit/Serialization/TestDolphinExporter.cpp
+++ b/Tests/Unit/Serialization/TestDolphinExporter.cpp
@@ -10,6 +10,7 @@
 
 #include "App/BeWavedDolphin/DolphinExporter.h"
 #include "App/BeWavedDolphin/SignalModel.h"
+#include "App/Core/Enums.h"
 #include "Tests/Common/TestUtils.h"
 
 void TestDolphinExporter::testExportToPdfThrowsWhenPrinterCannotOpen()
@@ -40,4 +41,41 @@ void TestDolphinExporter::testExportToPdfThrowsWhenPrinterCannotOpen()
     QFile::setPermissions(lockedDir.path(),
         QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
 #endif
+}
+
+void TestDolphinExporter::testTruthTableTextWritesOneCharacterPerThreeStateCell()
+{
+    // The format has no separator between cells, so a row is only parseable while every value is
+    // one character wide. Status is four-state (Unknown = -1, Error = 2), so writing the raw int
+    // would widen a cell to two characters and shift every column after it.
+    SignalModel model(2, 4);
+    model.setInputRows(1);
+    model.setVerticalHeaderLabels({QStringLiteral("in"), QStringLiteral("out")});
+
+    model.setValue(0, 0, static_cast<int>(Status::Unknown));
+    model.setValue(0, 1, 1);
+    model.setValue(0, 2, 0);
+    model.setValue(0, 3, static_cast<int>(Status::Error));
+    for (int col = 0; col < 4; ++col) {
+        model.setValue(1, col, col % 2);
+    }
+
+    QString text;
+    QTextStream out(&text);
+    DolphinExporter::writeTruthTableText(out, &model, 1);
+    out.flush();
+
+    const auto lines = text.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    bool sawRow = false;
+    for (const QString &line : lines) {
+        const int sep = static_cast<int>(line.indexOf(QStringLiteral(" : ")));
+        if (sep < 0) {
+            continue;
+        }
+        sawRow = true;
+        QCOMPARE(sep, 4); // exactly one character per column, for all four columns
+        QVERIFY2(!line.left(sep).contains(QLatin1Char('-')),
+                 qPrintable(QStringLiteral("a raw negative Status leaked into the export: %1").arg(line)));
+    }
+    QVERIFY2(sawRow, "precondition: the export must contain at least one labelled data row");
 }

--- a/Tests/Unit/Serialization/TestDolphinExporter.h
+++ b/Tests/Unit/Serialization/TestDolphinExporter.h
@@ -13,4 +13,10 @@ class TestDolphinExporter : public QObject
 private slots:
 
     void testExportToPdfThrowsWhenPrinterCannotOpen();
+
+    /// writeTruthTableText() writes cells with NO separator, so every cell must be exactly one
+    /// character. A raw Status::Unknown (-1) prints as two and silently shifts the column count,
+    /// making the row unparseable -- routinely reachable, since oscillating regions canonicalise
+    /// to Unknown and propagate it to their readers.
+    void testTruthTableTextWritesOneCharacterPerThreeStateCell();
 };

--- a/Tests/Unit/Serialization/TestWaveformSimulator.cpp
+++ b/Tests/Unit/Serialization/TestWaveformSimulator.cpp
@@ -7,6 +7,7 @@
 #include "App/Element/GraphicElements/InputRotary.h"
 #include "App/Element/GraphicElements/InputSwitch.h"
 #include "App/Wiring/Port.h"
+#include "Tests/Common/TestUtils.h"
 
 void TestWaveformSimulator::testCaptureAndRestoreSinglePortInputs()
 {
@@ -50,4 +51,29 @@ void TestWaveformSimulator::testCaptureAndRestoreMultiPortInput()
     for (int port = 0; port < rotary.outputSize(); ++port) {
         QCOMPARE(rotary.outputPort(port)->status(), saved.at(port));
     }
+}
+
+void TestWaveformSimulator::testRestorePreservesNonDefiniteStatus()
+{
+    WorkSpace workspace;
+    CircuitBuilder builder(workspace.scene());
+    auto *sw = new InputSwitch();
+    builder.add(sw);
+
+    // A port that has never been driven reads Unknown -- the state captureInputs() would see for
+    // an input added but not yet simulated.
+    sw->outputPort(0)->setStatus(Status::Unknown);
+
+    const QVector<GraphicElementInput *> inputs{sw};
+    const auto saved = WaveformSimulator::captureInputs(inputs, 1);
+    QCOMPARE(saved.size(), 1);
+    QCOMPARE(saved.at(0), Status::Unknown);
+
+    // Whatever the sweep left behind:
+    sw->setOn(true);
+    QCOMPARE(sw->outputPort(0)->status(), Status::Active);
+
+    WaveformSimulator::restoreInputs(inputs, saved);
+    QVERIFY2(sw->outputPort(0)->status() == Status::Unknown,
+             "an undefined input port must be restored undefined, not driven HIGH");
 }

--- a/Tests/Unit/Serialization/TestWaveformSimulator.h
+++ b/Tests/Unit/Serialization/TestWaveformSimulator.h
@@ -14,4 +14,8 @@ private slots:
 
     void testCaptureAndRestoreSinglePortInputs();
     void testCaptureAndRestoreMultiPortInput();
+    /// A four-state Status must survive the capture/restore round trip. Status::Unknown is -1
+    /// and Status::Error is 2, so casting one to bool makes BOTH true and brings an undefined
+    /// input port back driven HIGH -- a sweep silently mutating the live circuit.
+    void testRestorePreservesNonDefiniteStatus();
 };

--- a/Tests/Unit/Simulation/TestSimulation.cpp
+++ b/Tests/Unit/Simulation/TestSimulation.cpp
@@ -3,6 +3,8 @@
 
 #include "Tests/Unit/Simulation/TestSimulation.h"
 
+#include <QElapsedTimer>
+
 #include "App/Core/Application.h"
 #include "App/Core/SimulationHost.h"
 #include "App/Element/ElementFactory.h"
@@ -14,6 +16,7 @@
 #include "App/Scene/Scene.h"
 #include "App/Scene/Workspace.h"
 #include "App/Simulation/Simulation.h"
+#include "App/Simulation/SimulationBlocker.h"
 #include "App/Wiring/Connection.h"
 #include "App/Wiring/Port.h"
 #include "Tests/Common/TestUtils.h"
@@ -299,4 +302,44 @@ void TestSimulationUnit::testUpdateFlushesPendingVisualsOnLaterIdleTick()
     sim.update(); // tick 5/5: interval elapses, flush happens
     QVERIFY2(!sim.m_visualsDirty,
               "A pending visual flush must happen on an idle tick once the throttle interval elapses");
+}
+
+void TestSimulationUnit::testBlockerCyclePreservesClockLevel()
+{
+    WorkSpace workspace;
+    auto *scene = workspace.scene();
+    auto *sim = scene->simulation();
+
+    auto *clock = qobject_cast<Clock *>(ElementFactory::buildElement(ElementType::Clock));
+    QVERIFY(clock);
+    // 10 Hz ⇒ 50 ms per phase: slow enough that the post-resume assertion below runs well
+    // inside the LOW phase, fast enough for the first falling edge to land quickly.
+    clock->setFrequency(10.0);
+    scene->addItem(clock);
+
+    sim->start();
+    QVERIFY(sim->isRunning());
+
+    // Clocks start HIGH (resetClock in initialize()); spin the event loop until the first
+    // real falling edge lands so the clock is observably mid-LOW-phase. A plain qWait loop
+    // instead of QTRY_VERIFY_WITH_TIMEOUT: Qt 6.8/6.9's QTRY macros expand with a
+    // long→int chrono conversion that trips -Werror=conversion on the CI compilers.
+    QElapsedTimer waitForLow;
+    waitForLow.start();
+    while (clock->isOn() && waitForLow.elapsed() < 2000) {
+        QTest::qWait(10);
+    }
+    QVERIFY2(!clock->isOn(), "clock never fell within 2 s of starting");
+
+    // A SimulationBlocker cycle brackets every UpdateCommand redo/undo — including a plain
+    // InputSwitch click on a running circuit. The resume must preserve the level: resetClock()
+    // forces the output HIGH, which is an out-of-thin-air rising edge for every clock-driven
+    // element, advancing counters without a real edge.
+    {
+        SimulationBlocker blocker(sim);
+    }
+    QVERIFY2(!clock->isOn(),
+             "resume after a SimulationBlocker cycle forced the clock HIGH mid-LOW-phase");
+
+    sim->stop();
 }

--- a/Tests/Unit/Simulation/TestSimulation.h
+++ b/Tests/Unit/Simulation/TestSimulation.h
@@ -27,4 +27,8 @@ private slots:
     void testUpdatePortWithNullPortsAreNoOps();
     void testCollectSequentialElementsSkipsNullElements();
     void testUpdateFlushesPendingVisualsOnLaterIdleTick();
+
+    /// A SimulationBlocker pause/resume cycle (every UpdateCommand redo/undo, including a
+    /// plain InputSwitch click) must not force clocks HIGH or restart their phase.
+    void testBlockerCyclePreservesClockLevel();
 };


### PR DESCRIPTION
Fourteen fixes for behaviour that is broken in the product today. Each one is
self-contained, needs nothing from any in-flight work, and carries a regression
test that was confirmed to fail against the unfixed code.

They were found while auditing a larger simulation branch and are split out
here so they do not wait behind it.

## Simulation

- **Clocks lose their phase and level on every pause/resume.** `SimulationBlocker`
  brackets every `UpdateCommand` — a plain `InputSwitch` click on a running
  circuit included — and resumed through `Simulation::start()`, which called
  `resetClock()` on every `Clock`. That forces the output HIGH and restarts the
  phase, so clicking a switch while a clock was LOW injected a rising edge out of
  nothing (counters advanced without a real edge), and clicking faster than the
  half-period pinned clocks HIGH. `start()` now shifts each clock's phase
  reference forward by the pause duration instead of resetting it.
- **The 1 ms timer slot was unguarded.** `Application::notify`'s catch is
  structurally unreachable on macOS, which is why slots that can throw must use
  `Application::guardedSlot`. Guarded at the connection, so `update()`'s direct
  callers (the sweep, the MCP handlers, the tests) still see exceptions.

## Three-state was collapsed at four boundaries

Each one picked a different wrong answer for `Unknown`/`Error`:

- `WaveformSimulator::restoreInputs()` did `static_cast<bool>` on a `Status`.
  `Unknown` is -1 and `Error` is 2, so **both restored ON** — a sweep turning an
  undriven input into a driven-high one in the live circuit.
- `SignalDelegate::segmentFor()` drew an undefined signal as a confident logic
  HIGH, so the same signal read as a grey wire on the canvas and a clean `1` in
  the waveform view.
- `DolphinExporter::writeTruthTableText()` writes cells with no separator, so a
  raw `-1` printed as two characters and shifted the column count, leaving the
  row unparseable.
- `SystemVerilogCodeGen::highLow()` exported `Unknown` as `1'b0` into a language
  that has `1'bx`. Split: seeded feedback regs stay two-state deliberately;
  unconnected-input defaults now export `1'bx`.
- `get_output_value` returned a bare bool while `create_waveform` emitted a raw
  `-1` — one server reporting the same signal two ways. A `status` field
  (`low|high|unknown|error`) resolves it, and `create_waveform` now declares its
  encoding in the schema instead of typing values as bare integers.

## BeWavedDolphin

- **`create_waveform` returned mislabelled rows.** The table has always been one
  row per *port*, but the layout was re-derived in three places and they
  disagreed — `sweep()` indexed per port, `snapshot()` and `inputRow()` per
  *element*. Any multi-port element (a 2-bit rotary, a Display7) produced
  confidently wrong values under correct-looking labels: 3 signals reported for
  an 11-row table. `DolphinModelBuilder::Row` is now the single source of truth.
  `snapshot()` reports one signal per port, labelled `Name[port]` — a breaking
  change to `create_waveform`'s response shape, with the schema and Python client
  updated.
- **A sweep left its last column in the live circuit.** `sweep()` reset every
  element on entry but restored only input levels, so a read-only-looking
  `create_waveform` mutated the user's circuit: a flip-flop driven high came back
  low. `saveSimState()`/`restoreSimState()` now mirror `resetSimState()` exactly,
  IC recursion included, under a `qScopeGuard`.
- **`InputRotary` never participated in that reset.** `m_currentPort` is not an
  output value, so the base reset left it alone. Every column of a default sweep
  ran at whatever position the user last left the rotary on: sweep, click the
  rotary, re-run the identical table, get different outputs.

## SystemVerilog export

- **Top-level feedback loops were silently constant-folded.**
  `findFeedbackElements()` had one call site, inside `generateSingleICModule()`,
  and its set is cleared on the way out — so no top-level element could ever be
  recognised. A cross-coupled NAND latch drawn on the canvas exported as
  `assign led5_1 = ~(ns & ~(~(1'b0 & 1'b0) & nr));`: it compiles, simulates
  cleanly, and computes the wrong function with the memory removed. Verified
  through iverilog rather than by reading the text, which looked plausible at two
  of the three intermediate stages. First top-level (non-IC) circuit in the
  differential — all 77 existing fixtures are `.panda` ICs, which is why this path
  was never exercised.

## Build and infrastructure

- **The MCP schema copy only ran on relink.** It was an
  `add_custom_command(TARGET ... POST_BUILD)`, so editing *only* the schema left a
  stale copy next to the executables and the server kept validating the old
  contract — surviving several rebuilds and presenting as an
  "additional property is invalid" naming a property the checked-in schema plainly
  allows. Now an `OUTPUT`/`DEPENDS` rule keyed on the schema itself.
- **Autosaves were written into the bundled `Examples/` directory.** 81 had
  accumulated, which `.gitignore` then explicitly un-ignores. The existing
  read-only check covers an *installed* copy; a dev checkout's `Examples/` is
  writable, so writability was never the right question — these are shipped
  content, not the user's project.
- **Arduino export had no differential at all.** Reading emitted text cannot catch
  a tick-model divergence; only running it against the engine can. About thirty
  lines of stubs, gated Linux-only with `QSKIP` when `g++` is absent, ~160 ms.
- `TruthTable`'s key size was three magic numbers peaking at bit 2047 of a
  2048-bit array — correct with zero slack. Derived from the port limits, with a
  `static_assert` pinning 2048, because `.panda` stores the `QBitArray` verbatim.
- A comment named a class the codebase itself renamed.

## Verification

`ctest --preset debug` 216/216 at the tip, zero compiler warnings, and each of
the fourteen commits was built and tested on its own — none of them repairs an
earlier one. MCP client suite 108/108. The SystemVerilog iverilog differential
(78/78) and the new Arduino differential run as part of the suite.
