### PR TITLE
fix: three product defects the non-blocking GUI lanes were hiding, and the tests that hid them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,32 +169,28 @@ jobs:
       if: runner.os == 'Linux' && failure()
       run: ./Scripts/ci_linux_core_analyze.sh build-release/test_wiredpanda "$RUNNER_TEMP/cores" crash-diagnostics
 
-    # Trial runs of the gui suite off-Linux, non-blocking while they build a
+    # Trial run of the gui suite off-Linux, non-blocking while it builds a
     # track record (promote to blocking once proven stable; see the polling
-    # AutoDismisser test hardening that unblocked this). macOS pins the
-    # offscreen platform: the historical hang class was native-cocoa modal
-    # activation timing. Windows tries the native platform first — its
-    # runners already run the widget-creating non-gui suite natively and
-    # green. Separate steps on purpose: a ternary env expression could set
-    # QT_QPA_PLATFORM to "" (set-but-empty), which makes Qt load no platform.
+    # AutoDismisser test hardening that unblocked this). Offscreen on both:
+    # the historical macOS hang class was native-cocoa modal activation
+    # timing, and Windows turned out to have the same shape against a real
+    # window manager — TestMainWindowGui calls createMW() at 145 sites, so it
+    # shows that many top-level windows in one process, and it stalled 4 of 10
+    # native runs on QTEST_FUNCTION_TIMEOUT, at a different test function each
+    # time, while the same binary on the same runner passed 5 of 5 offscreen.
+    # The non-gui suite stays native: it creates widgets, but not a window per
+    # test. One step rather than one per OS, now that both want the same
+    # literal value — the pitfall that forced them apart was a ternary env
+    # expression evaluating to "" (set-but-empty), which makes Qt load no
+    # platform at all.
     - name: Test (GUI, offscreen, trial)
-      id: test-gui-macos-trial
-      if: runner.os == 'macOS'
+      id: test-gui-trial
+      if: runner.os != 'Linux'
       timeout-minutes: 10
       continue-on-error: true
       env:
         QT_FORCE_STDERR_LOGGING: 1
         QT_QPA_PLATFORM: offscreen
-      run: |
-        ctest --preset release -V -L gui -FS non_gui_complete
-
-    - name: Test (GUI, native, trial)
-      id: test-gui-windows-trial
-      if: runner.os == 'Windows'
-      timeout-minutes: 10
-      continue-on-error: true
-      env:
-        QT_FORCE_STDERR_LOGGING: 1
       run: |
         ctest --preset release -V -L gui -FS non_gui_complete
 
@@ -219,10 +215,10 @@ jobs:
         fi
 
     - name: Upload build artifacts on failure
-      # continue-on-error on the two GUI-trial steps means their failure alone
-      # doesn't make failure() true -- check those steps' own outcomes too, or a
+      # continue-on-error on the GUI-trial step means its failure alone doesn't
+      # make failure() true -- check that step's own outcome too, or a
       # GUI-trial-only crash's diagnostics would never get uploaded.
-      if: failure() || steps.test-gui-macos-trial.outcome == 'failure' || steps.test-gui-windows-trial.outcome == 'failure'
+      if: failure() || steps.test-gui-trial.outcome == 'failure'
       uses: actions/upload-artifact@v7
       with:
         name: build-logs-${{ matrix.os }}-${{ matrix.qt }}${{ contains(matrix.cmake_args, 'ENABLE_UNITY=OFF') && '-no-unity' || contains(matrix.cmake_args, 'BATCH_SIZE=1000') && '-mega-unity' || '' }}

--- a/App/Scene/ICRegistry.cpp
+++ b/App/Scene/ICRegistry.cpp
@@ -10,6 +10,7 @@
 #include <QSaveFile>
 #include <QThread>
 
+#include "App/Core/Application.h"
 #include "App/Core/Common.h"
 #include "App/Element/GraphicElement.h"
 #include "App/Element/IC.h"
