### PR TITLE
fix(ci): build sentry-cli from source with the relocation-application fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,28 @@ jobs:
             echo "Downloaded Sentry CLI binary is invalid!" >&2
             exit 1
           fi
+        elif [ "$RUNNER_OS" == "Linux" ]; then
+          # Official sentry-cli releases link an unpatched symbolic-debuginfo whose ELF loader
+          # never applies relocations to debug sections in unlinked .o files: every
+          # DW_FORM_line_strp/strp offset silently reads back as the section's own zero
+          # placeholder, which `debug-files upload --include-sources` can resolve into a
+          # directory instead of a file and hard-error on ("Is a directory"). Fix submitted
+          # upstream as https://github.com/getsentry/symbolic/pull/1060; until it ships in a
+          # release, build sentry-cli 3.7.0 from source with that same fix patched in from a
+          # pinned branch (kept in sync with the upstream PR) instead of downloading the binary.
+          git clone --depth 1 --branch 3.7.0 https://github.com/getsentry/sentry-cli.git /tmp/sentry-cli-src
+          {
+            echo ''
+            echo '[patch.crates-io]'
+            echo 'symbolic = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+            echo 'symbolic-common = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+            echo 'symbolic-debuginfo = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+            echo 'symbolic-il2cpp = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+            echo 'symbolic-ppdb = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+            echo 'symbolic-symcache = { git = "https://github.com/darktorres/symbolic", branch = "ci-fix-13.8.0-apply-elf-relocations" }'
+          } >> /tmp/sentry-cli-src/Cargo.toml
+          cargo build --release --manifest-path /tmp/sentry-cli-src/Cargo.toml --bin sentry-cli
+          sudo install -m 755 /tmp/sentry-cli-src/target/release/sentry-cli /usr/local/bin/sentry-cli
         else
           curl -sL https://sentry.io/get-cli/ | bash
         fi


### PR DESCRIPTION
## Summary
- 5.2.2's Linux deploy jobs (x86_64 and arm64) failed at `sentry-cli debug-files upload --include-sources` with `failed to write source bundle: Is a directory (os error 21)`, aborting the step before it reached `Publish Ubuntu` — the release currently has no Linux AppImages attached.
- Root cause, confirmed byte-for-byte: `symbolic-debuginfo`'s ELF loader (a dependency of sentry-cli) already parses ELF relocations for debug sections into `elf.shdr_relocs`, but never applies them before handing section bytes to `gimli`. Every `DW_FORM_line_strp`/`DW_FORM_strp` offset field in an **unlinked relocatable object** (`.o`, `ET_REL`) is left by the compiler as a zero placeholder with a companion relocation recording the real offset (final layout isn't settled until link time) — so every such field silently reads back as offset 0, corrupting directory/file resolution. This affects any GCC/Clang-compiled `.o`, not Qt or wiRedPanda specifically — confirmed with GCC 13/15, Clang, DWARF32/64, x86_64/aarch64, and a causal proof (stripping the relocation section from a working file reproduces the identical corruption in `readelf`'s own dump).
- Real root-cause fix submitted upstream: **https://github.com/getsentry/symbolic/pull/1060**.
- Until that ships in a release, this PR's only change is to the "Install Sentry CLI" step: on Linux, build `sentry-cli` from source with that same fix patched in from a pinned branch, instead of downloading the official (unpatched) binary. `--include-sources` itself is untouched — it was already present in `deploy.yml` before this branch and stays that way; only the `sentry-cli` binary running it changes. Windows and macOS are untouched (PDB and Mach-O/dSYM aren't affected by this ELF-specific bug), so they keep downloading the official release binary.

## Test plan
- [x] Verified the exact `deploy.yml` recipe (fresh clone, patched `Cargo.toml`, `cargo build --release`) locally: builds successfully in ~5-8 minutes.
- [x] Verified the resulting binary correctly bundles sources (no crash, correct manifest/paths) for every previously-crashing case: real production `.o` files from this repo, plus synthetic x86_64/aarch64 repros.
- [x] Verified zero regression on already-working linked binaries/shared libraries.
- [x] Triggered a real `workflow_dispatch` dry run of this recipe on both `ubuntu-24.04` and `ubuntu-24.04-arm` — passes on both (an earlier revision's heredoc-indentation bug was only caught this way, not by local testing; fixed and re-verified before the history was squashed into this commit).
- [ ] CI required checks pass on this PR
- [ ] After merge, get the Linux AppImages published to the live 5.2.2 release
- [ ] Once getsentry/symbolic#1060 ships in a release, revert the "Install Sentry CLI" step back to downloading the official binary on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
