### PR TITLE
test(harness): default to offscreen on every non-macOS Unix, not just Linux

### DIFF
--- a/Tests/Common/TestUtils.cpp
+++ b/Tests/Common/TestUtils.cpp
@@ -28,10 +28,22 @@ namespace TestUtils {
 
 void setupTestEnvironment()
 {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS) && !defined(Q_OS_WASM)
     // Default to headless, but never clobber an explicit choice — CI workflows
     // and developers set QT_QPA_PLATFORM to pick the platform per-OS (e.g.
     // xcb to exercise native window-activation timing locally).
+    //
+    // Q_OS_UNIX rather than Q_OS_LINUX: GNU/Hurd is not Linux (Qt defines
+    // Q_OS_HURD for __GNU__), so it was left running the gui suite against a
+    // real platform plugin, and Debian's hurd-amd64 and hurd-i386 builds fail
+    // there on exactly the test that stalled on Windows before that lane was
+    // pinned offscreen. macOS keeps its current behaviour, where CI pins the
+    // platform explicitly instead. Q_OS_WASM is excluded too -- Qt's own
+    // qsystemdetection.h leaves it under Q_OS_UNIX (only Q_OS_WIN #undefs it),
+    // and Emscripten has no offscreen platform plugin to select. Currently
+    // moot (wasm.yml builds only the `wiredpanda` target, never
+    // `test_wiredpanda`), but nothing should depend on that CI detail to stay
+    // correct if a wasm test target is ever added.
     if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
         qputenv("QT_QPA_PLATFORM", "offscreen");
     }


### PR DESCRIPTION
Extends the offscreen-QPA default the Windows GUI lane just adopted to every non-macOS Unix
target, not just Linux — closing the same class of stall on GNU/Hurd that fixed on Windows.

## The bug

`setupTestEnvironment()` pinned `QT_QPA_PLATFORM=offscreen` under `#ifdef Q_OS_LINUX`.
GNU/Hurd is not Linux — Qt defines `Q_OS_HURD` for `__GNU__` — so the GUI suite ran there
against whatever real platform plugin was available. That's the exact situation the Windows
lane was moved off for stalling.

## The evidence

Read directly from Debian's own buildd logs for `wiredpanda` 5.2.1-1, not inferred:

- The offscreen marker (`This plugin does not support propagateSizeHints()`) appears **247
  times** on armhf, hppa and sparc64, and **zero times** on hurd-amd64 and hurd-i386.
- Those two Hurd architectures are the only ones failing on
  `testMouseCtrlClickMultiSelect` — exactly the test that stalled 9 runs in 20 on Windows
  native and passed 5 of 5 offscreen (see the recent `gui-test-fixes` merge).

## The fix

`Q_OS_UNIX && !Q_OS_MACOS && !Q_OS_WASM`. On Linux this compiles to precisely what it did
before. It extends the default to Hurd and the BSDs, and leaves macOS untouched, where CI
already pins the platform explicitly. An explicit `QT_QPA_PLATFORM` still wins everywhere.

`Q_OS_WASM` is excluded on purpose, not by omission — Qt's own `qsystemdetection.h` leaves
Emscripten under `Q_OS_UNIX` too (only `Q_OS_WIN` `#undef`s it), and it has no offscreen
platform plugin to select. Currently moot, since `wasm.yml` builds only the `wiredpanda`
target and never `test_wiredpanda`, but the guard shouldn't depend on that CI detail to stay
correct if a wasm test target is ever added.

## What this does and doesn't claim

Those Debian builds also fail `testUndoRedoViaKeyboard` (one element left after undo,
expected none) — activation-sensitive in the same way (`createMW()` already notes
`activateWindow()` is a no-op offscreen), but it never failed on Windows, so this is expected
to fix the stall and only plausibly the second failure. Debian's Hurd builders are the only
place either can be confirmed.

## Verification

Full suite 216/216 locally, no new warnings. This is a test-harness-only change — nothing in
`App/` is touched.