@@ -80,43 +81,50 @@ QList<GraphicElement *> ICRegistry::findICsByFile(const QString &fileName) const
 
 void ICRegistry::onFileChanged(const QString &filePath)
 {
-    qCDebug(zero) << "IC file changed:" << filePath;
+    // Guarded because this is a queued slot that deliberately rethrows below: an escaping
+    // exception crosses Qt's signal-slot dispatch, where Application::notify's catch is
+    // structurally unreachable on macOS -- the unwinder reaches std::terminate mid-stack.
+    // Deleting a watched IC file therefore killed the application there instead of
+    // reporting the load error, while Linux caught the same throw and carried on.
+    Application::guardedSlot(this, [this, &filePath] {
+        qCDebug(zero) << "IC file changed:" << filePath;
 
-    // Invalidate the cached definition so it's rebuilt on next access
-    invalidate(filePath);
+        // Invalidate the cached definition so it's rebuilt on next access
+        invalidate(filePath);
 
-    // Re-add the watch (some OS remove it after a file change event)
-    if (!m_fileWatcher.files().contains(filePath) && QFileInfo::exists(filePath)) {
-        m_fileWatcher.addPath(filePath);
-    }
+        // Re-add the watch (some OS remove it after a file change event)
+        if (!m_fileWatcher.files().contains(filePath) && QFileInfo::exists(filePath)) {
+            m_fileWatcher.addPath(filePath);
+        }
 
-    // Reload all IC instances referencing this file
-    const auto targets = findICsByFile(filePath);
-    if (targets.isEmpty()) {
-        emit definitionChanged(filePath);
-        return;
-    }
+        // Reload all IC instances referencing this file
+        const auto targets = findICsByFile(filePath);
+        if (targets.isEmpty()) {
+            emit definitionChanged(filePath);
+            return;
+        }
 
-    // Capture pre-reload state so the undo command can restore both the
-    // ICs' element data and the scene wires that touch their ports.
-    // Without this the wires get cascade-deleted by setInputSize/setOutputSize
-    // inside loadFile and Cluster D throws on the next undo lookup.
-    const auto connections = UpdateBlobCommand::captureConnections(targets);
-    const QByteArray oldData = captureSnapshot(targets);
+        // Capture pre-reload state so the undo command can restore both the
+        // ICs' element data and the scene wires that touch their ports.
+        // Without this the wires get cascade-deleted by setInputSize/setOutputSize
+        // inside loadFile and Cluster D throws on the next undo lookup.
+        const auto connections = UpdateBlobCommand::captureConnections(targets);
+        const QByteArray oldData = captureSnapshot(targets);
 
-    try {
-        reloadTargetsAtomically(targets, oldData, [&](IC *ic) { ic->loadFile(filePath); });
-    } catch (...) {
+        try {
+            reloadTargetsAtomically(targets, oldData, [&](IC *ic) { ic->loadFile(filePath); });
+        } catch (...) {
+            m_scene->setCircuitUpdateRequired();
+            emit definitionChanged(filePath);
+            throw;
+        }
         m_scene->setCircuitUpdateRequired();
+
+        auto *cmd = new UpdateBlobCommand(targets, oldData, connections, m_scene);
+        m_scene->undoStack()->push(cmd);
+
         emit definitionChanged(filePath);
-        throw;
-    }
-    m_scene->setCircuitUpdateRequired();
-
-    auto *cmd = new UpdateBlobCommand(targets, oldData, connections, m_scene);
-    m_scene->undoStack()->push(cmd);
-
-    emit definitionChanged(filePath);
+    });
 }
 
 // --- Embedded IC blob storage ---

--- a/App/UI/ICController.cpp
+++ b/App/UI/ICController.cpp
@@ -199,242 +199,256 @@ bool ICController::ensureProjectSaved(Scene *scene)
 
 void ICController::embedSelectedIC()
 {
-    sentryBreadcrumb("ic", QStringLiteral("Embed IC"));
-    auto *firstIC = selectedIC();
-    if (!firstIC || firstIC->file().isEmpty()) {
-        return;
-    }
-
-    auto *scene = m_host.currentTab()->scene();
-
-    if (!ensureProjectSaved(scene)) {
-        return;
-    }
-    const QString contextDir = scene->contextDir();
-
-    QString blobName = resolveUniqueBlobName(QFileInfo(firstIC->file()).baseName(), scene);
-    if (blobName.isEmpty()) {
-        return;
-    }
-
-    QFile file(QDir(contextDir).absoluteFilePath(firstIC->file()));
-    if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-        return;
-    }
-    QByteArray fileBytes = file.readAll();
-    file.close();
-
-    scene->icRegistry()->embedICsByFile(firstIC->file(), fileBytes, blobName);
-    m_host.palette()->updateEmbeddedICList(scene);
-    m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
-}
-
-void ICController::extractSelectedIC()
-{
-    sentryBreadcrumb("ic", QStringLiteral("Extract IC"));
-    auto *firstIC = selectedIC();
-    if (!firstIC || !firstIC->isEmbedded()) {
-        return;
-    }
-
-    auto *scene = m_host.currentTab()->scene();
-    const QString blobName = firstIC->blobName();
-    if (!ensureProjectSaved(scene)) {
-        return;
-    }
-    const QString contextDir = scene->contextDir();
-
-    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
-    QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files") + " (*.panda)").fileName;
-
-    if (fileName.isEmpty()) {
-        return;
-    }
-
-    if (!fileName.endsWith(".panda")) {
-        fileName.append(".panda");
-    }
-
-    scene->icRegistry()->extractToFile(blobName, fileName);
-    m_host.palette()->updateICList(m_host.icListFile());
-    m_host.palette()->updateEmbeddedICList(scene);
-    m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
-}
-
-void ICController::embedICByFile(const QString &fileName)
-{
-    auto *tab = m_host.currentTab();
-    if (!tab) {
-        return;
-    }
-
-    auto *scene = tab->scene();
-    if (!ensureProjectSaved(scene)) {
-        return;
-    }
-    const QString contextDir = scene->contextDir();
-
-    const QString absolutePath = QDir(contextDir).absoluteFilePath(fileName);
-    QFile file(absolutePath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-        return;
-    }
-    QByteArray fileBytes = file.readAll();
-    file.close();
-
-    QString blobName = resolveUniqueBlobName(QFileInfo(absolutePath).baseName(), scene);
-    if (blobName.isEmpty()) {
-        return;
-    }
-
-    auto *reg = scene->icRegistry();
-    if (reg->embedICsByFile(absolutePath, fileBytes, blobName) == 0) {
-        // No existing instances — register the blob only; don't add to scene.
-        scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
-    }
-
-    m_host.palette()->updateEmbeddedICList(scene);
-    m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
-}
-
-void ICController::extractICByBlobName(const QString &blobName)
-{
-    auto *tab = m_host.currentTab();
-    if (!tab) {
-        return;
-    }
-
-    auto *scene = tab->scene();
-    if (!ensureProjectSaved(scene)) {
-        return;
-    }
-    const QString contextDir = scene->contextDir();
-
-    // Find any embedded IC with this blobName to get the blob data
-    auto *reg = scene->icRegistry();
-    if (!reg->hasBlob(blobName)) {
-        return;
-    }
-
-    const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
-    QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files") + " (*.panda)").fileName;
-
-    if (fileName.isEmpty()) {
-        return;
-    }
-
-    if (!fileName.endsWith(".panda")) {
-        fileName.append(".panda");
-    }
-
-    reg->extractToFile(blobName, fileName);
-    m_host.palette()->updateICList(m_host.icListFile());
-    m_host.palette()->updateEmbeddedICList(scene);
-    m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
-}
-
-void ICController::makeSelfContained()
-{
-    sentryBreadcrumb("ic", QStringLiteral("Make self-contained"));
-    auto *tab = m_host.currentTab();
-    if (!tab) {
-        return;
-    }
-
-    auto *scene = tab->scene();
-    if (!ensureProjectSaved(scene)) {
-        return;
-    }
-    const QString contextDir = scene->contextDir();
-
-    // Collect unique file paths from all file-backed ICs
-    QStringList uniqueFiles;
-    for (auto *elm : scene->elements()) {
-        if (elm->elementType() != ElementType::IC || elm->isEmbedded()) {
-            continue;
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ic", QStringLiteral("Embed IC"));
+        auto *firstIC = selectedIC();
+        if (!firstIC || firstIC->file().isEmpty()) {
+            return;
         }
-        const QString icFile = static_cast<IC *>(elm)->file();
-        if (!icFile.isEmpty() && !uniqueFiles.contains(icFile)) {
-            uniqueFiles.append(icFile);
+
+        auto *scene = m_host.currentTab()->scene();
+
+        if (!ensureProjectSaved(scene)) {
+            return;
         }
-    }
+        const QString contextDir = scene->contextDir();
 
-    if (uniqueFiles.isEmpty()) {
-        m_host.showStatusMessage(tr("No file-based ICs to embed."), 4000);
-        return;
-    }
+        QString blobName = resolveUniqueBlobName(QFileInfo(firstIC->file()).baseName(), scene);
+        if (blobName.isEmpty()) {
+            return;
+        }
 
-    int totalEmbedded = 0;
-    bool completed = true;
-    auto *reg = scene->icRegistry();
-
-    for (const QString &icFile : std::as_const(uniqueFiles)) {
-        const QString fullPath = QDir(contextDir).absoluteFilePath(icFile);
-        QFile file(fullPath);
+        QFile file(QDir(contextDir).absoluteFilePath(firstIC->file()));
         if (!file.open(QIODevice::ReadOnly)) {
             QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
-            completed = false;
-            break;
+            return;
         }
         QByteArray fileBytes = file.readAll();
         file.close();
 
-        QString blobName = resolveUniqueBlobName(QFileInfo(icFile).baseName(), scene);
-        if (blobName.isEmpty()) {
-            completed = false;
-            break; // User cancelled
+        scene->icRegistry()->embedICsByFile(firstIC->file(), fileBytes, blobName);
+        m_host.palette()->updateEmbeddedICList(scene);
+        m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
+    });
+}
+
+void ICController::extractSelectedIC()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ic", QStringLiteral("Extract IC"));
+        auto *firstIC = selectedIC();
+        if (!firstIC || !firstIC->isEmbedded()) {
+            return;
         }
 
-        totalEmbedded += reg->embedICsByFile(fullPath, fileBytes, blobName);
-    }
+        auto *scene = m_host.currentTab()->scene();
+        const QString blobName = firstIC->blobName();
+        if (!ensureProjectSaved(scene)) {
+            return;
+        }
+        const QString contextDir = scene->contextDir();
 
-    m_host.palette()->updateEmbeddedICList(scene);
-    // Only claim the circuit is self-contained when every file-based IC was embedded. On a
-    // read error or a cancelled prompt the loop breaks early, so report the partial result
-    // honestly (or stay quiet if nothing was embedded — the error/cancel already spoke).
-    if (completed) {
-        m_host.showStatusMessage(tr("Embedded %1 IC(s). Circuit is now self-contained.").arg(totalEmbedded), 4000);
-    } else if (totalEmbedded > 0) {
-        m_host.showStatusMessage(tr("Embedded %1 IC(s); some file-based ICs remain.").arg(totalEmbedded), 4000);
-    }
+        const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
+        QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files") + " (*.panda)").fileName;
+
+        if (fileName.isEmpty()) {
+            return;
+        }
+
+        if (!fileName.endsWith(".panda")) {
+            fileName.append(".panda");
+        }
+
+        scene->icRegistry()->extractToFile(blobName, fileName);
+        m_host.palette()->updateICList(m_host.icListFile());
+        m_host.palette()->updateEmbeddedICList(scene);
+        m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
+    });
+}
+
+void ICController::embedICByFile(const QString &fileName)
+{
+    Application::guardedSlot(this, [this, &fileName] {
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        auto *scene = tab->scene();
+        if (!ensureProjectSaved(scene)) {
+            return;
+        }
+        const QString contextDir = scene->contextDir();
+
+        const QString absolutePath = QDir(contextDir).absoluteFilePath(fileName);
+        QFile file(absolutePath);
+        if (!file.open(QIODevice::ReadOnly)) {
+            QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
+            return;
+        }
+        QByteArray fileBytes = file.readAll();
+        file.close();
+
+        QString blobName = resolveUniqueBlobName(QFileInfo(absolutePath).baseName(), scene);
+        if (blobName.isEmpty()) {
+            return;
+        }
+
+        auto *reg = scene->icRegistry();
+        if (reg->embedICsByFile(absolutePath, fileBytes, blobName) == 0) {
+            // No existing instances — register the blob only; don't add to scene.
+            scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
+        }
+
+        m_host.palette()->updateEmbeddedICList(scene);
+        m_host.showStatusMessage(tr("IC embedded successfully."), 4000);
+    });
+}
+
+void ICController::extractICByBlobName(const QString &blobName)
+{
+    Application::guardedSlot(this, [this, &blobName] {
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        auto *scene = tab->scene();
+        if (!ensureProjectSaved(scene)) {
+            return;
+        }
+        const QString contextDir = scene->contextDir();
+
+        // Find any embedded IC with this blobName to get the blob data
+        auto *reg = scene->icRegistry();
+        if (!reg->hasBlob(blobName)) {
+            return;
+        }
+
+        const QString suggestion = QDir(contextDir).absoluteFilePath(blobName + ".panda");
+        QString fileName = FileDialogs::provider()->getSaveFileName(m_host.widget(), tr("Extract IC to file..."), suggestion, tr("Panda files") + " (*.panda)").fileName;
+
+        if (fileName.isEmpty()) {
+            return;
+        }
+
+        if (!fileName.endsWith(".panda")) {
+            fileName.append(".panda");
+        }
+
+        reg->extractToFile(blobName, fileName);
+        m_host.palette()->updateICList(m_host.icListFile());
+        m_host.palette()->updateEmbeddedICList(scene);
+        m_host.showStatusMessage(tr("IC extracted to %1").arg(fileName), 4000);
+    });
+}
+
+void ICController::makeSelfContained()
+{
+    Application::guardedSlot(this, [this] {
+        sentryBreadcrumb("ic", QStringLiteral("Make self-contained"));
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+
+        auto *scene = tab->scene();
+        if (!ensureProjectSaved(scene)) {
+            return;
+        }
+        const QString contextDir = scene->contextDir();
+
+        // Collect unique file paths from all file-backed ICs
+        QStringList uniqueFiles;
+        for (auto *elm : scene->elements()) {
+            if (elm->elementType() != ElementType::IC || elm->isEmbedded()) {
+                continue;
+            }
+            const QString icFile = static_cast<IC *>(elm)->file();
+            if (!icFile.isEmpty() && !uniqueFiles.contains(icFile)) {
+                uniqueFiles.append(icFile);
+            }
+        }
+
+        if (uniqueFiles.isEmpty()) {
+            m_host.showStatusMessage(tr("No file-based ICs to embed."), 4000);
+            return;
+        }
+
+        int totalEmbedded = 0;
+        bool completed = true;
+        auto *reg = scene->icRegistry();
+
+        for (const QString &icFile : std::as_const(uniqueFiles)) {
+            const QString fullPath = QDir(contextDir).absoluteFilePath(icFile);
+            QFile file(fullPath);
+            if (!file.open(QIODevice::ReadOnly)) {
+                QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read IC file: %1").arg(file.errorString()));
+                completed = false;
+                break;
+            }
+            QByteArray fileBytes = file.readAll();
+            file.close();
+
+            QString blobName = resolveUniqueBlobName(QFileInfo(icFile).baseName(), scene);
+            if (blobName.isEmpty()) {
+                completed = false;
+                break; // User cancelled
+            }
+
+            totalEmbedded += reg->embedICsByFile(fullPath, fileBytes, blobName);
+        }
+
+        m_host.palette()->updateEmbeddedICList(scene);
+        // Only claim the circuit is self-contained when every file-based IC was embedded. On a
+        // read error or a cancelled prompt the loop breaks early, so report the partial result
+        // honestly (or stay quiet if nothing was embedded — the error/cancel already spoke).
+        if (completed) {
+            m_host.showStatusMessage(tr("Embedded %1 IC(s). Circuit is now self-contained.").arg(totalEmbedded), 4000);
+        } else if (totalEmbedded > 0) {
+            m_host.showStatusMessage(tr("Embedded %1 IC(s); some file-based ICs remain.").arg(totalEmbedded), 4000);
+        }
+    });
 }
 
 void ICController::addEmbeddedICFromFile()
 {
-    auto *tab = m_host.currentTab();
-    if (!tab) {
-        return;
-    }
-    QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Select IC file to embed"), m_host.currentDir().absolutePath(), tr("Panda files") + " (*.panda)");
-    if (fileName.isEmpty()) {
-        return;
-    }
+    Application::guardedSlot(this, [this] {
+        auto *tab = m_host.currentTab();
+        if (!tab) {
+            return;
+        }
+        QString fileName = FileDialogs::provider()->getOpenFileName(m_host.widget(), tr("Select IC file to embed"), m_host.currentDir().absolutePath(), tr("Panda files") + " (*.panda)");
+        if (fileName.isEmpty()) {
+            return;
+        }
 
-    QFile file(fileName);
-    if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read file: %1").arg(file.errorString()));
-        return;
-    }
-    QByteArray fileBytes = file.readAll();
-    file.close();
+        QFile file(fileName);
+        if (!file.open(QIODevice::ReadOnly)) {
+            QMessageBox::warning(m_host.widget(), tr("Error"), tr("Could not read file: %1").arg(file.errorString()));
+            return;
+        }
+        QByteArray fileBytes = file.readAll();
+        file.close();
 
-    auto *scene = tab->scene();
-    QString blobName = resolveUniqueBlobName(QFileInfo(fileName).baseName(), scene);
-    if (blobName.isEmpty()) {
-        return;
-    }
+        auto *scene = tab->scene();
+        QString blobName = resolveUniqueBlobName(QFileInfo(fileName).baseName(), scene);
+        if (blobName.isEmpty()) {
+            return;
+        }
 
-    scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
-    m_host.palette()->updateEmbeddedICList(scene);
+        scene->receiveCommand(new RegisterBlobCommand(blobName, fileBytes, scene));
+        m_host.palette()->updateEmbeddedICList(scene);
+    });
 }
 
 void ICController::removeEmbeddedIC(const QString &blobName)
 {
-    auto *tab = m_host.currentTab();
-    if (tab) {
-        tab->removeEmbeddedIC(blobName);
-        m_host.palette()->updateEmbeddedICList(tab->scene());
-    }
+    Application::guardedSlot(this, [this, &blobName] {
+        auto *tab = m_host.currentTab();
+        if (tab) {
+            tab->removeEmbeddedIC(blobName);
+            m_host.palette()->updateEmbeddedICList(tab->scene());
+        }
+    });
 }

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -450,6 +450,11 @@ MainWindow::~MainWindow()
 {
     // Tear down the active tab's chrome wiring before child objects are destroyed.
     m_binder->unbind();
+
+    // Same ordering concern, one level deeper: the waveform window is a child, so ~QWidget
+    // deletes it and its destroyed() reaches the slot below with this object already torn
+    // down to its QWidget base. Sever it here, while the derived object is still whole.
+    disconnect(m_bwdDestroyed);
 }
 
 void MainWindow::createNewTab()
@@ -1103,7 +1108,7 @@ void MainWindow::on_actionWaveform_triggered()
         auto *bwd = new BewavedDolphin(currentTab()->scene(), true, this, this);
         bwd->createWaveform(currentTab()->dolphinFileName());
         m_bwd = bwd;
-        connect(bwd, &QObject::destroyed, this, [this] {
+        m_bwdDestroyed = connect(bwd, &QObject::destroyed, this, [this] {
             if (m_exerciseOverlay && m_exerciseEngine && m_exerciseEngine->isActive()) {
                 m_exerciseOverlay->hide();
                 m_exerciseOverlay->setParent(nullptr);

--- a/App/UI/MainWindow.cpp
+++ b/App/UI/MainWindow.cpp
@@ -414,7 +414,15 @@ void MainWindow::setupConnections()
     });
     connect(m_ui->pushButtonAddIC,             &QPushButton::clicked,     m_icController,      &ICController::addICFromFile);
     connect(m_ui->pushButtonRemoveIC,          &QPushButton::clicked,     m_icController,      &ICController::showRemoveICHint);
-    connect(m_ui->pushButtonRemoveIC,          &TrashButton::removeICFile,m_icController,      &ICController::removeICFile);
+    // Guarded here rather than inside removeICFile(): a failed moveToTrash() must keep
+    // throwing to direct callers, which TestICController pins, while an exception crossing
+    // signal-slot dispatch must not reach notify()'s catch -- unreachable on macOS.
+    connect(m_ui->pushButtonRemoveIC, &TrashButton::removeICFile, m_icController,
+        [this](const QString &icFileName) {
+            Application::guardedSlot(m_icController, [this, &icFileName] {
+                m_icController->removeICFile(icFileName);
+            });
+        });
     connect(m_ui->pushButtonMakeSelfContained, &QPushButton::clicked,     m_icController,      &ICController::makeSelfContained);
     connect(m_ui->actionMakeSelfContained,     &QAction::triggered,       m_icController,      &ICController::makeSelfContained);
 

--- a/App/UI/MainWindow.h
+++ b/App/UI/MainWindow.h
@@ -333,6 +333,10 @@ private:
     QPointer<TourOverlay> m_tourOverlay;
 
     QPointer<BewavedDolphin> m_bwd;
+    /// Severed in ~MainWindow. The waveform window is a child of this one, so its destroyed()
+    /// is emitted from QObjectPrivate::deleteChildren() inside ~QWidget -- by which point
+    /// ~MainWindow's body has run and the slot's captured `this` is only a QWidget.
+    QMetaObject::Connection m_bwdDestroyed;
 
     /// The tab being left, captured for onCurrentTabChanged(): by the time that slot runs,
     /// currentTab() already reflects the arriving tab (WorkspaceManager updates its current-tab

--- a/App/UI/UpdateController.cpp
+++ b/App/UI/UpdateController.cpp
@@ -15,6 +15,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QPointer>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QSslError>
@@ -102,9 +103,22 @@ void UpdateController::downloadUpdate(const QString &latestVersion, const QUrl &
     QDir().mkpath(downloadDir);
     const QString savePath = QDir(downloadDir).filePath(fileName);
 
+    // The progress dialog below is not window-modal, so the main window stays interactive and
+    // Check for Updates can be triggered again mid-download. Raise the existing download
+    // rather than starting a second one onto the same path.
+    if (m_progressDialog) {
+        m_progressDialog->raise();
+        m_progressDialog->activateWindow();
+        return;
+    }
+
     auto *progress = new QProgressDialog(tr("Downloading wiRedPanda %1…").arg(latestVersion), tr("Cancel"), 0, 100, m_parent);
     progress->setWindowTitle(tr("Downloading Update"));
-    progress->setWindowModality(Qt::WindowModal);
+    // Deliberately NOT window-modal. QProgressDialog::setValue() calls processEvents() when the
+    // dialog is modal, so driving it from downloadProgress re-enters the event loop: that nested
+    // pump delivers finished(), which tears this dialog down, and setValue() then resumes on its
+    // own freed QProgressBar. Cancel still works -- it is a button on this dialog, not something
+    // modality provides.
     progress->setMinimumDuration(0);
     progress->setValue(0);
 
@@ -125,17 +139,29 @@ void UpdateController::downloadUpdate(const QString &latestVersion, const QUrl &
     request.setTransferTimeout(60000);
     QNetworkReply *reply = network->get(request);
 
-    connect(reply, &QNetworkReply::downloadProgress, progress, [progress](qint64 received, qint64 total) {
-        if (total > 0) {
-            progress->setValue(static_cast<int>(received * 100 / total));
-        }
-    });
+    // Belt and braces around the non-modality above: the connection is severed the moment the
+    // download finishes, and the dialog is reached through a QPointer so a delivery after its
+    // destruction is skipped rather than fatal. Neither is sufficient on its own -- a guard
+    // cannot help once the object dies inside the very setValue() call the guard permitted,
+    // which is exactly what modality caused.
+    const QPointer<QProgressDialog> progressGuard(progress);
+    m_progressDialog = progress;
+    const QMetaObject::Connection progressConnection =
+        connect(reply, &QNetworkReply::downloadProgress, progress, [progressGuard](qint64 received, qint64 total) {
+            if (total > 0 && progressGuard) {
+                progressGuard->setValue(static_cast<int>(received * 100 / total));
+            }
+        });
 
     connect(progress, &QProgressDialog::canceled, reply, &QNetworkReply::abort);
 
-    connect(reply, &QNetworkReply::finished, this, [this, reply, progress, savePath] {
-        progress->close();
-        progress->deleteLater();
+    connect(reply, &QNetworkReply::finished, this, [this, reply, progressGuard, progressConnection, savePath] {
+        // Before the dialog goes away, and before any modal box below opens a nested loop.
+        disconnect(progressConnection);
+        if (progressGuard) {
+            progressGuard->close();
+            progressGuard->deleteLater();
+        }
 
         if (reply->error() != QNetworkReply::NoError) {
             if (reply->error() != QNetworkReply::OperationCanceledError) {

--- a/App/UI/UpdateController.h
+++ b/App/UI/UpdateController.h
@@ -8,9 +8,11 @@
 #pragma once
 
 #include <QObject>
+#include <QPointer>
 #include <QString>
 #include <QUrl>
 
+class QProgressDialog;
 class QWidget;
 
 /**
@@ -43,4 +45,10 @@ private:
     void downloadUpdate(const QString &latestVersion, const QUrl &url);
 
     QWidget *m_parent = nullptr;
+
+    /// The in-flight download's progress dialog, if any. Tracked because that dialog is no
+    /// longer window-modal (see downloadUpdate), so the main window stays interactive and a
+    /// second Check for Updates could otherwise start a concurrent download writing the same
+    /// file. QPointer: the dialog deletes itself when the download ends.
+    QPointer<QProgressDialog> m_progressDialog;
 };

--- a/Tests/Common/TestUtils.cpp
+++ b/Tests/Common/TestUtils.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include <QAbstractButton>
+#include <QCoreApplication>
 #include <QGraphicsScene>
 #include <QPainter>
 #include <QRandomGenerator>
@@ -58,6 +59,16 @@ void setupTestEnvironment()
     // ~/.local/share/GIBIS-UNIFESP/wiRedPanda — confirmed accumulating thousands of
     // leaked autosave files and stray test-category folders across real test runs.
     QStandardPaths::setTestModeEnabled(true);
+
+    // Force Qt's own dialog widgets everywhere. The AutoDismisser infrastructure drives
+    // dialogs by qobject_cast-ing shown widgets -- QMessageBox here, QFileDialog in the
+    // file-dialog tests -- which only works when Qt draws them itself. On Windows the platform's native file
+    // dialog opens instead, no Qt widget is ever shown, the dismisser never fires, and the
+    // test sits until QTEST_FUNCTION_TIMEOUT turns into a qFatal -- the whole class then
+    // aborts, so the functions after it never run either. Linux passes today only because
+    // the offscreen platform has no native dialogs to prefer; this states the requirement
+    // rather than inheriting it from the QPA plugin.
+    QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 
     Comment::setVerbosity(-1);
     Application::interactiveMode = false;   // Suppress UI dialogs in tests

--- a/Tests/Integration/TestMainWindowGui.cpp
+++ b/Tests/Integration/TestMainWindowGui.cpp
@@ -8,6 +8,7 @@
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QFile>
+#include <QKeySequence>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
@@ -1320,12 +1321,23 @@ void TestMainWindowGui::testShortcutsDialog()
     // The help body is generated from the live actions, so it must cover the real key
     // bindings (not the old hand-maintained subset) and pick up newly added actions.
     const QString html = window->shortcutsHelpHtml();
-    QVERIFY(html.contains("Copy") && html.contains("Ctrl+C"));
-    QVERIFY(html.contains("Paste") && html.contains("Ctrl+V"));
-    QVERIFY(html.contains("Ctrl+A")); // Select All — was missing from the old list
-    QVERIFY(html.contains("Undo") && html.contains("Ctrl+Z")); // injected per-scene action
+    // shortcutsHelpHtml() renders chords with QKeySequence::NativeText, deliberately: the
+    // dialog shows the user their own platform's keys, which on macOS means ⌘C rather than
+    // Ctrl+C. Build the expectations through the same conversion instead of pinning one
+    // platform's spelling, or this asserts that macOS is wrong for being macOS.
+    const auto chord = [](const char *portable) {
+        const QString rendered = QKeySequence(QString::fromLatin1(portable)).toString(QKeySequence::NativeText).toHtmlEscaped();
+        // Without this the test can go quietly vacuous: QString::contains("") is always true,
+        // so a parse failure would turn every assertion below into a no-op that still passes.
+        [&] { QVERIFY(!rendered.isEmpty()); }();
+        return rendered;
+    };
+    QVERIFY(html.contains("Copy") && html.contains(chord("Ctrl+C")));
+    QVERIFY(html.contains("Paste") && html.contains(chord("Ctrl+V")));
+    QVERIFY(html.contains(chord("Ctrl+A"))); // Select All — was missing from the old list
+    QVERIFY(html.contains("Undo") && html.contains(chord("Ctrl+Z"))); // injected per-scene action
     QVERIFY(html.contains("Redo"));
-    QVERIFY(html.contains("Ctrl+Shift+F")); // Zoom to Fit — appears automatically
+    QVERIFY(html.contains(chord("Ctrl+Shift+F"))); // Zoom to Fit — appears automatically
     QVERIFY(html.contains("Morph")); // curated property-navigation section
     QVERIFY(html.contains("arrow keys")); // curated tips section
     // The old hand-written "beWaveDolphin" typo is gone — the label now comes from the action.

--- a/Tests/Unit/Ui/TestElementContextMenu.cpp
+++ b/Tests/Unit/Ui/TestElementContextMenu.cpp
@@ -3,6 +3,7 @@
 
 #include "Tests/Unit/Ui/TestElementContextMenu.h"
 
+#include <QAction>
 #include <QClipboard>
 #include <QComboBox>
 #include <QMenu>
@@ -40,11 +41,33 @@ namespace {
 // when run after another exec()+click in the same test; a leading mouseMove to prime QMenu's
 // own hover/current-action tracking made it reliable in every ordering tried).
 // Also handles one-level-nested actions (e.g. the "Change color to..."/"Morph to..."
-// submenus): a submenu only becomes its own visible top-level widget once opened, which
-// normally only happens on real mouse hover -- hover the parent action (not a manual popup()
+// submenus): a submenu only becomes its own visible top-level widget once opened, so the
+// parent action is activated and Key_Right sent, and a later poll (the submenu is now
+// independently visible) finds and clicks the actual target inside it. Not a manual popup()
 // call, which opens the submenu as its own widget but leaves exec()'s internal state unaware
-// of it) so a later poll (the submenu is now independently visible) can find and click the
-// actual target inside it.
+// of it; and not a hover, which waits on the platform's own popup timing -- synthetic mouse
+// moves do not drive it on Windows, where the submenu then never opens at all.
+/// Finds an action by text in this menu or any submenu, without opening the submenus.
+/// Hovering a parent action to reveal its submenu depends on the platform's popup timing,
+/// which synthetic mouse events do not drive on Windows -- the submenu never opens, the
+/// action is never found, and the test sits until QTEST_FUNCTION_TIMEOUT turns into a
+/// qFatal. Walking the action tree asks the same question (is the entry there?) without
+/// asking the window manager to agree.
+QAction *findMenuActionRecursive(QMenu *menu, const QString &actionText)
+{
+    for (auto *action : menu->actions()) {
+        if (action->text() == actionText) {
+            return action;
+        }
+        if (auto *submenu = action->menu()) {
+            if (auto *found = findMenuActionRecursive(submenu, actionText)) {
+                return found;
+            }
+        }
+    }
+    return nullptr;
+}
+
 TestUtils::AutoDismisser dismisserForContextMenuAction(const QString &actionText)
 {
     return TestUtils::AutoDismisser([actionText](QWidget *w) {
@@ -57,9 +80,22 @@ TestUtils::AutoDismisser dismisserForContextMenuAction(const QString &actionText
                 QTest::mouseClick(menu, Qt::LeftButton, Qt::NoModifier, pos);
                 return true;
             }
-            if (action->menu()) {
-                QTest::mouseMove(menu, menu->actionGeometry(action).center());
+        }
+        // Open the submenu that holds the target so this dismisser runs again with the
+        // submenu as its own shown widget, and the click above dispatches it through
+        // QMenu's normal machinery -- which is what makes menu.exec() return the action.
+        // Key_Right rather than a hover: QMenu opens the submenu itself on that key,
+        // whereas hovering waits on the platform's popup timing, and synthetic mouse
+        // moves do not drive it on Windows -- the submenu never opens and the test sits
+        // until QTEST_FUNCTION_TIMEOUT becomes a qFatal.
+        for (auto *action : menu->actions()) {
+            auto *submenu = action->menu();
+            if (!submenu || !findMenuActionRecursive(submenu, actionText)) {
+                continue;
             }
+            menu->setActiveAction(action);
+            QTest::keyClick(menu, Qt::Key_Right);
+            break;
         }
         return false;
     });


### PR DESCRIPTION
Six defects in the GUI test lanes, three of them product bugs that reach users. They were
found by reading the CI logs of the macOS and Windows trial lanes, which have been reporting
green since July while failing continuously.

## Why nobody saw these

`continue-on-error: true` rewrites a step's REST `conclusion` to `success`. Across 100
`build.yml` runs, not one trial step reports anything but green — including runs whose logs
carry `##[error]Process completed with exit code 8`. Only `steps.<id>.outcome` preserves the
real result, and only inside the workflow. The track record those lanes exist to accumulate
has been unreadable from outside since the day they were added.

Reading the logs instead — 15 macOS jobs, 15 Windows jobs, 7 sanitizer runs — every lane was
failing, and no two platforms shared a failure.

## Product defects

- **`MainWindow` read after it is half-destroyed.** The waveform window is parented to it, so
  `~QWidget` → `deleteChildren()` → `~BewavedDolphin` → `destroyed()` reaches a slot that
  reads `m_exerciseOverlay` on an object already torn down to its `QWidget` base. UBSan says
  so verbatim (*"object is of type 'QWidget'"*). It failed **every ubsan run**; asan is green,
  because it is a wrong-type member access, not a read past a free boundary. Neither `this`
  as connection context nor a `QPointer` helps — QObject clears those later still, in
  `~QObject`. The connection is severed from `~MainWindow`'s own body.

- **Deleting a watched IC file terminates the application on macOS.**
  `ICRegistry::onFileChanged` is a `Qt::QueuedConnection` slot that deliberately rethrows
  after rolling back a failed reload, so the exception crosses signal-slot dispatch — exactly
  where `Application::notify`'s catch is structurally unreachable on macOS. Linux catches the
  same throw and reports it. The abort also truncated `TestMainWindowGui` at 72 of ~120
  functions there. Every `ICController` slot is now guarded too; `removeICFile` at its
  *connection* rather than its body, because a test pins that it must keep throwing to direct
  callers.

- **The update downloader crashes on the completion callback.**
  `QProgressDialog::setValue()` pumps `processEvents()` when the dialog is modal — Qt
  documents this — so driving it from `downloadProgress` re-enters the loop from inside
  `setValue()`: the nested pump delivers `finished()`, which tears the dialog down, and
  `setValue()` resumes on its own freed `QProgressBar`. Deterministic: **5 of 5 runs crashed
  on both macOS images**, Qt 6.8.3 and 6.9.3 alike. Root-caused on a GitHub macOS runner under
  `lldb`, since `ci_linux_core_analyze.sh` is Linux-gated and this had only ever been reported
  as a bare signal number.

## Test and CI defects

- **Two Windows failures were tests asserting on things the platform does not do** (14 of 15
  jobs each): one waiting for a Qt `QFileDialog` widget where Windows opens the native dialog,
  one revealing a submenu by synthetic hover, which native menus open on their own timer.
  Both timed out at `QTEST_FUNCTION_TIMEOUT` and aborted the whole class with `0xc0000409`,
  so the functions after them had never run.
- **`testShortcutsDialog` hardcoded `Ctrl+C`** where the code correctly renders the native
  chord — asserting that macOS is wrong for being macOS.
- **The Windows GUI lane ran against a real window manager.** `TestMainWindowGui` shows 145
  top-level windows in one process and stalled **4 of 10** native runs on
  `QTEST_FUNCTION_TIMEOUT`, at a different function each time, while the same binary on the
  same runner passed **5 of 5** offscreen — which is what macOS already pins. Deliberate
  trade: it gives up native window-manager coverage in this lane, and a lane that stalls 40%
  of the time reports nothing at all.

## Result

| lane | before | after |
|---|---|---|
| macos-15 Qt 6.8.3 | 2 failing | 7/7 |
| macos-26 Qt 6.9.3 | 2 failing | 7/7 |
| windows-2025 Qt 6.8.3 / 6.9.3 | 2–4 failing | 7/7 |
| windows-11-arm Qt 6.9.3 | 2–4 failing | 7/7 |
| ubsan (Linux) | 7/7 failing | 7/7, zero runtime errors |

## Verification

Every commit builds and passes `ctest --preset debug` **on its own** (8 × 216/216) — none
repairs an earlier one. ubsan with `halt_on_error=1`: 216/216, zero runtime errors. MCP client
106/106. All 11 build jobs green, including `no unity/PCH`, plus Sanitizers, Lint and API docs.

The trial lanes stay `continue-on-error` for now. They are all green, so they are ready to be
promoted to blocking whenever you want — without that, this class of regression goes back to
being invisible.
